### PR TITLE
chore(Bring back twitter): Remove XML special characters handling that is no longer needed

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
@@ -125,7 +125,6 @@ val bringBackTwitterPatch =
 
             // region Change strings
 
-            val isRunningOnManager = System.getProperty("java.runtime.name") == "Android Runtime"
             val basePath = "twitter/bringbacktwitter/strings"
 
             replaceXmlResources(basePath, ResourceGroup("values", "strings.xml"))
@@ -157,33 +156,12 @@ val bringBackTwitterPatch =
                 }
                 val resGroup = ResourceGroup(folderName, "strings.xml")
                 replaceXmlResources(basePath, resGroup)
-
-                /*
-                 * The Java XML API on Android has a bug that converts surrogate pair characters
-                 * to invalid numeric character references.
-                 * It prevents resource compilation.
-                 * Fix the text directly after closing the xmlEditor.
-                 */
-                if (isRunningOnManager) {
-                    replaceStringsInFile(
-                        resGroup,
-                        replacements =
-                            mapOf(
-                                "&#55349;&#56655;" to "Twitter",
-                                "&#55357;&#56613;" to "🔥",
-                                "&#55356;&#57217;" to "🎁",
-                                "&#55356;&#57225;" to "🎉",
-                                "&#9200;" to "⏰",
-                            ),
-                    )
-                }
             }
 
             /*
              * Instead of defining strings in the map, replaces texts directly.
              * Reason: https://t.me/pikopatches/1/17339
              */
-
             replaceStringsInFile(
                 ResourceGroup("values-ja", "strings.xml", "arrays.xml"),
                 replacements =

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/enableVidAutoAdvance/EnableVidAutoAdvancePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/enableVidAutoAdvance/EnableVidAutoAdvancePatch.kt
@@ -6,12 +6,10 @@ import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.string
 import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 
 private object EnableVidAutoAdvancePatchFingerprint : Fingerprint(
     filters = listOf(
@@ -32,9 +30,7 @@ val enableVidAutoAdvancePatch =
         execute {
             val method = EnableVidAutoAdvancePatchFingerprint.method
             val matches = EnableVidAutoAdvancePatchFingerprint.instructionMatches
-            var strLoc: Int = matches.first().index
             val loc = matches[1].index
-            val reg = method.getInstruction<OneRegisterInstruction>(loc).registerA
             method.addInstruction(
                 loc,
                 """


### PR DESCRIPTION
Morphe Patcher includes the fix for XML surrogate pair characters bug on Android (https://github.com/ReVanced/revanced-patcher/commit/33fadcbd0c7076b848bdca4d62a9c684d5781232), so this workaround is no longer needed.