### PR TITLE
fix(instagram): correct dex emission bugs surfaced by recent ART

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/story/StoryButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/story/StoryButton.java
@@ -55,7 +55,7 @@ public class StoryButton {
         return buttonList;
     }
 
-    public boolean storyButtonAction(CharSequence buttonText, Context ctx, Object mediaObject){
+    public static boolean storyButtonAction(CharSequence buttonText, Context ctx, Object mediaObject){
         try {
             if (buttonText.equals(Strings.VIEW_STORY_MENTIONS)) {
                 ViewStoryMentionsPatch.viewMentions(ctx, mediaObject);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/instagramButton/InstagramButtonEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/instagramButton/InstagramButtonEntity.kt
@@ -28,10 +28,17 @@ val instagramButtonEntity =
             SetStyleExtensionFingerprint.changeFirstString(classNameToExtension(buttonStyleClass))
 
             SetStyleObjectExtensionFingerprint.method.apply {
+                // p1 arrives typed as java.lang.Object (the setStyleObject(Object)
+                // signature is intentionally generic so callers don't depend on
+                // the obfuscated IgdsButtonStyle class name). ART's verifier
+                // requires an explicit check-cast before we hand p1 to
+                // setStyle($buttonStyleClass), otherwise the class fails to
+                // verify with "register v1 has type Object but expected …".
                 addInstructions(
                     0,
                     """
                     iget-object v0, p0, $EXTENSION_CLASS_DESCRIPTOR->igdsButton:$IGDS_BUTTON_CLASS_DESCRIPTOR
+                    check-cast p1, $buttonStyleClass
                     invoke-virtual {v0, p1}, $IGDS_BUTTON_CLASS_DESCRIPTOR->setStyle($buttonStyleClass)V
                     """.trimIndent(),
                 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/stories/customiseStoryTimestamp/CustomiseStoryTimestampPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/stories/customiseStoryTimestamp/CustomiseStoryTimestampPatch.kt
@@ -50,7 +50,7 @@ val customiseStoryTimestampPatch =
                 addInstructionsWithLabels(
                     longToDoubleIndex,
                     """
-                    invoke-static {v$postedTimestampRegister, v1 }, ${PATCHES_DESCRIPTOR}/story/StoryTimestamp;->customiseStoryTimestamp(J)Ljava/lang/String;
+                    invoke-static/range {v$postedTimestampRegister .. v${postedTimestampRegister + 1}}, ${PATCHES_DESCRIPTOR}/story/StoryTimestamp;->customiseStoryTimestamp(J)Ljava/lang/String;
                     move-result-object v$dummyRegister
                     if-eqz v$dummyRegister, :piko
                     return-object v$dummyRegister


### PR DESCRIPTION
Three bytecode-emission bugs in Instagram patches. Recent ART Mainline
modules reject the affected classes, crashing the app the first time
the affected code path is exercised.

### Changes

1. **`StoryButton.storyButtonAction`** — declared virtual but every
   emitted callsite uses `invoke-static`. The body never references
   `this`, so adding `static` matches both the opcode and the method's
   intent.
   Throws `IncompatibleClassChangeError` at method resolution on the
   first tap of a story-action menu button.

2. **`instagramButtonEntity` emission** — issues `invoke-virtual` on an
   `Object` register where the callee expects a specific reference type.
   Inserted `check-cast p1, $buttonStyleClass` before the invoke so the
   narrowing is explicit.
   Throws `VerifyError` when `InstagramButton` is first loaded — on
   opening a user profile. dex2oat logs the rejection in advance:
   `register has type Object but expected Reference …`.

3. **`customiseStoryTimestampPatch` emission** — passes a `long (J)`
   argument as a non-consecutive register pair because the high half
   was hardcoded to `v1`. Switched to
   `invoke-static/range {v$N .. v$(N+1)}`: the pair is consecutive
   regardless of which register the low half lands in, and the `3rc`
   16-bit register encoding handles allocations where
   `postedTimestampRegister == v15` (at which point `v16` would
   overflow the non-range `35c` form's 4-bit register fields).
   Throws `VerifyError` when `ReelItem` is first loaded — on home feed
   render. dex2oat log: `long or double parameter at index 0 is not a
   pair`.

### Testing

Rebuilt the MPP from this branch, repatched Instagram on two builds,
and installed fresh on a device whose ART Mainline module enforces
these checks:

- `423.0.0.47.66` (build `382907094`) — 35/35 patches applied, 0 failed.
- `425.0.0.0.0` (build `383100026`) — 35/35 patches applied, 0 failed.

Before the fixes, dex2oat reported two `failed to verify` entries
(commits 2 and 3) and `ReelItem`/`InstagramButton` threw `VerifyError`
on feed render / profile open; tapping a story-action menu button
threw `IncompatibleClassChangeError` (commit 1). After the fixes:
dex2oat reports no rejections against our extension classes, no runtime
`VerifyError`/`IncompatibleClassChangeError`, and all three previously-
crashing flows complete — verified end-to-end on both builds.

### Closes

- #914, #969, #992 — `ReelItem.A0c` register-pair crash (commit 3).
- #880, #921, #947 — profile-tab `UI.pikoSettingsButton` VerifyError.
  Predate the v3.3.0-dev.1 `78d1b69a` refactor that consolidated the
  `IgdsButton.setStyle` injection into `InstagramButton.setStyleObject`;
  the consolidated path is fixed by commit 2, covering every current
  caller (`UI.pikoSettingsButton`,
  `ProfileMoreOption.addProfileMoreOptionsButton`).

Relates to #955 (thin report without a stack trace, likely same family).
