### PR TITLE
feat(Bring back twitter): Add Japanese

### DIFF
--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -7,6 +7,7 @@ import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.util.ResourceGroup
 import app.revanced.util.asSequence
 import app.revanced.util.copyResources
+import crimera.patches.twitter.misc.bringbacktwitter.custromstringsupdater.ja
 import crimera.patches.twitter.misc.bringbacktwitter.strings.StringsMap
 import org.w3c.dom.Element
 import java.io.File
@@ -98,6 +99,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
 
         // update strings to old ones
         updateStrings(context)
+        ja.updateStrings(context)
     }
 
     private fun updateStrings(context: ResourceContext) {

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/custromstringsupdater/ja.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/custromstringsupdater/ja.kt
@@ -1,0 +1,20 @@
+package crimera.patches.twitter.misc.bringbacktwitter.custromstringsupdater
+
+import app.revanced.patcher.data.ResourceContext
+
+object ja {
+    /*
+     * Instead of defining strings in the map, use a custom implementation
+     * that reads the files and replaces texts directly.
+     * Reason: https://t.me/pikopatches/1/17339
+     */
+    fun updateStrings(context: ResourceContext) {
+        context["res/values-ja"].listFiles()?.forEach {
+            it.writeText(
+                it.readText()
+                    .replace("X", "Twitter")
+                    .replace("ポスト", "ツイート")
+            )
+        }
+    }
+}


### PR DESCRIPTION
Add Japanese support for Bring back twitter patch.

As I explained in https://t.me/pikopatches/1/17339 and following messages, a custom implementation is used instead of using a pre-defined srtings map.
This is the optimal processing method for the Japanese strings.