### PR TITLE
Update README to include deep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Then patch Twitter/X:
 2. Download original APKM file from ApkMirror. Do _not_ unspilt or modify the file, Morphe patches APKM directly
 3. Wait for patching to complete, install
 
-> For an up-to-date patching guide, see [Liso's official X patch guide](https://www.reddit.com/r/MorpheApp/comments/1r4xt24/x_twitter_can_now_be_patched_with_piko_patches/).
+> For an up-to-date patching guide, [follow this Reddit guide](https://www.reddit.com/r/MorpheApp/comments/1r4xt24/x_twitter_can_now_be_patched_with_piko_patches/).
 
 </details>
 


### PR DESCRIPTION
**What changed:**
- Embedded the deep link `https://morphe.software/add-source?github=crimera/piko` as a clickable button in the Usage section
- Removed the manual 3-step instructions for adding the patch source (replaced by the link)
- Fixed broken `<summary>` tags without matching `<details>`
- Removed the TODO comment
- Slightly trimmed the license text
- #851