### PR TITLE
refactor(Twitter): Rename `Hide timeline posts by category` patch to `Hide recommendation items`

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideRecommendationItemsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideRecommendationItemsPatch.kt
@@ -16,10 +16,10 @@ import app.crimera.patches.twitter.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
-val hideTimelinePostByCategory =
+val hideRecommendationItemsPatch =
     bytecodePatch(
-        name = "Hide timeline posts by category",
-        description = "Hides different post category like who to follow, news today etc from timeline.",
+        name = "Hide recommendation items",
+        description = "Adds options to hide recommendation items such as \"Who to follow\" and \"Today's news\" in timeline, search, and replies.",
     ) {
         compatibleWith(COMPATIBILITY_X)
         dependsOn(timelineEntryHookPatch, settingsPatch)


### PR DESCRIPTION
I've always thought that the name of "Hide timeline posts by category" patch is confusing since we migrated to patcher v21.
This patch name could be misunderstood to mean that it hides timeline tweets based on categories (≒ genres) such as “sports,” “politics,” or “entertainment.”

Additionally, this patch actually hides more than just posts.
For example, the "Who to follow" section, which this patch hides, is not a "post".

I suggest the name "Hide timeline items".
I think the word "item" describes both posts and sections well.

What do you think?

This PR is marked as draft because I think this change requires discussion.