### PR TITLE
fix(Twitter - Import/Export login token): Add import menu to piko settings as a workaround for redesigned login screen

### DIFF
--- a/docs/about_login_token_patch.md
+++ b/docs/about_login_token_patch.md
@@ -12,9 +12,7 @@ This is useful in the following cases:
 - If you have another rooted device and can log in normally
 
 Tokens and other necessary data will be exported in JSON format.  
-You can use it from the login screen.
-
-To import additional accounts, select "Create a new account" instead of "Add an existing account".
+You can import it from the login screen or piko settings.
 
 **Important: This patch does NOT fix the login attestation problem.**
 
@@ -39,11 +37,30 @@ Please be careful if you want to remove an account from one device after importi
 
 Logging out from settings will log out of the session associated with that token.  
 Therefore, if you simply press the logout button in the settings, you will also be logged out of other devices using the same token.
+This also applies when you press "Remove account" in the account manager in the device settings app.
 
 There are two ways to remove an account from the app without logging out.
 
 - Press the Logout button in airplane mode. (no internet connections)
 - If the app has only one account currently logged in, just uninstall and reinstall the app.
+
+In other words, you just need to prevent the logout request from being sent to the server.
+
+Also, when you factory reset your device, you will need to uninstall the Twitter app beforehand.
+It has been reported that the token is logged out when performing a factory reset.
+
+## Regarding the new login screen
+
+Recently, Twitter has been testing a new redesigned login screen for some users.  
+This patch does not yet support this new login screen, and the "Login through token json" button will not be displayed.
+
+<img alt="new_login_screen" width="360" src="https://github.com/user-attachments/assets/22d9c2b4-8947-41bb-90a2-c305b02a8833"/>
+
+As a workaround, you can open the import menu by clicking the deep link.  
+First, set the Piko Twitter app to open x.com links. (App Info > Open by default)  
+Then click the deep link below.
+
+[**\<\<\<CLICK HERE\>\>\>**](https://x.com/i/piko/pref)
 
 ## Troubleshooting
 
@@ -54,6 +71,10 @@ A: The session has already been logged out. That token cannot be used.
 **Q: After importing a token, it's not logged in even after restarting the app, but there is no notification.**
 
 A: Allow notifications for the X app and try again.
+
+**Q: Can I use tokens from the web version of Twitter?**
+
+A: No. Because it is completely different from the Android token.
 
 ## Appendix
 

--- a/docs/twitter_deep_links.md
+++ b/docs/twitter_deep_links.md
@@ -1,0 +1,44 @@
+# Deep links for piko twitter
+
+Piko Twitter provides custom deep links.
+
+To use the deep links, set the Piko Twitter app to open x.com links. (App Info > Open by default)
+
+(Last updated: April 16, 2026)
+
+## List of available deep links
+
+Open piko settings:
+
+- https://x.com/i/piko/  
+- https://x.com/i/pikosettings/
+
+Open each section of piko settings:
+
+- https://x.com/i/piko/premium
+- https://x.com/i/piko/download
+- https://x.com/i/piko/flags
+- https://x.com/i/addflags
+- https://x.com/i/piko/ads
+- https://x.com/i/piko/native
+- https://x.com/i/piko/misc
+- https://x.com/i/piko/customise
+- https://x.com/i/piko/font
+- https://x.com/i/piko/timeline
+- https://x.com/i/piko/pref
+- https://x.com/i/piko/info
+
+Open X settings:
+
+- https://x.com/i/settings
+
+Add a feature flag:
+
+Pattern:  
+`https://x.com/i/addflags?f=<flag_name>&v=<value>`
+
+value can either be true/false or 1/0
+
+For example:  
+https://x.com/i/addflags?f=longform_notetweets_rich_text_timeline_enabled&v=0  
+https://x.com/i/addflags?f=xprofile_blocked_by_view_enabled&v=true

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
@@ -70,6 +70,7 @@ public class ExportLoginTokenFragment extends Fragment {
         Button saveToFileButton = view.findViewById(Utils.getResourceIdentifier("save_to_file_button", "id"));
         saveToFileButton.setOnClickListener(v -> {
             Account account = (Account) spinner.getSelectedItem();
+            if (account == null) return;
             accountToSaveToFile = account;
 
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
@@ -105,11 +105,7 @@ public class ImportExportLoginTokenPatch {
             new AlertDialog.Builder(context)
                     .setTitle(StringRef.str("piko_pref_success"))
                     .setMessage(StringRef.str("piko_login_token_import_success_reopen_required"))
-                    .setPositiveButton(android.R.string.ok, (dialog, which) -> {
-                        if (context instanceof Activity activity)
-                            activity.finish();
-                    })
-                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(android.R.string.ok, null)
                     .setCancelable(false)
                     .show();
         } catch (JSONException e) {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
@@ -15,6 +15,7 @@ import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.StringRef;
@@ -31,7 +32,8 @@ public class ImportLoginTokenDialogFragment extends DialogFragment {
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         String[] items = {
                 StringRef.str("piko_login_token_import_from_text"),
-                StringRef.str("piko_login_token_import_from_file")
+                StringRef.str("piko_login_token_import_from_file"),
+                StringRef.str("piko_login_token_import_about")
         };
 
         AlertDialog dialog = new AlertDialog.Builder(getContext())
@@ -50,6 +52,11 @@ public class ImportLoginTokenDialogFragment extends DialogFragment {
                     intent.addCategory(Intent.CATEGORY_OPENABLE);
                     intent.setType("application/json");
                     startActivityForResult(intent, PICK_FILE_REQUEST_CODE);
+                }
+                case 2 -> { // About this feature
+                    String url = "https://github.com/crimera/piko/blob/dev/docs/about_login_token_patch.md";
+                    Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                    startActivity(intent);
                 }
             }
         });

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
@@ -1042,6 +1042,15 @@ public class ScreenBuilder {
        if (SettingsStatus.exportLoginToken) {
            addPreference(category,
                    helper.buttonPreference(
+                           StringRef.str("piko_pref_import_login_token"),
+                           "",
+                           Settings.IMPORT_LOGIN_TOKEN,
+                           "ic_vector_passkey",
+                           null
+                   )
+           );
+           addPreference(category,
+                   helper.buttonPreference(
                            StringRef.str("piko_pref_export_login_token"),
                            "",
                            Settings.EXPORT_LOGIN_TOKEN,

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
@@ -126,6 +126,7 @@ public class Settings extends BaseSettings {
     public static final String DELETE_EMOJI_FONT = "delete_emoji_font";
     public static final String RESET_READER_MODE_CACHE = "reader_mode_cache";
     public static final String CHANGE_APP_ICON = "change_app_icon";
+    public static final String IMPORT_LOGIN_TOKEN = "import_login_token";
     public static final String EXPORT_LOGIN_TOKEN = "export_login_token";
 
     public static final String PREMIUM_SECTION = "premium_section";

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
@@ -24,6 +24,7 @@ import android.util.AttributeSet;
 import app.morphe.extension.twitter.Utils;
 import app.morphe.extension.twitter.patches.DatabasePatch;
 import app.morphe.extension.twitter.patches.logintoken.ExportLoginTokenFragment;
+import app.morphe.extension.twitter.patches.logintoken.ImportLoginTokenDialogFragment;
 import app.morphe.extension.twitter.settings.ActivityHook;
 import app.morphe.extension.twitter.settings.Settings;
 import app.morphe.extension.twitter.settings.fragments.BackupPrefFragment;
@@ -128,6 +129,8 @@ public class ButtonPref extends Preference {
                         ReaderModeUtils.clearCache();
                     } else if (key.equals(Settings.CHANGE_APP_ICON)) {
                         fragment = new IconSelectorFragment();
+                    } else if (key.equals(Settings.IMPORT_LOGIN_TOKEN)) {
+                        new ImportLoginTokenDialogFragment().show(((Activity) context).getFragmentManager(), null);
                     } else if (key.equals(Settings.EXPORT_LOGIN_TOKEN)) {
                         fragment = new ExportLoginTokenFragment();
                     } else {

--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -204,6 +204,7 @@
     <string name="piko_pref_export_no_uri">Error: No destination provided</string>
     <string name="piko_pref_import_no_uri">Error: No file provided</string>
     <string name="piko_pref_export_login_token">Export login token</string>
+    <string name="piko_pref_import_login_token">Import login token</string>
 
     <!-- About -->
     <string name="piko_title_about">About</string>
@@ -368,7 +369,8 @@ It's recommended to read this before using this feature. It includes some import
     <string name="piko_login_token_import_token_button_text">Login through token json</string>
     <string name="piko_login_token_import_from_text">Import from text</string>
     <string name="piko_login_token_import_from_file">Import from file</string>
-    <string name="piko_login_token_import_success_reopen_required">Please exit and reopen the app</string>
+    <string name="piko_login_token_import_about">About this feature (Open website)</string>
+    <string name="piko_login_token_import_success_reopen_required">Please quit the app and reopen it</string>
     <string name="piko_login_token_import_failed_missing_info">Error: Missing username or token or secret</string>
     <string name="piko_login_token_import_failed_already_exist">Failed to add account (may already exist)</string>
 


### PR DESCRIPTION
Includes:
* Added "About this feature (Open website)" in import menu
* Added a document of deep links

Fixes #964, https://github.com/crimera/piko/issues/714#issuecomment-4202524694

I still haven't figured out how to add buttons to the new login screen unfortunately
In fact, I can't even reproduce the new login screen at all
Any feature flags don't enable it

Therefore, this PR adds a token import menu to the piko settings so that it is accessible via deep link as a workaround
I have confirmed that we can open the piko settings even before logging in by using deep links

To import tokens with the new login screen enabled, please refer to the updated docs.