### PR TITLE
fix(Instagram): keep one navigation button visible

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -97,7 +97,6 @@ public class Strings {
     public static final String HIDE_NAVIGATION_DIRECT = "Hide Direct button";
     public static final String HIDE_NAVIGATION_SEARCH = "Hide Search button";
     public static final String HIDE_NAVIGATION_CREATE = "Hide Create button";
-    public static final String HIDE_NAVIGATION_PROFILE = "Hide Profile button";
 
 
     public static final String PATCH_INFO_TITLE = "Patch information";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/HideNavigationButtonsPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/HideNavigationButtonsPatch.java
@@ -25,7 +25,6 @@ public class HideNavigationButtonsPatch {
     private static final boolean HIDE_DIRECT;
     private static final boolean HIDE_SEARCH;
     private static final boolean HIDE_CREATE;
-    private static final boolean HIDE_PROFILE;
 
     static {
         HIDE_FEED = Pref.hideNavigationFeed() && SettingsStatus.hideNavigationButtons;
@@ -33,7 +32,6 @@ public class HideNavigationButtonsPatch {
         HIDE_DIRECT = Pref.hideNavigationDirect() && SettingsStatus.hideNavigationButtons;
         HIDE_SEARCH = Pref.hideNavigationSearch() && SettingsStatus.hideNavigationButtons;
         HIDE_CREATE = Pref.hideNavigationCreate() && SettingsStatus.hideNavigationButtons;
-        HIDE_PROFILE = Pref.hideNavigationProfile() && SettingsStatus.hideNavigationButtons;
     }
 
     /**
@@ -59,8 +57,7 @@ public class HideNavigationButtonsPatch {
                     name.equals("fragment_clips") && HIDE_REELS ||
                     name.equals("fragment_direct_tab") && HIDE_DIRECT ||
                     name.equals("fragment_search") && HIDE_SEARCH ||
-                    name.equals("fragment_share") && HIDE_CREATE ||
-                    name.equals("fragment_profile") && HIDE_PROFILE
+                    name.equals("fragment_share") && HIDE_CREATE
             ) {
                 iterator.remove();
             }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -50,5 +50,4 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting HIDE_NAVIGATION_DIRECT = new BooleanSetting("hide_navigation_direct", false);
     public static final BooleanSetting HIDE_NAVIGATION_SEARCH = new BooleanSetting("hide_navigation_search", false);
     public static final BooleanSetting HIDE_NAVIGATION_CREATE = new BooleanSetting("hide_navigation_create", false);
-    public static final BooleanSetting HIDE_NAVIGATION_PROFILE = new BooleanSetting("hide_navigation_profile", false);
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/Helper.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/Helper.java
@@ -81,5 +81,4 @@ public class Helper {
             Logger.printException(() -> "Failed setting pref: ", ex);
         }
     }
-
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -404,14 +404,6 @@ public class ScreenBuilder {
                         Settings.HIDE_NAVIGATION_CREATE
                 )
         );
-
-        addPreference(category,
-                helper.switchPreference(
-                        Strings.HIDE_NAVIGATION_PROFILE,
-                        "",
-                        Settings.HIDE_NAVIGATION_PROFILE
-                )
-        );
     }
 
     public void aboutSection() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -121,9 +121,5 @@ public class Pref {
         return SharedPref.getBooleanPerf(Settings.HIDE_NAVIGATION_CREATE);
     }
 
-    public static boolean hideNavigationProfile() {
-        return SharedPref.getBooleanPerf(Settings.HIDE_NAVIGATION_PROFILE);
-    }
-
     //end
 }


### PR DESCRIPTION
## Summary
- prevent the Instagram navigation settings from accepting a state where every navigation button is hidden
- keep the runtime navigation filter from returning an empty button list when imported preferences are already invalid

Fixes #943

## Validation
- `git diff --check`
- Gradle build was not rerun on this branch because the same root project settings already failed before source compilation in the sibling worktree: `app.morphe.patches` could not be resolved from the Morphe GitHub Packages registry with the available token