### PR TITLE
fix(ui): adjust monet-light colors to have a white background

### DIFF
--- a/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
+++ b/src/main/kotlin/app/revanced/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
@@ -130,8 +130,8 @@ object DynamicColorPatch : ResourcePatch() {
             newStyle.setAttribute("parent", "@style/HorizonColorPaletteLight")
 
             val styleItems = mapOf(
-                "abstractColorCellBackground" to "@android:color/system_neutral2_50",
-                "abstractColorCellBackgroundTranslucent" to "@android:color/system_neutral2_50",
+                "abstractColorCellBackground" to "@android:color/system_neutral2_0",
+                "abstractColorCellBackgroundTranslucent" to "@android:color/system_neutral2_0",
                 "abstractColorDeepGray" to "@color/gray_1000",
                 "abstractColorDivider" to "@android:color/system_accent1_400",
                 "abstractColorFadedGray" to "@color/material_dynamic_primary99",


### PR DESCRIPTION
The previous light monet colors weren't true white which looked odd in a lot of places (community notes, dms).
This PR changes this color to `system_neutral2_0` from `system_neutral2_50` :)