### PR TITLE
chore: Update to Patcher 1.3.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-morphe-patcher = "1.1.1"
+morphe-patcher = "1.3.2"
 #noinspection GradleDependency
 smali = "b6365a84f4"
 gson = "2.13.2"

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideAds.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideAds.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.ads.timelineEntryHook
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
@@ -37,7 +38,7 @@ val hideAds =
         name = "Remove Ads",
         description = "Removed promoted posts, trends and google ads",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(timelineEntryHookPatch, settingsPatch)
         execute {
             // Normal Ads.

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideTimelinePostByCategory.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/ads/timelineEntryHook/HideTimelinePostByCategory.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.ads.timelineEntryHook
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val hideTimelinePostByCategory =
         name = "Hide timeline posts by category",
         description = "Hides different post category like who to follow, news today etc from timeline.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(timelineEntryHookPatch, settingsPatch)
         execute {
             // Pinned posts by followers.

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/DisableChirpFontPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/DisableChirpFontPatch.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.featureFlag.featureFlagPatch.featureFlagPatch
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
 import app.morphe.patcher.patch.bytecodePatch
@@ -23,7 +24,7 @@ val disableChirpFontPatch =
     bytecodePatch(
         name = "Disable chirp font",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagPatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideBookmarkInTimelinePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideBookmarkInTimelinePatch.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.featureFlag.featureFlagPatch.featureFlagPatch
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
 import app.morphe.patcher.patch.bytecodePatch
@@ -23,7 +24,7 @@ val hideBookmarkInTimelinePatch =
     bytecodePatch(
         name = "Hide bookmark icon in timeline",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagPatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideFABMenuButtonsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideFABMenuButtonsPatch.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.featureFlag.featureFlagPatch.featureFlagPatch
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
 import app.morphe.patcher.patch.bytecodePatch
@@ -23,7 +24,7 @@ val hideFABMenuButtonsPatch =
     bytecodePatch(
         name = "Hide FAB Menu Buttons",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagPatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideImmersivePlayer.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/HideImmersivePlayer.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.featureFlag.featureFlagPatch.featureFlagPatch
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
 import app.morphe.patcher.patch.bytecodePatch
@@ -24,7 +25,7 @@ val hideImmersivePlayer =
         name = "Hide immersive player",
         description = "Removes swipe up for more videos in video player",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagPatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/RemoveViewCountPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/RemoveViewCountPatch.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.featureFlag.featureFlagPatch.featureFlagPatch
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
 import app.morphe.patcher.patch.bytecodePatch
@@ -25,7 +26,7 @@ val removeViewCountPatch =
         name = "Remove view count",
         description = "Removes the view count from the bottom of tweets",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagPatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/featureFlagPatch/FeatureFlagPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/featureFlag/featureFlagPatch/FeatureFlagPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.featureFlag.featureFlagPatch
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.FSTS_DESCRIPTOR
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
@@ -35,7 +36,7 @@ val featureFlagPatch =
     bytecodePatch(
         name = "Hook feature flag",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(featureFlagResourcePatch, settingsPatch)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/changedirectory/ChangeDownloadDirPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/changedirectory/ChangeDownloadDirPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.interaction.downloads.changedirectory
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -38,8 +39,9 @@ val changeDownloadDirPatch =
     bytecodePatch(
         name = "Custom download folder",
         description = "Change the download directory for video downloads",
+        default = true
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/interaction/downloads/copyMediaLink/CopyMediaLink.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.interaction.downloads.copyMediaLink
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -39,8 +40,10 @@ internal object DownloadCallFingerprint : Fingerprint(
 val copyMediaLink =
     bytecodePatch(
         name = "Add ability to copy media link",
+        default = true
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
+
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/cleartrackingparams/ClearTrackingParamsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/cleartrackingparams/ClearTrackingParamsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.link.cleartrackingparams
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
@@ -37,8 +38,9 @@ val clearTrackingParamsPatch =
     bytecodePatch(
         name = "Clear tracking params",
         description = "Removes tracking parameters when sharing links",
+        default = true
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/customDeeplinks/CustomDeepLinksPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/customDeeplinks/CustomDeepLinksPatch.kt
@@ -1,5 +1,6 @@
 package app.crimera.patches.twitter.link.customDeeplinks
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.patch.stringsOption
@@ -31,7 +32,7 @@ val customDeepLinksPatch = resourcePatch(
         ),
     )
 
-    compatibleWith("com.twitter.android")
+    compatibleWith(COMPATIBILITY_X)
 
     dependsOn(handleCustomDeepLinksPatch)
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/customsharingdomain/CustomSharingDomainPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/customsharingdomain/CustomSharingDomainPatch.kt
@@ -4,7 +4,7 @@
  * This file is part of piko.
  *
  * Any modifications, derivatives, or substantial rewrites of this file
- * must retain this copyright notice and the piko attribution 
+ * must retain this copyright notice and the piko attribution
  * in the source code and version control history.
  */
 
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.link.cleartrackingparams.AddSessionTokenFinge
 import app.crimera.patches.twitter.link.handlemodernsharesheetlinks.handleModernShareSheetLinks
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
@@ -25,7 +26,7 @@ val customSharingDomainPatch =
         name = "Custom sharing domain",
         description = "Allows for using domains like fxtwitter when sharing tweets/posts.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, handleModernShareSheetLinks)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
@@ -11,6 +11,7 @@
 package app.crimera.patches.twitter.link.handlemodernsharesheetlinks
 
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.extractDescriptors
 import app.morphe.patcher.Fingerprint
@@ -44,7 +45,7 @@ val handleModernShareSheetLinks =
     bytecodePatch(
         description = "Hooks links on modern share sheet ( after 11.4x.xx )",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         execute {
 
             // Try catch is used in case someone uses this patch pre-11.4x.xx

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/legacyShareLinks/LegacyShareLinksPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/legacyShareLinks/LegacyShareLinksPatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.link.legacyShareLinks
 import app.crimera.patches.twitter.link.handlemodernsharesheetlinks.handleModernShareSheetLinks
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -22,7 +23,7 @@ val legacyShareLinksPatch =
         name = "Legacy share links",
         description = "Brings back username on post share links. Works post 11.4x.xx",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, handleModernShareSheetLinks)
         execute {
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/unshorten/NoShortenedUrlPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/unshorten/NoShortenedUrlPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.link.unshorten
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -32,7 +33,7 @@ val noShortenedUrlPatch =
         name = "No shortened URL",
         description = "Get rid of t.co short urls.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/logging/responseLogging/ResponseLogging.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/logging/responseLogging/ResponseLogging.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.logging.responseLogging
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -32,7 +33,7 @@ val responseLoggingPatch =
         name = "Log server response",
         description = "Log json responses received from server",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/appicon/AppIconPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/appicon/AppIconPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.appicon
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -20,7 +21,7 @@ val appIconPatch =
     bytecodePatch(
         name = "Change app icon",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, appIconResourcePatch)
         execute {
             SettingsStatusLoadFingerprint.enableSettings("appIconCustomisation")

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
@@ -10,6 +10,7 @@
 
 package app.crimera.patches.twitter.misc.bringbacktwitter
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.replaceStringsInFile
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patches.all.misc.resources.addAppResources
@@ -25,9 +26,9 @@ val bringBackTwitterPatch =
     resourcePatch(
         name = "Bring back twitter",
         description = "Bring back old twitter logo and name",
-        use = false,
+        default = false,
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
 
         dependsOn(addResourcesPatch)
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/exploretabs/CustomiseExploreTabsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/exploretabs/CustomiseExploreTabsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.exploretabs
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -33,7 +34,7 @@ val customiseExploreTabsPatch =
     bytecodePatch(
         name = "Customize explore tabs",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomEmojiFont.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomEmojiFont.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.font
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val customEmojiFont =
         name = "Custom emoji font",
         description = "Customise emoji font style",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(customFontHook, settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomFont.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomFont.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.font
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val customFont =
         name = "Custom font",
         description = "Customise font style",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(customFontHook, settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomiseFontHook.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/font/CustomiseFontHook.kt
@@ -11,6 +11,7 @@
 package app.crimera.patches.twitter.misc.customize.font
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
@@ -32,7 +33,7 @@ val customFontHook =
     bytecodePatch(
         description = "Hook to customise font",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/inlinebar/CustomiseInlineBarPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/inlinebar/CustomiseInlineBarPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.inlinebar
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val customiseInlineBarPatch =
     bytecodePatch(
         name = "Customize Inline action Bar items",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.customize.navbar
 import app.crimera.patches.twitter.featureFlag.featureFlagPatch.fingerprints.FeatureFlagLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.crimera.utils.flagSettings
@@ -47,7 +48,7 @@ val customiseNavBarPatch =
     bytecodePatch(
         name = "Customize Navigation Bar items",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/notificationtabs/CustomiseNotificationTabsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/notificationtabs/CustomiseNotificationTabsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.notificationtabs
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -39,7 +40,7 @@ val customiseNotificationTabsPatch =
     bytecodePatch(
         name = "Customize notification tabs",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/postFontSize/CustomizePostFontSize.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/postFontSize/CustomizePostFontSize.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.postFontSize
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -31,7 +32,7 @@ val customizePostFontSize =
     bytecodePatch(
         name = "Customise post font size",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/profiletabs/CustomiseProfileTabsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/profiletabs/CustomiseProfileTabsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.profiletabs
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -41,7 +42,7 @@ val customiseProfileTabsPatch =
     bytecodePatch(
         name = "Customize profile tabs",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/replySorting/DefaultReplySortingPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/replySorting/DefaultReplySortingPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.replySorting
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -43,7 +44,7 @@ val defaultReplySortingPatch =
     bytecodePatch(
         name = "Customize default reply sorting",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/searchtabs/CustomiseSearchTabsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/searchtabs/CustomiseSearchTabsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.searchtabs
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val customiseSearchTabsPatch =
     bytecodePatch(
         name = "Customize search tab items",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/sidebar/CustomiseSideBarPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/sidebar/CustomiseSideBarPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.sidebar
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -33,7 +34,7 @@ val customiseSideBarPatch =
     bytecodePatch(
         name = "Customize side bar items",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/timelinetabs/CustomiseTimelineTabsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/timelinetabs/CustomiseTimelineTabsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.timelinetabs
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -31,7 +32,7 @@ val customiseTimelineTabsPatch =
     bytecodePatch(
         name = "Customize timeline top bar",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/typeAheadResponse/CustomiseTypeAheadResponsePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/typeAheadResponse/CustomiseTypeAheadResponsePatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.customize.typeAheadResponse
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -31,7 +32,7 @@ val customiseTypeAheadResponsePatch =
     bytecodePatch(
         name = "Customize search suggestions",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/disUnifyXChatSystem/DisUnifyXChatSystemPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/disUnifyXChatSystem/DisUnifyXChatSystemPatch.kt
@@ -4,7 +4,7 @@
  * This file is part of piko.
  *
  * Any modifications, derivatives, or substantial rewrites of this file
- * must retain this copyright notice and the piko attribution 
+ * must retain this copyright notice and the piko attribution
  * in the source code and version control history.
  */
 
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.disUnifyXChatSystem
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -33,9 +34,9 @@ val disUnifyXchatSystemPatch =
     bytecodePatch(
         name = "Disunify xchat system",
         description = "Bring back legacy features like messages and share sheet.",
-        use = false
+        default = false
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/dynamiccolor/DynamicColorPatch.kt
@@ -1,5 +1,6 @@
 package app.crimera.patches.twitter.misc.dynamiccolor
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.resourcePatch
 import java.io.FileWriter
 import java.nio.file.Files
@@ -8,9 +9,9 @@ import java.nio.file.Files
 val dynamicColorPatch = resourcePatch(
     name = "Dynamic color",
     description = "Replaces the default Twitter Blue with the user's Material You palette.",
-    use = false,
+    default = false,
 ) {
-    compatibleWith("com.twitter.android")
+    compatibleWith(COMPATIBILITY_X)
 
     execute {
         // For backward compatibility, add colors and styles into v31 res dir (A12+).

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/fab/HideFABPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/fab/HideFABPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.fab
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -34,7 +35,7 @@ val hideFABPatch =
         name = "Hide FAB",
         description = "Adds an option to hide Floating action button",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/recommendedusers/HideRecommendedUsersPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/recommendedusers/HideRecommendedUsersPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.recommendedusers
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -36,7 +37,7 @@ val hideRecommendedUsers =
         name = "Hide Recommended Users",
         description = "Hide recommended users that pops up when you follow someone",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/roundOffNumbers/RoundOffNumbersPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/roundOffNumbers/RoundOffNumbersPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.roundOffNumbers
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -41,7 +42,7 @@ val roundOffNumbersPatch =
         name = "Round off numbers",
         description = "Enable or disable rounding off numbers",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/searchsuggestions/PauseSearchSuggestionsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/searchsuggestions/PauseSearchSuggestionsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.searchsuggestions
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -34,7 +35,7 @@ val pauseSearchSuggestion =
         name = "Pause search suggestions",
         description = "Search suggestions will not be saved locally",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/searchsuggestions/RemoveSearchSuggestionsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/searchsuggestions/RemoveSearchSuggestionsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.searchsuggestions
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val RemoveSearchSuggestions =
         name = "Remove search suggestions",
         description = "Hide/Remove search suggestion in explore section",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/selectabletext/SelectableTextPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/selectabletext/SelectableTextPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.selectabletext
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
@@ -46,7 +47,7 @@ val selectableTextPatch =
         name = "Selectable Text",
         description = "Makes bio and username selectable",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, selectableTextResourcePatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/browseObject/BrowseTweetObjectPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/browseObject/BrowseTweetObjectPatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.shareMenu.browseObject
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.shareMenu.hooks.shareMenuButtonInjection
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -20,9 +21,9 @@ val browseObjectPatch =
     bytecodePatch(
         name = "Browse tweet object",
         description = "Adds an option to browse the tweet object in the share menu.",
-        use = false,
+        default = false,
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, entityGenerator)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/debugMenu/DebugMenu.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/debugMenu/DebugMenu.kt
@@ -14,6 +14,7 @@ import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.shareMenu.fingerprints.ActionEnumsFingerprint
 import app.crimera.patches.twitter.misc.shareMenu.hooks.registerButton
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -22,7 +23,7 @@ val debugMenu =
     bytecodePatch(
         name = "Enable debug menu for posts",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeDownloader/InlineDownloadButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeDownloader/InlineDownloadButtonPatch.kt
@@ -2,6 +2,7 @@ package app.crimera.patches.twitter.misc.shareMenu.nativeDownloader
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.changeFirstString
 import app.crimera.utils.enableSettings
@@ -58,7 +59,7 @@ private val inlineDownloadRenderHintsFocalFieldFingerprint = placeholderFingerpr
 val inlineDownloadButtonPatch = bytecodePatch(
     description = "Adds an inline 'Download' button to the tweet inline action bar and registers the extension hook.",
 ) {
-    compatibleWith("com.twitter.android")
+    compatibleWith(COMPATIBILITY_X)
     dependsOn(settingsPatch)
 
     execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeDownloader/NativeDownloaderPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeDownloader/NativeDownloaderPatch.kt
@@ -4,7 +4,7 @@
  * This file is part of piko.
  *
  * Any modifications, derivatives, or substantial rewrites of this file
- * must retain this copyright notice and the piko attribution 
+ * must retain this copyright notice and the piko attribution
  * in the source code and version control history.
  */
 
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.shareMenu.nativeDownloader
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.shareMenu.hooks.shareMenuButtonInjection
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -21,7 +22,7 @@ val nativeDownloaderPatch =
         name = "Native downloader",
         description = "Requires X 11.0.0-release.0 or higher.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, entityGenerator, inlineDownloadButtonPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeReaderMode/NativeReaderModePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeReaderMode/NativeReaderModePatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.shareMenu.nativeReaderMode
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.shareMenu.hooks.*
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -21,7 +22,7 @@ val nativeReaderModePatch =
         name = "Native reader mode",
         description = "Requires X 11.0.0-release.0 or higher.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(nativeReaderModeResourcePatch,settingsPatch, entityGenerator)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeShareImage/NativeShareImagePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeShareImage/NativeShareImagePatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.shareMenu.nativeShareImage
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.shareMenu.hooks.shareMenuButtonInjection
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -21,7 +22,7 @@ val nativeShareImagePatch =
         name = "Share Tweet as Image",
         description = "Share tweets as rendered image. Requires X 11.0.0-release.0 or higher.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, entityGenerator)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeTranslator/NativeTranslatorPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/nativeTranslator/NativeTranslatorPatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.misc.shareMenu.nativeTranslator
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.shareMenu.hooks.*
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -21,7 +22,7 @@ val nativeTranslatorModePatch =
         name = "Custom translator",
         description = "Requires X 11.0.0-release.0 or higher.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, entityGenerator)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/showchangelogs/ShowChangelogsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/showchangelogs/ShowChangelogsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.misc.showchangelogs
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -28,7 +29,7 @@ val changelogsPatch =
         name = "Show changelogs",
         description = "Shows changelogs when new a patch is installed.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/premium/enableForcePip/EnableForcePipPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/premium/enableForcePip/EnableForcePipPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.premium.enableForcePip
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -39,7 +40,7 @@ val enableForcePipPatch =
         name = "Enable PiP mode automatically",
         description = "Enables PiP mode when you close the app",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/premium/undoposts/EnableUndoPostPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/premium/undoposts/EnableUndoPostPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.premium.undoposts
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -55,7 +56,7 @@ val enableUndoPostPatch =
         name = "Enable Undo Posts",
         description = "Enables ability to undo posts before posting",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/premium/unlockdownloads/DownloadPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/premium/unlockdownloads/DownloadPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.premium.unlockdownloads
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.OpcodesFilter
@@ -66,7 +67,7 @@ val downloadPatch =
         name = "Download patch",
         description = "Unlocks the ability to download videos and gifs from Twitter/X",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/shared/Constants.kt
@@ -1,0 +1,24 @@
+package app.crimera.patches.twitter.shared
+
+import app.morphe.patcher.patch.ApkFileType
+import app.morphe.patcher.patch.AppTarget
+import app.morphe.patcher.patch.Compatibility
+
+internal object Constants {
+    val COMPATIBILITY_X = Compatibility(
+        name = "X",
+        packageName = "com.twitter.android",
+        apkFileType = ApkFileType.APKM,
+        appIconColor = 0x000000,
+        signatures = setOf(
+            // APK
+            "0fd9a0cfb07b65950997b4eaebdc53931392391aa406538a3b04073bc2ce2fe9",
+            // APKM
+            "45c53db089fb8d63a1c71154037c414b1b0646a141a73ae6e3bcbf8cd148402f"
+        ),
+        targets = listOf(
+            // Any version
+            AppTarget(version = null)
+        )
+    )
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/banner/HideBannerPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/banner/HideBannerPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.banner
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val hideBannerPatch =
         name = "Hide Banner",
         description = "Hide new post banner",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/deleteFromDatabase/DeleteFromDatabasePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/deleteFromDatabase/DeleteFromDatabasePatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.deleteFromDatabase
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val deleteFromDatabasePatch =
         name = "Delete from database",
         description = "Delete entries from database(cache)",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/DisableAutoScrollPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/DisableAutoScrollPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.disableAutoScroll
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
@@ -35,7 +36,7 @@ val disableAutoScrollPatch =
     bytecodePatch(
         name = "Disable auto timeline scroll on launch",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/enableVidAutoAdvance/EnableVidAutoAdvancePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/enableVidAutoAdvance/EnableVidAutoAdvancePatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.enableVidAutoAdvance
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -34,7 +35,7 @@ val enableVidAutoAdvancePatch =
         name = "Control video auto scroll",
         description = "Control video auto scroll in immersive view",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/forceHD/ForceHDPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/forceHD/ForceHDPatch.kt
@@ -13,6 +13,7 @@ package app.crimera.patches.twitter.timeline.forceHD
 import app.crimera.patches.twitter.entity.entityGenerator
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -37,7 +38,7 @@ val forceHDPatch =
         name = "Enable force HD videos",
         description = "Videos will be played in highest quality always",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, entityGenerator)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideCommunityBadge/HideCommunityBadge.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideCommunityBadge/HideCommunityBadge.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hideCommunityBadge
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.crimera.utils.extractDescriptors
@@ -35,7 +36,7 @@ val hideCommunityBadge =
     bytecodePatch(
         name = "Hide community badges",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideHiddenReplies/HideHiddenRepliesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideHiddenReplies/HideHiddenRepliesPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hideHiddenReplies
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -32,7 +33,7 @@ val hideHiddenRepliesPatch =
     bytecodePatch(
         name = "Hide hidden replies",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideNavbarBadges/HideNavBarBadges.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideNavbarBadges/HideNavBarBadges.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hideNavbarBadges
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -29,7 +30,7 @@ val hideNavBarBadgesPatch =
         name = "Hide badges from navigation bar icons",
         description = "Hides notification nudges & counts from navigation bar icons",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideNudgeButtons/HideNudgeButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideNudgeButtons/HideNudgeButtonPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hideNudgeButtons
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -34,7 +35,7 @@ val hideNudgeButtonPatch =
         name = "Hide nudge button",
         description = "Hides follow/subscribe/follow back buttons on posts",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hidePostMetrics/HidePostMetrics.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hidePostMetrics/HidePostMetrics.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hidePostMetrics
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -43,7 +44,7 @@ val hidePostMetrics =
         name = "Hide post metrics",
         description = "Hides like, reposts etc counts.",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideSocialProof/HideSoialProofPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/hideSocialProof/HideSoialProofPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.hideSocialProof
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -32,7 +33,7 @@ val hideSocialProofPatch =
         name = "Hide followed by context",
         description = "Hides followed by context under profile",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/live/HideLiveThreadsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/live/HideLiveThreadsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.live
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val hideLiveThreadsPatch =
     bytecodePatch(
         name = "Hide Live Threads",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/removePremiumUpsell/RemovePremiumUpsellPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/removePremiumUpsell/RemovePremiumUpsellPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.removePremiumUpsell
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -33,7 +34,7 @@ val disablePremiumUpsellPatch =
         name = "Remove premium upsell",
         description = "Removes premium upsell in home timeline",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.sensitivemediasettings
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -33,7 +34,7 @@ val sensitiveMediaPatch =
     bytecodePatch(
         name = "Show sensitive media",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/showSourceLabel/ShowSourceLabel.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/showSourceLabel/ShowSourceLabel.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.showSourceLabel
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
@@ -39,7 +40,7 @@ val showSourceLabel =
         name = "Show post source label",
         description = "Source label will be shown only on public posts",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/showpollresults/ShowPollResultsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/showpollresults/ShowPollResultsPatch.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.showpollresults
 
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
 import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.Fingerprint
@@ -35,7 +36,7 @@ val showPollResultsPatch =
         name = "Show poll results",
         description = "Adds an option to show poll results without voting",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/ForceTranslate.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/ForceTranslate.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.tweetinfo
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val forceTranslate =
         name = "Force enable translate",
         description = "Get translate option for all posts",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, tweetInfoHook)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/HideCommunityNotes.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/HideCommunityNotes.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.tweetinfo
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -20,7 +21,7 @@ val hideCommunityNotes =
     bytecodePatch(
         name = "Hide Community Notes",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, tweetInfoHook)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/HidePromoteButton.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/tweetinfo/HidePromoteButton.kt
@@ -12,6 +12,7 @@ package app.crimera.patches.twitter.timeline.tweetinfo
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.misc.settings.SettingsStatusLoadFingerprint
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.crimera.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -21,7 +22,7 @@ val hidePromoteButton =
         name = "Hide promote button",
         description = "Hides promote button under self posts",
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, tweetInfoHook)
 
         execute {

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/activity/exportall/ExportAllActivitiesPatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/activity/exportall/ExportAllActivitiesPatch.kt
@@ -1,5 +1,6 @@
 package app.revanced.patches.all.misc.activity.exportall
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.resourcePatch
 
 @Suppress("unused")
@@ -7,9 +8,9 @@ val exportAllActivitiesPatch =
     resourcePatch(
         name = "Export all activities",
         description = "Makes all app activities exportable.",
-        use = false,
+        default = false,
     ) {
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
 
         execute {
             val exportedFlag = "android:exported"

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -1,5 +1,6 @@
 package app.revanced.patches.all.misc.versioncode
 
+import app.crimera.patches.twitter.shared.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.intOption
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.util.getNode
@@ -9,10 +10,9 @@ import org.w3c.dom.Element
 val changeVersionCodePatch =
     resourcePatch(
         name = "Change version code",
-        description =
-            "Changes the version code of the app. This will turn off app store updates " +
+        description = "Changes the version code of the app. This will turn off app store updates " +
                 "and allows downgrading an existing app install to an older app version.",
-        use = true // Default on
+        default = true
     ) {
         val versionCode by intOption(
             key = "versionCode",
@@ -29,7 +29,7 @@ val changeVersionCodePatch =
             required = true,
         ) { versionCode -> versionCode!! >= 1 }
 
-        compatibleWith("com.twitter.android")
+        compatibleWith(COMPATIBILITY_X)
 
         execute {
             document("AndroidManifest.xml").use { document ->


### PR DESCRIPTION
Uses the new compatibility tag which includes:
- App name
- App icon color
- SHA-256 signing signature (ensures users doesn't accidentally patch a previously patched app)
- Default file type (currently only used for Manager UI).

