### PR TITLE
fix(Bring back twitter): Change the character "𝕏" into "Twitter".

### DIFF
--- a/src/main/kotlin/app/util/PikoUtils.kt
+++ b/src/main/kotlin/app/util/PikoUtils.kt
@@ -1,0 +1,21 @@
+package app.util
+
+import java.io.File
+
+inline fun measureExecutionTime(block: () -> Unit): Long {
+    val start = System.currentTimeMillis()
+    block()
+    val end = System.currentTimeMillis()
+    return end - start
+}
+
+fun fixStrings(file: File) {
+    val regex = Regex("""(<string\s+name="conference_default_title">)([^<]*)(<\/string>)""")
+    val defaultValue = "&#120143; Conference"
+    val content = file.readText()
+    file.writeText(
+        content.replace(regex) {
+            "${it.groupValues[1]}$defaultValue${it.groupValues[3]}"
+        }
+    )
+}

--- a/src/main/kotlin/app/util/PikoUtils.kt
+++ b/src/main/kotlin/app/util/PikoUtils.kt
@@ -1,21 +1,8 @@
 package app.util
 
-import java.io.File
-
 inline fun measureExecutionTime(block: () -> Unit): Long {
     val start = System.currentTimeMillis()
     block()
     val end = System.currentTimeMillis()
     return end - start
-}
-
-fun fixStrings(file: File) {
-    val regex = Regex("""(<string\s+name="conference_default_title">)([^<]*)(<\/string>)""")
-    val defaultValue = "&#120143; Conference"
-    val content = file.readText()
-    file.writeText(
-        content.replace(regex) {
-            "${it.groupValues[1]}$defaultValue${it.groupValues[3]}"
-        }
-    )
 }

--- a/src/main/kotlin/app/util/ResourceUtils.kt
+++ b/src/main/kotlin/app/util/ResourceUtils.kt
@@ -5,6 +5,7 @@ import app.revanced.patcher.util.DomFileEditor
 import app.revanced.util.resource.BaseResource
 import org.w3c.dom.Node
 import org.w3c.dom.NodeList
+import java.io.File
 import java.io.FileNotFoundException
 import java.io.InputStream
 import java.nio.file.Files
@@ -153,7 +154,6 @@ fun ResourceContext.appendStrings(
         }
     }
 }
-
 
 // /**
 //  * Copies the specified node of the source [Document] to the target [Document].

--- a/src/main/kotlin/app/util/ResourceUtils.kt
+++ b/src/main/kotlin/app/util/ResourceUtils.kt
@@ -142,14 +142,14 @@ fun ResourceContext.appendStrings(
 
     target.bufferedWriter().use { writer ->
         targetContent.forEach {
-            writer.write(it)
+            writer.write(it+"\n")
         }
 
         source.bufferedReader().useLines { lines ->
             lines.dropWhile {
                 it != "<resources>"
             }.drop(1).forEach { line ->
-                writer.write(line)
+                writer.write(line+"\n")
             }
         }
     }

--- a/src/main/kotlin/app/util/Utils.kt
+++ b/src/main/kotlin/app/util/Utils.kt
@@ -1,8 +1,0 @@
-package app.util
-
-inline fun measureExecutionTime(block: () -> Unit): Long {
-    val start = System.currentTimeMillis()
-    block()
-    val end = System.currentTimeMillis()
-    return end - start
-}

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -7,6 +7,8 @@ import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.util.ResourceGroup
 import app.revanced.util.asSequence
 import app.revanced.util.copyResources
+import app.util.fixStrings
+import app.util.measureExecutionTime
 import crimera.patches.twitter.misc.bringbacktwitter.custromstringsupdater.ja
 import crimera.patches.twitter.misc.bringbacktwitter.strings.StringsMap
 import org.w3c.dom.Element
@@ -115,6 +117,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                 }
             }
             updateStringsFile(stringsFile, value, context)
+//            fixStrings(stringsFile)
         }
     }
 
@@ -127,10 +130,13 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                 var keyReplaced = false
                 for (i in 0 until nodes.length) {
                     val node = nodes.item(i)
-                    if (node.attributes.getNamedItem("name")?.nodeValue == key) {
+                    val name = node.attributes.getNamedItem("name")?.nodeValue
+                    if (name == key) {
                         node.textContent = value
                         keyReplaced = true
                         break
+                    } else if (name == "conference_default_title") {
+                        node.textContent = "&#120143; Conference"
                     }
                 }
 

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -137,7 +137,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                         val content = node.textContent
                         val delimiter = if (content.contains("-")) '-' else ' '
                         val default = content.split(delimiter).joinToString(delimiter.toString()) {
-                            if (it[0] == '&') "&#120143;" else it
+                            if (it.encodeToByteArray()[0] == (-16).toByte()) "𝕏test" else it
                         }
                         node.textContent = default
                     }

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -134,7 +134,11 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                         break
                     } else if (name == "conference_default_title") {
                         // parsing causes the default value to be "corrupted" so we reset it to the default value
-                        val default = node.textContent.replace("&#55349;&#56655;", "&#120143;")
+                        val content = node.textContent
+                        val delimiter = if (content.contains("-")) '-' else ' '
+                        val default = content.split(delimiter).joinToString(delimiter.toString()) {
+                            if (it[0] == '&') "&#120143;" else it
+                        }
                         node.textContent = default
                     }
                 }

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -137,7 +137,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                         val content = node.textContent
                         val delimiter = if (content.contains("-")) '-' else ' '
                         val default = content.split(delimiter).joinToString(delimiter.toString()) {
-                            if (it.encodeToByteArray()[0] == (-16).toByte()) "𝕏test" else it
+                            if (it.encodeToByteArray()[0] == (-16).toByte()) "X" else it
                         }
                         node.textContent = default
                     }

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -7,7 +7,6 @@ import app.revanced.patcher.patch.annotation.Patch
 import app.revanced.util.ResourceGroup
 import app.revanced.util.asSequence
 import app.revanced.util.copyResources
