### PR TITLE
fix(Twitter - copy media link + Custom download folder): Update fingerprint

### DIFF
--- a/src/main/kotlin/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
+++ b/src/main/kotlin/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
@@ -4,19 +4,22 @@ import app.revanced.patcher.data.BytecodeContext
 import app.revanced.patcher.extensions.InstructionExtensions.addInstruction
 import app.revanced.patcher.extensions.InstructionExtensions.getInstructions
 import app.revanced.patcher.extensions.InstructionExtensions.removeInstruction
+import app.revanced.patcher.extensions.or
 import app.revanced.patcher.fingerprint.MethodFingerprint
 import app.revanced.patcher.patch.BytecodePatch
 import app.revanced.patcher.patch.PatchException
 import app.revanced.patcher.patch.annotation.CompatiblePackage
 import app.revanced.patcher.patch.annotation.Patch
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.AccessFlags
 import crimera.patches.twitter.misc.settings.SettingsPatch
 import crimera.patches.twitter.misc.settings.fingerprints.SettingsStatusLoadFingerprint
 
 object DownloadCallFingerprint: MethodFingerprint(
+    accessFlags = AccessFlags.PUBLIC or AccessFlags.FINAL,
     returnType = "V",
     strings = listOf(
-        "downloadData",
+        "getString(...)",
         "isUseSnackbar"
     )
 )


### PR DESCRIPTION
Copy media link patch and custom download directory patch were no longer working since twitter version 10.94.0-release.0 due to change in method fingerprint.

I have updated the method fingerprint to work with the latest twitter apk version which should fix the two mentioned patches.

c.f. #569