### PR TITLE
feat: Add `Import/export login token` patch

### DIFF
--- a/docs/about_login_token_patch.md
+++ b/docs/about_login_token_patch.md
@@ -1,0 +1,104 @@
+# About "Import/Export login token" patch
+
+## About this feature
+
+It exports the session token for the currently logged-in account.
+
+This is useful in the following cases:
+
+- If you already have a device logged in and want to log in on another device
+- If you want to reinstall Piko
+- If you want to log into a cloned APK
+- If you have another rooted device and can log in normally
+
+Tokens and other necessary data will be exported in JSON format.  
+You can use it from the login screen.
+
+To import additional accounts, select "Create a new account" instead of "Add an existing account".
+
+**Important: This patch does NOT fix the login attestation problem.**
+
+## WARNING
+
+Exported tokens are highly confidential information. Never share it with anyone!  
+If a third party obtains this token, they can freely access your account until you log out of the session.
+
+Please also be careful of your clipboard or exported files.
+
+## How it works
+
+X for Android stores the session token and some cached information into the Android system's AccountManager.  
+This information continues to work even if you clear the app data.  
+(This is also why X still be logged in even after clearing the app data.)
+
+Therefore, you can restore this information and log in after re-installation.
+
+## A note when removing account from the app
+
+Please be careful if you want to remove an account from one device after importing the token into another device.
+
+Logging out from settings will log out of the session associated with that token.  
+Therefore, if you simply press the logout button in the settings, you will also be logged out of other devices using the same token.
+
+There are two ways to remove an account from the app without logging out.
+
+- Press the Logout button in airplane mode. (no internet connections)
+- If the app has only one account currently logged in, just uninstall and reinstall the app.
+
+## Troubleshooting
+
+**Q: After importing a token, a notification "You were logged out of @username due to an error." appears immediately.**
+
+A: The session has already been logged out. That token cannot be used.
+
+**Q: After importing a token, it's not logged in even after restarting the app, but there is no notification.**
+
+A: Allow notifications for the X app and try again.
+
+## Appendix
+
+### The format of piko's token file
+
+```json
+{
+  "username": "",
+  "token": "",
+  "secret": "",
+  "userdata": {
+    "account_user_id": "",
+    "account_state": "",
+    "account_field_version": "",
+    "account_user_type": "",
+    "account_settings": "",
+    "account_teams_contributor": "",
+    "account_teams_contributees": "",
+    "account_user_info": "",
+    "account_can_access_x_payments": "",
+    "account_is_x_payments_enrolled": "",
+    "com.twitter.android.oauth.token.teamsContributeeUserId": ""
+  }
+}
+```
+
+- "token" is the value of an auth token `com.twitter.android.oauth.token` from AccountManager
+- "secret" is the value of an auth token `com.twitter.android.oauth.token.secret` from AccountManager
+- "userdata" is an array of the user data stored in AccountManager in key-value format
+
+Not all keys in "userdata" necessarily exist.  
+However, some keys are required. If any required keys are missing when importing an account, the X app will remove that account immediately after it is imported.
+
+### Get token from rooted device without piko
+
+If you are using official X instead of piko on a rooted device (e.g., using an Xposed module) and want to export tokens to use with piko, you can extract your tokens and user data without piko using the following method.
+
+1. Use any file manager app that supports root access
+2. Get `/data/system_ce/0/accounts_ce.db`
+3. Open it with any SQLite database browser/editor app
+4. Open `accounts` table
+5. Remember the number of `_id` of the account you want to export
+6. Open `authtokens` table
+7. Find records where `accounts_id` field is the number you have remembered above
+8. Copy the values of `com.twitter.android.oauth.token` and `com.twitter.android.oauth.token.secret` into the corresponding properties in the JSON format shown above
+9. Open `extras` table
+10. Find records where `accounts_id` field is the number you have remembered above
+11. Copy all the keys and values into the `userdata` property of the JSON format above. Note that `account_user_info` is a JSON text in itself, so you must escape all double quotes.

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.morphe.extension.twitter.patches.logintoken;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.app.Fragment;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.Button;
+import android.widget.Spinner;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.StringRef;
+import app.morphe.extension.shared.Utils;
+
+import java.io.OutputStream;
+
+@SuppressWarnings("deprecation")
+public class ExportLoginTokenFragment extends Fragment {
+
+    private static final int CREATE_FILE_REQUEST_CODE = 31;
+    private Account accountToSaveToFile;
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        return inflater.inflate(Utils.getResourceIdentifier("fragment_export_token", "layout"), container, false);
+    }
+
+    @Override
+    public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        Spinner spinner = view.findViewById(Utils.getResourceIdentifier("spinner", "id"));
+        AccountManager accountManager = AccountManager.get(getContext());
+        Account[] accounts = accountManager.getAccountsByType("com.twitter.android.auth.login");
+        AccountArrayAdapter arrayAdapter = new AccountArrayAdapter(getContext(), android.R.layout.simple_spinner_dropdown_item, accounts);
+        spinner.setAdapter(arrayAdapter);
+
+        Button copyToClipboardButton = view.findViewById(Utils.getResourceIdentifier("copy_button", "id"));
+        copyToClipboardButton.setOnClickListener(v -> {
+            try {
+                Account account = (Account) spinner.getSelectedItem();
+                String jsonString = ImportExportLoginTokenPatch.createAccountJsonText(account);
+                Utils.setClipboard(jsonString);
+                Utils.showToastShort(StringRef.str("copied_to_clipboard"));
+            } catch (Exception e) {
+                Utils.showToastLong(StringRef.str("piko_pref_export_failed", StringRef.str("accounts_title")));
+                Logger.printInfo(() -> "Failed to export account to clipboard", e);
+            }
+        });
+
+        Button saveToFileButton = view.findViewById(Utils.getResourceIdentifier("save_to_file_button", "id"));
+        saveToFileButton.setOnClickListener(v -> {
+            Account account = (Account) spinner.getSelectedItem();
+            accountToSaveToFile = account;
+
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("application/json");
+            intent.putExtra(Intent.EXTRA_TITLE, "piko_account_" + account.name);
+            startActivityForResult(intent, CREATE_FILE_REQUEST_CODE);
+        });
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        /*
+         * Save to a file
+         */
+        if (requestCode == CREATE_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            if (data == null || data.getData() == null) {
+                Utils.showToastLong(StringRef.str("piko_pref_export_no_uri"));
+                return;
+            }
+            try (OutputStream outputStream = getContext().getContentResolver().openOutputStream(data.getData())) {
+                byte[] jsonStringByteArray = ImportExportLoginTokenPatch.createAccountJsonText(accountToSaveToFile).getBytes();
+                outputStream.write(jsonStringByteArray);
+                Utils.showToastShort(StringRef.str("piko_pref_success"));
+            } catch (Exception e) {
+                Utils.showToastLong(StringRef.str("piko_pref_export_failed", StringRef.str("accounts_title")));
+                Logger.printInfo(() -> "Failed to export account to a file", e);
+            }
+        }
+        accountToSaveToFile = null;
+    }
+
+    /**
+     * To show account names in spinner
+     */
+    private static class AccountArrayAdapter extends ArrayAdapter<Account> {
+        public AccountArrayAdapter(@NonNull Context context, int resource, @NonNull Account[] accounts) {
+            super(context, resource, accounts);
+        }
+
+        @NonNull
+        @Override
+        public View getView(int position, View convertView, @NonNull ViewGroup parent) {
+            TextView view = (TextView) super.getView(position, convertView, parent);
+            Account account = getItem(position);
+            view.setText(account.name);
+            return view;
+        }
+
+        @Override
+        public View getDropDownView(int position, View convertView, @NonNull ViewGroup parent) {
+            TextView view = (TextView) super.getDropDownView(position, convertView, parent);
+            Account account = getItem(position);
+            view.setText(account.name);
+            return view;
+        }
+    }
+}

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.morphe.extension.twitter.patches.logintoken;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.StringRef;
+import app.morphe.extension.shared.Utils;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Iterator;
+
+public class ImportExportLoginTokenPatch {
+    private static final String[] USER_DATA_KEYS = {
+            "account_user_id",
+            "account_state",
+            "account_field_version",
+            "account_user_type",
+            "account_settings",
+            "account_teams_contributor",
+            "account_teams_contributees",
+            "account_user_info",
+            "account_can_access_x_payments",
+            "account_is_x_payments_enrolled",
+            "com.twitter.android.oauth.token.teamsContributeeUserId"
+    };
+
+    /**
+     * Create a JSON text for export
+     */
+    public static String createAccountJsonText(Account account) throws JSONException {
+        AccountManager accountManager = AccountManager.get(Utils.getContext());
+
+        JSONObject json = new JSONObject();
+        json.put("username", account.name);
+        json.put("token", accountManager.peekAuthToken(account, "com.twitter.android.oauth.token"));
+        json.put("secret", accountManager.peekAuthToken(account, "com.twitter.android.oauth.token.secret"));
+
+        JSONObject userData = new JSONObject();
+        for (String key : USER_DATA_KEYS) {
+            String value = accountManager.getUserData(account, key);
+            if (value != null) {
+                userData.put(key, value);
+            }
+        }
+
+        json.put("userdata", userData);
+        return json.toString(2);
+    }
+
+    /**
+     * Add an account from imported JSON text
+     */
+    public static void addAccount(Context context, String jsonText) {
+        try {
+            JSONObject accountJson = new JSONObject(jsonText);
+
+            String userName = accountJson.optString("username");
+            String token = accountJson.optString("token");
+            String secret = accountJson.optString("secret");
+            if (userName.isEmpty() || token.isEmpty() || secret.isEmpty()) {
+                Utils.showToastLong(StringRef.str("piko_login_token_import_failed_missing_info"));
+                return;
+            }
+
+            Account account = new Account(userName, "com.twitter.android.auth.login");
+            Bundle newUserData = new Bundle();
+            JSONObject userData = accountJson.getJSONObject("userdata");
+            Iterator<String> itr = userData.keys();
+            while (itr.hasNext()) {
+                String key = itr.next();
+                newUserData.putString(key, userData.getString(key));
+            }
+
+            AccountManager accountManager = AccountManager.get(context);
+            boolean succeeded = accountManager.addAccountExplicitly(account, null, newUserData);
+            if (!succeeded) {
+                Utils.showToastLong(StringRef.str("piko_login_token_import_failed_already_exist"));
+                return;
+            }
+
+            accountManager.setAuthToken(account, "com.twitter.android.oauth.token", token);
+            accountManager.setAuthToken(account, "com.twitter.android.oauth.token.secret", secret);
+
+            // Show a dialog to prompt user to reopen the app.
+            // Closing the activity is enough to reflect the added account.
+            // Since the app begins some process immediately after an account is added,
+            // we do not use Utils.restartApp() which calls System.exit(0) for safety.
+            new AlertDialog.Builder(context)
+                    .setTitle(StringRef.str("piko_pref_success"))
+                    .setMessage(StringRef.str("piko_login_token_import_success_reopen_required"))
+                    .setPositiveButton(android.R.string.ok, (dialog, which) -> {
+                        if (context instanceof Activity activity)
+                            activity.finish();
+                    })
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setCancelable(false)
+                    .show();
+        } catch (JSONException e) {
+            Utils.showToastLong("Failed to parse JSON: " + e.getMessage());
+        } catch (Exception e) {
+            Logger.printException(() -> "addAccount failure", e);
+        }
+    }
+
+    /*
+     * Injection point.
+     */
+    @SuppressWarnings({"deprecation", "unused"})
+    public static void initImportButton(View view) {
+        try {
+            TextView pikoTextView = view.findViewById(Utils.getResourceIdentifier(view.getContext(), "import_token_text", "id"));
+            pikoTextView.setTextColor(Utils.getResourceColor("twitter_blue"));
+            pikoTextView.setOnClickListener(v -> {
+                if (v.getContext() instanceof Activity activity) {
+                    new ImportLoginTokenDialogFragment().show(activity.getFragmentManager(), null);
+                } else {
+                    Logger.printException(() -> "Failed to open import dialog");
+                }
+            });
+        } catch (Exception e) {
+            Logger.printException(() -> "Failed to insert import token button", e);
+        }
+    }
+
+}

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.morphe.extension.twitter.patches.logintoken;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.content.Intent;
+import android.os.Bundle;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.StringRef;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@SuppressWarnings("deprecation")
+public class ImportLoginTokenDialogFragment extends DialogFragment {
+    private static final int PICK_FILE_REQUEST_CODE = 31;
+
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        String[] items = {
+                StringRef.str("piko_login_token_import_from_text"),
+                StringRef.str("piko_login_token_import_from_file")
+        };
+
+        AlertDialog dialog = new AlertDialog.Builder(getContext())
+                .setItems(items, null)
+                .create();
+
+        // To prevent AlertDialog from closing automatically after pressing the "Import from file", set listener manually
+        dialog.getListView().setOnItemClickListener((parent, view, position, id) -> {
+            switch (position) {
+                case 0 -> { // Import from text
+                    new ImportLoginTokenFromTextDialogFragment().show(getFragmentManager(), null);
+                    dismiss();
+                }
+                case 1 -> { // Import from file
+                    Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
+                    intent.addCategory(Intent.CATEGORY_OPENABLE);
+                    intent.setType("application/json");
+                    startActivityForResult(intent, PICK_FILE_REQUEST_CODE);
+                }
+            }
+        });
+
+        return dialog;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        // Import from file
+        if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            if (data == null || data.getData() == null) {
+                StringRef.str("piko_pref_import_no_uri");
+                return;
+            }
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(getContext().getContentResolver().openInputStream(data.getData())))) {
+                StringBuilder sb = new StringBuilder();
+                String readString;
+                while ((readString = reader.readLine()) != null) {
+                    sb.append(readString);
+                }
+                ImportExportLoginTokenPatch.addAccount(getContext(), sb.toString());
+                dismiss();
+            } catch (IOException e) {
+                Logger.printException(() -> "IOException while reading imported file", e);
+            }
+        }
+    }
+}

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenFromTextDialogFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenFromTextDialogFragment.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.morphe.extension.twitter.patches.logintoken;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.app.DialogFragment;
+import android.os.Bundle;
+import android.text.InputType;
+import android.widget.EditText;
+
+@SuppressWarnings("deprecation")
+public class ImportLoginTokenFromTextDialogFragment extends DialogFragment {
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        EditText editText = new EditText(getContext());
+        editText.setHint("json");
+        editText.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE);
+        return new AlertDialog.Builder(getContext())
+                .setView(editText)
+                .setPositiveButton(android.R.string.ok, (dialog, id) ->
+                        ImportExportLoginTokenPatch.addAccount(getContext(), editText.getText().toString()))
+                .setNegativeButton(android.R.string.cancel, null)
+                .create();
+
+    }
+}

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ActivityHook.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ActivityHook.java
@@ -122,10 +122,10 @@ public class ActivityHook {
             toolbarText = "piko_title_logging";
         }else if (activity_name.equals(Settings.READER_MODE_KEY)) {
             toolbarText = "piko_title_native_reader_mode";
-        }else if (activity_name.equals(Settings.READER_MODE_KEY)) {
-            toolbarText = "piko_title_native_reader_mode";
         }else if (activity_name.equals(Settings.CHANGE_APP_ICON)) {
             toolbarText = "piko_pref_customisation_change_app_icon";
+        }else if (activity_name.equals(Settings.EXPORT_LOGIN_TOKEN)) {
+            toolbarText = "piko_pref_export_login_token";
         }
         return Utils.getResourceString(toolbarText);
     }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
