### PR TITLE
feat: Anonymous DM viewing in Instagram

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -38,6 +38,7 @@ public class Strings {
     public static final String CATEGORY_GHOST = "Ghost";
     public static final String VIEW_STORIES_ANONYMOUSLY = "View stories anonymously";
     public static final String VIEW_LIVE_ANONYMOUSLY = "View live anonymously";
+    public static final String VIEW_DM_ANONYMOUSLY = "View direct messages anonymously";
 
     public static final String CATEGORY_DISTRACTION_FREE = "Distraction free";
     public static final String DISABLE_STORIES = "Disable stories";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -27,6 +27,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
+    public static final BooleanSetting VIEW_DM_ANONYMOUSLY = new BooleanSetting("view_dm_anonymously", true);
     public static final BooleanSetting DISABLE_STORIES = new BooleanSetting("disable_stories", false);
     public static final BooleanSetting HIDE_STORIES_TRAY = new BooleanSetting("hide_stories_tray", false);
     public static final BooleanSetting DISABLE_EXPLORE = new BooleanSetting("disable_explore", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -59,8 +59,12 @@ public class SettingsStatus {
     public static void viewLiveAnonymously() {
         viewLiveAnonymously = true;
     }
+    public static boolean viewDmAnonymously = false;
+    public static void viewDmAnonymously() {
+        viewDmAnonymously = true;
+    }
     public static boolean ghostSection() {
-        return (viewStoriesAnonymously || viewLiveAnonymously);
+        return (viewStoriesAnonymously || viewLiveAnonymously || viewDmAnonymously);
     }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -144,6 +144,15 @@ public class ScreenBuilder {
                     )
             );
         }
+        if (SettingsStatus.viewDmAnonymously) {
+            addPreference(category,
+                    helper.switchPreference(
+                            Strings.VIEW_DM_ANONYMOUSLY,
+                            "",
+                            Settings.VIEW_DM_ANONYMOUSLY
+                    )
+            );
+        }
 
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -32,6 +32,9 @@ public class Pref {
     public static boolean viewLiveAnonymously(){
         return SharedPref.getBooleanPerf(Settings.VIEW_LIVE_ANONYMOUSLY);
     }
+    public static boolean viewDmAnonymously(){
+        return SharedPref.getBooleanPerf(Settings.VIEW_DM_ANONYMOUSLY);
+    }
 
     public static boolean disableStories(){
         return SharedPref.getBooleanPerf(Settings.DISABLE_STORIES);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/Fingerprint.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.instagram.misc.ghostMode
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object DMSeenFingerprint : Fingerprint(
+    returnType = "V",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
+    filters = listOf(
+        string("mark_thread_seen-")
+    ),
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/ViewDmAnonymouslyPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/ViewDmAnonymouslyPatch.kt
@@ -23,7 +23,7 @@ import app.morphe.util.getFreeRegisterProvider
 @Suppress("unused")
 val viewDmAnonymouslyPatch =
     bytecodePatch(
-        name = "View DM anonymously",
+        name = "View DMs anonymously",
     ) {
         dependsOn(settingsPatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
@@ -43,7 +43,7 @@ val viewDmAnonymouslyPatch =
                     if-eqz v$shouldDisableRegister, :piko_continue
                     return-void
                 """.trimIndent(),
-                    ExternalLabel("piko_continue", getInstruction(0))
+                    ExternalLabel("piko_continue", getInstruction(1))
                 )
             }
             enableSettings("viewDmAnonymously")

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/ViewDmAnonymouslyPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/ghostMode/ViewDmAnonymouslyPatch.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.instagram.misc.ghostMode
+
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.PREF_DESCRIPTOR
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.getFreeRegisterProvider
+
+@Suppress("unused")
+val viewDmAnonymouslyPatch =
+    bytecodePatch(
+        name = "View DM anonymously",
+    ) {
+        dependsOn(settingsPatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            DMSeenFingerprint.method.apply {
+                val shouldDisableRegister = getFreeRegisterProvider(
+                    index = 1,
+                    numberOfFreeRegistersNeeded = 1
+                ).getFreeRegister()
+
+                addInstructionsWithLabels(
+                    1,
+                    """
+                    invoke-static {}, $PREF_DESCRIPTOR->viewDmAnonymously()Z
+                    move-result v$shouldDisableRegister
+                    if-eqz v$shouldDisableRegister, :piko_continue
+                    return-void
+                """.trimIndent(),
+                    ExternalLabel("piko_continue", getInstruction(0))
+                )
+            }
+            enableSettings("viewDmAnonymously")
+        }
+    }


### PR DESCRIPTION
Adds an option in the settings to toggle settings DMs as read.

This patch could not be blocked by simply blocking the URI because of two main reasons:

1: The URI it uses (as far as I could intercept) is the general graphql_www endpoint and it actually encodes the request to mark as read in a field named fb_api_req_friendly_name (= IGDirectItemSeenMutation), which from what I understood from the codebase can't easily be intercepted yet.

2. I am not really experienced with working with apis and if there is a way that I am unaware of to block this specific request type then changing the patch to do that would be better and cleaner.

I have the request intercept to help make this work if it turns out to be feasible. In the meantime, this patch is tested working with v423.0.0.47.66 which is the stable supported version.