### PR TITLE
hotfix: decrease high saturation in light monet using neutral variant

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
@@ -47,7 +47,7 @@ object DynamicColorPatch : ResourcePatch() {
             mapOf(
                 "ps__twitter_blue" to "@color/twitter_blue",
                 "ps__twitter_blue_pressed" to "@color/twitter_blue_fill_pressed",
-                "twitter_blue" to "@android:color/system_accent1_400",
+                "twitter_blue" to "@android:color/system_accent1_500",
                 "twitter_blue_fill_pressed" to "@android:color/system_accent1_300",
                 "twitter_blue_opacity_30" to "@android:color/system_accent1_100",
                 "twitter_blue_opacity_50" to "@android:color/system_accent1_200",
@@ -130,17 +130,17 @@ object DynamicColorPatch : ResourcePatch() {
             newStyle.setAttribute("parent", "@style/HorizonColorPaletteLight")
 
             val styleItems = mapOf(
-                "abstractColorCellBackground" to "@color/material_dynamic_primary95",
-                "abstractColorCellBackgroundTranslucent" to "@color/material_dynamic_primary95",
-                "abstractColorDeepGray" to "@color/gray_700",
-                "abstractColorDivider" to "@color/material_dynamic_secondary90",
-                "abstractColorFadedGray" to "@color/material_dynamic_secondary95",
-                "abstractColorFaintGray" to "@color/material_dynamic_secondary95",
-                "abstractColorHighlightBackground" to "@color/material_dynamic_secondary95",
-                "abstractColorLightGray" to "@color/gray_200",
+                "abstractColorCellBackground" to "@android:color/system_neutral2_50",
+                "abstractColorCellBackgroundTranslucent" to "@android:color/system_neutral2_50",
+                "abstractColorDeepGray" to "@color/gray_1000",
+                "abstractColorDivider" to "@android:color/system_accent1_400",
+                "abstractColorFadedGray" to "@color/material_dynamic_primary99",
+                "abstractColorFaintGray" to "@color/material_dynamic_primary99",
+                "abstractColorHighlightBackground" to "@android:color/system_accent1_10",
+                "abstractColorLightGray" to "@color/gray_1100",
                 "abstractColorLink" to "@color/twitter_blue",
-                "abstractColorMediumGray" to "@color/gray_300",
-                "abstractColorText" to "@color/gray_1100",
+                "abstractColorMediumGray" to "@color/gray_1100",
+                "abstractColorText" to "#0d1115",
                 "abstractColorUnread" to "@color/blue_0",
                 "abstractElevatedBackground" to "@color/white",
                 "abstractElevatedBackgroundShadow" to "@color/black_opacity_10"


### PR DESCRIPTION
![IMG-20240518-WA0002](https://github.com/crimera/piko/assets/125901294/6bfe4ec4-4dba-4196-964a-70b02990aba6)
![IMG-20240518-WA0005](https://github.com/crimera/piko/assets/125901294/c0efeb00-6ddf-446f-98db-715591ffcd36)
![IMG-20240518-WA0001](https://github.com/crimera/piko/assets/125901294/f6689e05-a34d-43e9-8e67-ebba8cc1e276)
![IMG-20240518-WA0003](https://github.com/crimera/piko/assets/125901294/8c672eb8-588d-4bd4-bc62-46fa36547899)
![IMG-20240518-WA0006](https://github.com/crimera/piko/assets/125901294/1644eba9-ee2c-47ab-b5f6-0983e9cfd662)
![IMG-20240518-WA0007](https://github.com/crimera/piko/assets/125901294/c97e7362-5155-4682-8497-5c9dff96c552)
