### PR TITLE
feat(instagram): add amoled theme patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,9 +175,6 @@ java -jar cli.jar patch --patches piko.mpp input.apkm
 <tr><td><code>Remove empty bottom space</code></td><td>Removes empty space below bottom navigation bar</td></tr>
 <tr><td><code>Disable typing status</code></td><td></td></tr>
 <tr><td><code>Hide notes tray</code></td><td>Hides notes tray in DM section</td></tr>
-<tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
-<tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
-<tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
 <tr><td><code>Amoled theme</code></td><td>Replaces Instagram's dark-mode elevated greys with pure black for AMOLED displays.</td></tr>
 
 

--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ java -jar cli.jar patch --patches piko.mpp input.apkm
 <tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
 <tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
 <tr><td><code>Disable screenshot detection</code></td><td>Disables screenshots detection in DM</td></tr>
+<tr><td><code>Amoled theme</code></td><td>Replaces Instagram's dark-mode elevated greys with pure black for AMOLED displays.</td></tr>
 
 
 </tbody>

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/amoledTheme/AmoledThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/amoledTheme/AmoledThemePatch.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.instagram.misc.amoledTheme
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.util.findElementByAttributeValueOrThrow
+
+@Suppress("unused")
+val amoledThemePatch =
+    resourcePatch(
+        name = "Amoled theme",
+        description = "Replaces Instagram's dark-mode background greys with pure black for AMOLED displays.",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            // ── res/values-night/colors.xml ──────────────────────────
+            // Three elevated/secondary surface tokens normally resolve
+            // to bds_grey_* in dark mode. Remap them to pure black so
+            // cards, sheets, modals, and elevated surfaces match the
+            // primary background. igds_elevated_separator is left as
+            // bds_grey_8 so dividers remain visible.
+            val nightOverrides =
+                mapOf(
+                    "igds_secondary_background" to "@color/bds_black",
+                    "igds_elevated_background" to "@color/bds_black",
+                    "igds_elevated_highlight_background" to "@color/bds_black",
+                )
+
+            document("res/values-night/colors.xml").use { document ->
+                val colors = document.getElementsByTagName("color")
+                nightOverrides.forEach { (name, value) ->
+                    colors.findElementByAttributeValueOrThrow("name", name).textContent = value
+                }
+            }
+
+            // ── res/values/colors.xml ────────────────────────────────
+            // igds_prism_black is IG's "Prism" design-system black,
+            // hardcoded to #ff0c1014 (a near-black with a slight blue
+            // tint). It has no night-mode variant, so it renders the
+            // same in both themes — and IG's modern feed/header/nav
+            // surfaces use it directly, which is why the elevated
+            // overrides above don't reach them. Force it to pure
+            // black; in light mode it's used for text/icons where
+            // pure black is also correct.
+            val defaultOverrides =
+                mapOf(
+                    "igds_prism_black" to "#ff000000",
+                )
+
+            document("res/values/colors.xml").use { document ->
+                val colors = document.getElementsByTagName("color")
+                defaultOverrides.forEach { (name, value) ->
+                    colors.findElementByAttributeValueOrThrow("name", name).textContent = value
+                }
+            }
+        }
+    }


### PR DESCRIPTION
Resource patch. Remaps Instagram's dark-mode greys to pure black on
AMOLED panels by overriding four design-system color tokens.

### Changes

In `res/values-night/colors.xml`, three elevated/secondary surface tokens
are remapped to `@color/bds_black`:

- `igds_secondary_background`
- `igds_elevated_background`
- `igds_elevated_highlight_background`

`igds_primary_background` already resolves to `bds_black` upstream, so
the app background itself is unchanged. `igds_elevated_separator` is
deliberately left at `bds_grey_8` so hairline dividers remain visible
against black surfaces.

In `res/values/colors.xml`, `igds_prism_black` is overridden to
`#ff000000`. This token is IG's "Prism" design-system black, hardcoded
to `#ff0c1014` (a near-black with a slight blue tint). It has no
night-mode variant, so it renders the same in both themes — and IG's
modern feed/header/nav surfaces use it directly, which is why the
elevated overrides above don't reach them. In light mode the token is
used for text/icons where pure black is also correct.

### Testing

Rebuilt the MPP from this branch and repatched Instagram on two builds:

- `423.0.0.47.66` (build `382907094`) — 36/36 patches applied, 0 failed.
- `425.0.0.0.0` (build `383100026`) — 36/36 patches applied, 0 failed.

Verified visually in dark mode on emulator: status bar, header, story
tray, feed cards, nav, notification bands, search field, comment
threads, dialogs, DM thread list, and profile tabs all sample to
exactly `#000000`. Hairline dividers remain visible.

Android's own system permission dialogs render with the OS theme and
stay grey — out of scope for this patch.

### Closes

- #1001 — Add option to enable amoled theme