### PR TITLE
feat(Instagram): Disable read receipts in DMs

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -38,6 +38,8 @@ public class Strings {
     public static final String CATEGORY_GHOST = "Ghost";
     public static final String VIEW_STORIES_ANONYMOUSLY = "View stories anonymously";
     public static final String VIEW_LIVE_ANONYMOUSLY = "View live anonymously";
+    public static final String VIEW_DMS_ANONYMOUSLY = "View DMs anonymously";
+    public static final String VIEW_DMS_ANONYMOUSLY_DESC = "Hide read receipts in DMs";
 
     public static final String CATEGORY_DISTRACTION_FREE = "Distraction free";
     public static final String DISABLE_STORIES = "Disable stories";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -34,6 +34,7 @@ public class Links {
     private static final boolean DISABLE_COMMENTS;
     private static final boolean DISABLE_DISCOVER_PEOPLE;
     private static final boolean DISABLE_ADS;
+    private static final boolean VIEW_DMS_ANONYMOUSLY;
 
     static {
         DISABLE_ANALYTICS = Pref.disableAnalytics() && SettingsStatus.disableAnalytics;
@@ -44,6 +45,7 @@ public class Links {
         DISABLE_COMMENTS = Pref.disableComments() && SettingsStatus.disableComments;
         DISABLE_DISCOVER_PEOPLE = Pref.disableDiscoverPeople() && SettingsStatus.disableDiscoverPeople;
         DISABLE_ADS = Pref.disableAds() && SettingsStatus.disableAds;
+        VIEW_DMS_ANONYMOUSLY = Pref.viewDmsAnonymously() && SettingsStatus.viewDmsAnonymously;
     }
 
 
@@ -110,7 +112,12 @@ public class Links {
                         || path.contains("/feed/injected_reels_media/")
                         || path.contains("/api/v1/ads/graphql/")) {
                     shouldBlockUri = DISABLE_ADS;
-                }
+               else if ((host.contains("i.instagram.com") || host.contains("b.i.instagram.com"))
+                            && path.contains("/api/v1/direct_v2/threads/")
+                            && path.contains("/items/")
+                            && path.contains("/seen/")) {
+                        shouldBlockUri = VIEW_DMS_ANONYMOUSLY;
+                    }
 
             }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -27,6 +27,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
+    public static final BooleanSetting VIEW_DMS_ANONYMOUSLY = new BooleanSetting("view_dms_anonymously", false);
     public static final BooleanSetting DISABLE_STORIES = new BooleanSetting("disable_stories", false);
     public static final BooleanSetting HIDE_STORIES_TRAY = new BooleanSetting("hide_stories_tray", false);
     public static final BooleanSetting DISABLE_EXPLORE = new BooleanSetting("disable_explore", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -59,8 +59,12 @@ public class SettingsStatus {
     public static void viewLiveAnonymously() {
         viewLiveAnonymously = true;
     }
+    public static boolean viewDmsAnonymously = false;
+    public static void viewDmsAnonymously() {
+        viewDmsAnonymously = true;
+    }
     public static boolean ghostSection() {
-        return (viewStoriesAnonymously || viewLiveAnonymously);
+        return (viewStoriesAnonymously || viewLiveAnonymously || viewDmsAnonymously);
     }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -144,6 +144,15 @@ public class ScreenBuilder {
                     )
             );
         }
+        if (SettingsStatus.viewDmsAnonymously) {
+            addPreference(category,
+                    helper.switchPreference(
+                            Strings.VIEW_DMS_ANONYMOUSLY,
+                            Strings.VIEW_DMS_ANONYMOUSLY_DESC,
+                            Settings.VIEW_DMS_ANONYMOUSLY
+                    )
+            );
+        }
 
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -32,6 +32,9 @@ public class Pref {
     public static boolean viewLiveAnonymously(){
         return SharedPref.getBooleanPerf(Settings.VIEW_LIVE_ANONYMOUSLY);
     }
+    public static boolean viewDmsAnonymously(){
+        return SharedPref.getBooleanPerf(Settings.VIEW_DMS_ANONYMOUSLY) && SettingsStatus.viewDmsAnonymously;
+    }
 
     public static boolean disableStories(){
         return SharedPref.getBooleanPerf(Settings.DISABLE_STORIES);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/privacy/ViewDmsAnonymouslyPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/privacy/ViewDmsAnonymouslyPatch.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.instagram.links.privacy
+
+import app.crimera.patches.instagram.links.interceptUriPatch
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val viewDmsAnonymouslyPatch =
+    bytecodePatch(
+        name = "View DMs anonymously",
+        description = "Hide read receipts in DMs",
+    ) {
+        dependsOn(settingsPatch, interceptUriPatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            enableSettings("viewDmsAnonymously")
+        }
+    }


### PR DESCRIPTION
This PR is intended to prevent read receipts (i.e. Seen 5 minutes ago) from being sent when opening Instagram DMs. 

The endpoints may need to be adjusted, as the only sources I could find are quite old and may not represent the true endpoints used by Instagram in 2026. 