### PR TITLE
fix(Twitter): Fix `Custom sharing domain` not overriding new share sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <b>Morphe Cli</b>
 
 ```sh
-java -jar cli.jar patch -p piko.mpp input.apkm
+java -jar cli.jar patch --patches piko.mpp input.apkm
 ```
 
 <p><b>or Morphe Manager</b>
@@ -31,7 +31,8 @@ To use these patches in Morphe Manager, follow these steps:
 #### Add Piko patches as a patch source 
 1. Tap patch sources (lower left button)
 2. Tap `+` button
-3. Paste this repo url: `https://github.com/crimera/piko`
+3<!-- TODO: After first 3.0.0 stable is released, change this step to use https://github.com/crimera/piko
+4Paste this repo url: `https://github.com/crimera/piko/blob/dev/patches-bundle.json`
 
 #### Patching Twitter/X with Morphe
 1. Download an original unpatched X APKM from a reputable source such as [APKMirror.com](https://www.apkmirror.com/apk/x-corp/twitter/)

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/entity/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/entity/Fingerprints.kt
@@ -111,6 +111,6 @@ internal object TweetInfoObjectFingerprint : Fingerprint(
 )
 
 internal object TweetLangFingerprint : Fingerprint(
-    definingClass = "Lapp/revanced/extension/twitter/entity/TweetInfo",
+    definingClass = "Lapp/revanced/extension/twitter/entity/TweetInfo;",
     name = "getLang"
 )

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
@@ -1,20 +1,24 @@
 package app.crimera.patches.twitter.interaction.downloads.copyMediaLink
 
-import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.extensions.InstructionExtensions.removeInstruction
+import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 
 internal object DownloadCallFingerprint : Fingerprint(
+    definingClass = "Lcom/twitter/downloader/",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "V",
+    filters = listOf(
+        opcode(Opcode.GOTO),
+    ),
     strings = listOf(
         "getString(...)",
         "isUseSnackbar",
@@ -32,9 +36,7 @@ val copyMediaLink =
         execute {
             val method = DownloadCallFingerprint.method
 
-            val instructions = method.instructions
-
-            val gotoLoc = instructions.first { it.opcode == Opcode.GOTO }.location.index
+            val gotoLoc = DownloadCallFingerprint.instructionMatches.first().index
 
             val METHOD =
                 """

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/cleartrackingparams/ClearTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/cleartrackingparams/ClearTrackingParamsPatch.kt
@@ -9,6 +9,12 @@ import app.morphe.patcher.patch.bytecodePatch
 
 // https://github.com/FrozenAlex/revanced-patches-new
 internal object AddSessionTokenFingerprint : Fingerprint(
+    parameters = listOf(
+        "Ljava/lang/String;",
+        "L",
+        "Ljava/lang/String;"
+    ),
+    returnType = "Ljava/lang/String;",
     strings = listOf(
         "<this>",
         "shareParam",

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/customsharingdomain/CustomSharingDomainPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/customsharingdomain/CustomSharingDomainPatch.kt
@@ -1,8 +1,8 @@
 package app.crimera.patches.twitter.link.customsharingdomain
 
 import app.crimera.patches.twitter.link.cleartrackingparams.AddSessionTokenFingerprint
-import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -22,9 +22,11 @@ internal object NewShareSheetLinkFingerprint : Fingerprint(
 
 internal object NewShareSheetLinkFingerprint2 : Fingerprint(
     filters = listOf(
-        string(TARGET_STRING),
-        string("https://x.com/i/trending/"),
-        string("https://x.com/i/lists/"),
+        string(TARGET_STRING)
+    ),
+    strings = listOf(
+        "https://x.com/i/trending/",
+        "https://x.com/i/lists/"
     )
 )
 
@@ -62,12 +64,12 @@ val customSharingDomainPatch =
                 callStatement.replace(dummyReg, "p0"),
             )
 
-            try {
-                // Should be applied only post 11.48.xx in new share sheet.
-                NewShareSheetLinkFingerprint.addCustomDomainFunctionCall()
-                NewShareSheetLinkFingerprint2.addCustomDomainFunctionCall()
-            } catch (_: Exception) {
-            }
+//            try {
+            // Should be applied only post 11.48.xx in new share sheet.
+            NewShareSheetLinkFingerprint.addCustomDomainFunctionCall()
+            NewShareSheetLinkFingerprint2.addCustomDomainFunctionCall()
+//            } catch (_: Exception) {
+//            }
 
             SettingsStatusLoadFingerprint.enableSettings("enableCustomSharingDomain")
         }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/hooks/ShareMenuButtonAddHook.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/hooks/ShareMenuButtonAddHook.kt
@@ -10,13 +10,13 @@ import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.formats.Instruction35c
 
 internal object ShareMenuButtonAddHook : Fingerprint(
+    definingClass = "Lcom/twitter/tweet/action/",
     returnType = "V",
-    custom = { methodDef, _ ->
-        val params = methodDef.parameters.joinToString("") { it.type }
-        methodDef.name == "a" &&
-                params.contains("com/twitter/model/timeline") &&
-                params.contains("com/twitter/util/collection")
-    }
+    parameters = listOf(
+        "Lcom/twitter/model/timeline/",
+        "I",
+        "Lcom/twitter/util/collection/"
+    )
 )
 
 context(BytecodePatchContext)


### PR DESCRIPTION
Fixes #789 

Was caused by an overlooked existing try/catch block that caused a fingerprint to silently not match.