@@ -1039,6 +1039,17 @@ public class ScreenBuilder {
                 )
         );
 
+       if (SettingsStatus.exportLoginToken) {
+           addPreference(category,
+                   helper.buttonPreference(
+                           StringRef.str("piko_pref_export_login_token"),
+                           "",
+                           Settings.EXPORT_LOGIN_TOKEN,
+                           "ic_vector_passkey",
+                           null
+                   )
+           );
+       }
     }
 
     public void buildPikoSection(boolean buildCategory){

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
@@ -126,6 +126,7 @@ public class Settings extends BaseSettings {
     public static final String DELETE_EMOJI_FONT = "delete_emoji_font";
     public static final String RESET_READER_MODE_CACHE = "reader_mode_cache";
     public static final String CHANGE_APP_ICON = "change_app_icon";
+    public static final String EXPORT_LOGIN_TOKEN = "export_login_token";
 
     public static final String PREMIUM_SECTION = "premium_section";
     public static final String DOWNLOAD_SECTION = "download_section";

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/SettingsStatus.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/SettingsStatus.java
@@ -383,6 +383,11 @@ public class SettingsStatus {
         disUnifyXChatSystem = true;
     }
 
+    public static boolean exportLoginToken = false;
+    public static void exportLoginToken() {
+        exportLoginToken = true;
+    }
+
     public static boolean enableTimelineSection() {
         return ( hidePostMetrics || hideNavbarBadge || showSourceLabel || hideCommBadge || showSensitiveMedia || hideNudgeButton || disableAutoTimelineScroll || forceTranslate || hidePromoteButton || hideCommunityNote || hideLiveThreads || hideBanner || hideInlineBmk || showPollResultsEnabled || hideImmersivePlayer || enableVidAutoAdvance || enableForceHD);
     }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
@@ -146,7 +146,7 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
         flags.put(strRes("piko_pref_hide_post_inline_metrics"),SettingsStatus.hidePostMetrics);
         flags.put(strRes("piko_disunify_xchat_system"),SettingsStatus.disUnifyXChatSystem);
         flags.put(strRes("piko_legacy_share_link"),SettingsStatus.legacyShareLink);
-
+        flags.put(strRes("piko_pref_export_login_token"),SettingsStatus.exportLoginToken);
 
         LegacyTwitterPreferenceCategory patPref = preferenceCategory(strRes("piko_pref_patches"), screen);
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
@@ -23,6 +23,7 @@ import android.preference.Preference;
 import android.util.AttributeSet;
 import app.morphe.extension.twitter.Utils;
 import app.morphe.extension.twitter.patches.DatabasePatch;
+import app.morphe.extension.twitter.patches.logintoken.ExportLoginTokenFragment;
 import app.morphe.extension.twitter.settings.ActivityHook;
 import app.morphe.extension.twitter.settings.Settings;
 import app.morphe.extension.twitter.settings.fragments.BackupPrefFragment;
@@ -127,6 +128,8 @@ public class ButtonPref extends Preference {
                         ReaderModeUtils.clearCache();
                     } else if (key.equals(Settings.CHANGE_APP_ICON)) {
                         fragment = new IconSelectorFragment();
+                    } else if (key.equals(Settings.EXPORT_LOGIN_TOKEN)) {
+                        fragment = new ExportLoginTokenFragment();
                     } else {
                         ActivityHook.startActivity(key);
                     }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/login/ImportExportLoginTokenPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/login/ImportExportLoginTokenPatch.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.twitter.misc.login
+
+import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
+import app.crimera.patches.twitter.utils.Constants.PATCHES_DESCRIPTOR
+import app.crimera.patches.twitter.utils.enableSettings
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.literal
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.shared.misc.mapping.ResourceType
+import app.morphe.shared.misc.mapping.getResourceId
+import app.morphe.shared.misc.mapping.resourceMappingPatch
+import app.morphe.util.ResourceGroup
+import app.morphe.util.copyResources
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+private const val EXTENSIONS_CLASS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/logintoken/ImportExportLoginTokenPatch;"
+
+private object OcfCtaStepDynamicLayoutInflateFingerprint : Fingerprint(
+    definingClass = "Lcom/twitter/onboarding/ocf/common/",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.CONSTRUCTOR),
+    returnType = "V",
+    filters = listOf(
+        literal(getResourceId(ResourceType.LAYOUT, "ocf_cta_step_dynamic")),
+        methodCall(definingClass = "Landroid/view/LayoutInflater;", name = "inflate"),
+        opcode(Opcode.MOVE_RESULT_OBJECT, InstructionLocation.MatchAfterImmediately())
+    )
+)
+
+@Suppress("unused")
+val importExportLoginTokenPatch = bytecodePatch(
+    name = "Import/Export login token",
+    description = "Adds an feature to export and import the token of accounts. "
+    + "This is useful when logging in on your second device or when re-installing piko.",
+) {
+    compatibleWith(COMPATIBILITY_X)
+
+    dependsOn(
+        resourceMappingPatch,
+        settingsPatch,
+        resourcePatch {
+            execute {
+                document("res/layout/ocf_cta_step_dynamic.xml").use {
+                    val newElement = it.createElement("com.twitter.ui.components.text.legacy.TypefacesTextView").apply {
+                        setAttribute("android:id", "@+id/import_token_text")
+                        setAttribute("android:text", "@string/piko_login_token_import_token_button_text")
+                        setAttribute("android:gravity", "center_vertical")
+                        setAttribute("android:layout_width", "match_parent")
+                        setAttribute("android:layout_height", "wrap_content")
+                        setAttribute("android:layout_marginBottom", "@dimen/ocf_standard_spacing")
+                        setAttribute("android:layout_marginHorizontal", "@dimen/ocf_screen_padding_wide")
+                        setAttribute("android:clickable", "true")
+                        setAttribute("style", "@style/OcfBodyText")
+                    }
+                    it.documentElement.appendChild(newElement)
+                }
+
+                copyResources(
+                    "twitter/settings",
+                    ResourceGroup("layout", "fragment_export_token.xml")
+                )
+            }
+        }
+    )
+
+    execute {
+        OcfCtaStepDynamicLayoutInflateFingerprint.let {
+            it.method.apply {
+                val targetIndex = it.instructionMatches.last().index
+                val targetRegister = getInstruction<OneRegisterInstruction>(targetIndex).registerA
+                addInstructions(
+                    targetIndex + 1,
+                    """
+                    invoke-static {v$targetRegister}, $EXTENSIONS_CLASS_DESCRIPTOR->initImportButton(Landroid/view/View;)V
+                """
+                )
+            }
+        }
+
+        enableSettings("exportLoginToken")
+    }
+}

--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -203,6 +203,7 @@
     <string name="piko_pref_import_failed">Error: Importing %s failed</string>
     <string name="piko_pref_export_no_uri">Error: No destination provided</string>
     <string name="piko_pref_import_no_uri">Error: No file provided</string>
+    <string name="piko_pref_export_login_token">Export login token</string>
 
     <!-- About -->
     <string name="piko_title_about">About</string>
@@ -349,5 +350,26 @@
     <string name="piko_app_icon_name_neon_pink">Neon Pink</string>
     <string name="piko_app_icon_name_tropical_teal">Tropical Teal</string>
     <string name="piko_app_icon_name_vivid_orange">Vivid Orange</string>
+
+    <!-- Import / export login tokens -->
+    <string name="piko_login_token_export_screen_description">"This feature exports the session tokens for the currently logged-in account.
+You can import it from the login screen or \"Create new account\" screen.
+
+WARNING: Exported tokens are highly confidential information.
+Never share it with anyone!
+If someone has this token, they can freely access your account until you log out of the session.
+
+For more details, please refer to this page.
+https://github.com/crimera/piko/blob/dev/docs/about_login_token_patch.md
+It's recommended to read this before using this feature. It includes some important notes."</string>
+    <string name="piko_login_token_select_account">Select an account:</string>
+    <string name="piko_login_token_export_copy_to_clipboard">Copy to clipboard</string>
+    <string name="piko_login_token_export_save_to_file">Save to file</string>
+    <string name="piko_login_token_import_token_button_text">Login through token json</string>
+    <string name="piko_login_token_import_from_text">Import from text</string>
+    <string name="piko_login_token_import_from_file">Import from file</string>
+    <string name="piko_login_token_import_success_reopen_required">Please exit and reopen the app</string>
+    <string name="piko_login_token_import_failed_missing_info">Error: Missing username or token or secret</string>
+    <string name="piko_login_token_import_failed_already_exist">Failed to add account (may already exist)</string>
 
 </resources>

--- a/patches/src/main/resources/twitter/settings/layout/fragment_export_token.xml
+++ b/patches/src/main/resources/twitter/settings/layout/fragment_export_token.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:paddingHorizontal="16dp">
+
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/piko_login_token_export_screen_description"
+                android:autoLink="all"
+                android:textSize="18sp" />
+
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/piko_login_token_select_account"
+                android:textSize="16sp"/>
+
+        <Spinner
+                android:id="@+id/spinner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal" />
+
+        <Button
+                android:id="@+id/copy_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="@string/piko_login_token_export_copy_to_clipboard" />
+
+        <Button
+                android:id="@+id/save_to_file_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="@string/piko_login_token_export_save_to_file" />
+    </LinearLayout>
+</ScrollView>


### PR DESCRIPTION
**Important: This patch does NOT fix the login attestation problem.**

This will allow you to log in with a token exported from a device you're already logged in to.

This is useful in the following cases:
- If you already have a device logged in and want to log in on another device
  - Especially, if one device is Android 14+ (Proton Pass method is available), but another device is Android 13 or below.
- If you want to reinstall piko
- If you want to log into a cloned APK
- If you have a rooted device and want to log into another non-root device

Exported tokens can be imported from the login screen.

Also, I added the "Force remove account" setting.
It removes an account from the app without uninstalling the app, or logging out the session token.
It's necessary to remove account without revoking a token that has been imported to other devices.

### How it works

X for Android stores the tokens and information of the currently logged-in account in the Android system's AccountManager.
This information continues to work even if you clear the app data.
(This is also why X still be logged in even after clearing the app data.)
Therefore, you can restore this information and log in on other devices.

### Videos

https://github.com/user-attachments/assets/e46e4489-9c1c-4d52-8ffd-a6684eec8f65

https://github.com/user-attachments/assets/270ba603-f3ad-4852-a51c-79b6e6e322ae

### An example of exported json

```
{
  "username": "kitadai31",
  "token": "1190244536422785024-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
  "secret": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
  "userdata": {
    "account_user_id": "1190244536422785024",
    "account_state": "ACTIVE",
    "account_field_version": "4",
    "account_user_type": "SWoGTk9STUFMWA==",
    "account_settings": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX...",
    "account_user_info": (A long JSON text of user info),
    "account_can_access_x_payments": "MA==",
    "com.twitter.android.oauth.token.teamsContributeeUserId": "XXXXXXXXXXXXXXXX"
  }
}
```

### TODOs before it's ready

1. ~~"Force remove account" sometimes doesn't works properly.~~
~~The token is invalidated and the server is no longer accessible, but the automatic logout is not triggered. I'll address this in a later commit.~~
2. Currently, a long document is embedded within the app's strings. It might be better to host them outside the app.
Because piko strings are not translated in all languages. And app's text are hard to translate by users themselves. OTOH, if it's in Web, users can translate with their browsers.
Which is better? And when it comes to host outside, where should I place it? It can be repository's `/docs` dir or GitHub Wiki.
3. ~~Add a confirm dialog before remove account~~
4. ~~Improve restart experience~~