### PR TITLE
fix(Instagram): download all carousel media

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -77,8 +77,10 @@ public class MediaData extends Entity {
 
     public MediaData getMediaAt(int position) throws Exception {
         List<Object> mediaList = this.getMediaList();
-        if (position > mediaList.size()) return new MediaData(this.obj);
-        return new MediaData(mediaList.get(position));
+        if (mediaList.isEmpty()) return new MediaData(this.obj);
+
+        int safePosition = Math.max(0, Math.min(position, mediaList.size() - 1));
+        return new MediaData(mediaList.get(safePosition));
     }
 
     public String getPhotoLink() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
@@ -98,6 +98,9 @@ public class DownloadUtils {
                     } else if (selectedOption.equals(Strings.OPEN_VIDEO_EXTERNALLY) || selectedOption.equals(Strings.OPEN_IMAGE_EXTERNALLY)) {
                         ActivityHook.handleUrlIntent(isCurrentMediaVideo,currentMediaData.getMediaLink());
 
+                    } else if (selectedOption.equals(Strings.DOWNLOAD_ALL)) {
+                        downloadAllMedia(context, mediaInfo);
+
                     } else if (selectedOption.equals(Strings.PIKO_DEBUG)) {
                         ObjectBrowser.browseObject(context,currentMediaData);
 
@@ -124,6 +127,17 @@ public class DownloadUtils {
         String downloadFileName = currentMediaData.getDownloadFilename(false);
 
         downloadFile(context, currentMediaData.getMediaLink(), username, downloadFileName);
+    }
+
+    public static void downloadAllMedia(Context context, MediaData mediaInfo) throws Exception {
+        String username = mediaInfo.getUserData().getUsername();
+        int carouselSize = mediaInfo.getCarouselSize();
+
+        for (int position = 0; position < carouselSize; position++) {
+            MediaData currentMediaData = mediaInfo.getMediaAt(position);
+            String downloadFileName = currentMediaData.getDownloadFilename(false);
+            downloadFile(context, currentMediaData.getMediaLink(), username, downloadFileName);
+        }
     }
 
 


### PR DESCRIPTION
## Summary
- handle the existing Instagram Download all action for carousel posts
- clamp carousel media indexes before reading entries so an out-of-range current index does not abort the download dialog

Fixes #936
Fixes #956
Related to #953

## Validation
- `git diff --check`
- `GITHUB_ACTOR=officialasishkumar GITHUB_TOKEN=$(gh auth token) ./gradlew buildAndroid clean` (blocked locally because `app.morphe.patches` could not be resolved from the Morphe GitHub Packages registry with the available token)