-import app.util.fixStrings
 import app.util.measureExecutionTime
 import crimera.patches.twitter.misc.bringbacktwitter.custromstringsupdater.ja
 import crimera.patches.twitter.misc.bringbacktwitter.strings.StringsMap
@@ -30,11 +29,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
     ).map { "$it.webp" }.toTypedArray()
 
     val drawableIcons = arrayOf(
-        "ic_vector_twitter",
-        "ic_vector_home",
-        "ic_vector_twitter_white",
-        "ic_vector_home_stroke",
-        "splash_screen_icon"
+        "ic_vector_twitter", "ic_vector_home", "ic_vector_twitter_white", "ic_vector_home_stroke", "splash_screen_icon"
     ).map { "$it.xml" }.toTypedArray()
 
     val sizes = arrayOf(
@@ -58,12 +53,12 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
         sizes.map { "drawable-$it" }.plus("drawable").map {
             if (it == "drawable") {
                 ResourceGroup(it, *drawableIcons)
-            } else{
+            } else {
                 ResourceGroup(it, "ic_stat_twitter.webp")
             }
         }.forEach {
             val folderName = context["res/${it.resourceDirectoryName}"]
-            if(folderName.exists()){
+            if (folderName.exists()) {
                 context.copyResources("twitter/bringbacktwitter", it)
             }
         }
@@ -77,7 +72,7 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
             }
         }.forEach {
             val folderName = context["res/${it.resourceDirectoryName}"]
-            if(folderName.exists()) {
+            if (folderName.exists()) {
                 context.copyResources("twitter/bringbacktwitter", it)
             }
         }
@@ -108,20 +103,22 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
         val langs = StringsMap.replacementMap
         for ((key, value) in langs) {
             val stringsFile = context["res/$key/strings.xml"]
-            if(!stringsFile.isFile){
-//                println("$key/strings.xml not found")
+            if (!stringsFile.isFile) {
 
                 context["res/$key"].mkdirs()
                 FileWriter(stringsFile).use {
                     it.write("<?xml version=\"1.0\" encoding=\"utf-8\"?><resources></resources>")
                 }
             }
-            updateStringsFile(stringsFile, value, context)
-//            fixStrings(stringsFile)
+            measureExecutionTime {
+                updateStringsFile(stringsFile, value, context)
+            }.let {
+                println(it)
+            }
         }
     }
 
-    private fun updateStringsFile(stringsFile: File,stringsMap: Map<String,String>, context: ResourceContext) {
+    private fun updateStringsFile(stringsFile: File, stringsMap: Map<String, String>, context: ResourceContext) {
         context.xmlEditor[stringsFile.toString()].use { editor ->
             val document = editor.file
 
@@ -136,7 +133,9 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                         keyReplaced = true
                         break
                     } else if (name == "conference_default_title") {
-                        node.textContent = "&#120143; Conference"
+                        // parsing causes the default value to be "corrupted" so we reset it to the default value
+                        val default = node.textContent.replace("&#55349;&#56655;", "&#120143;")
+                        node.textContent = default
                     }
                 }
 

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterResourcePatch.kt
@@ -137,7 +137,8 @@ object BringBackTwitterResourcePatch : ResourcePatch() {
                         val content = node.textContent
                         val delimiter = if (content.contains("-")) '-' else ' '
                         val default = content.split(delimiter).joinToString(delimiter.toString()) {
-                            if (it.encodeToByteArray()[0] == (-16).toByte()) "X" else it
+                            // TODO: add support for other languages
+                            if (it.encodeToByteArray()[0] == (-16).toByte()) "Twitter" else it
                         }
                         node.textContent = default
                     }

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/strings/en_rGB.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/strings/en_rGB.kt
@@ -2,6 +2,7 @@ package crimera.patches.twitter.misc.bringbacktwitter.strings
 
 object en_rGB {
     val values = mapOf(
+        "conference_default_title" to "Twitter Conference",
         "button_action_add_tweet" to "Add a tweet",
         "button_action_options_tweet" to "Tweet options",
         "button_action_retweet" to "Retweet",

--- a/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/strings/ru.kt
+++ b/src/main/kotlin/crimera/patches/twitter/misc/bringbacktwitter/strings/ru.kt
@@ -2,6 +2,7 @@ package crimera.patches.twitter.misc.bringbacktwitter.strings
 
 object ru {
     val values = mapOf(
+        "conference_default_title" to "Конференция Твиттере",
         "button_action_add_tweet" to "Добавить твит",
         "button_action_options_tweet" to "Опции",
         "button_action_retweet" to "Ретвитнуть",


### PR DESCRIPTION
Editing the strings file with the dom library results in the character "𝕏" found in the string value of `conference_default_title` to be encoded as `&#55349;&#56655;`. This html entities results in the failure of aapt to compile the resources.