### PR TITLE
feat(instagram): implement FLAG_SECURE bytecode bypass with UI toggle

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -38,6 +38,8 @@ public class Strings {
     public static final String CATEGORY_GHOST = "Ghost";
     public static final String VIEW_STORIES_ANONYMOUSLY = "View stories anonymously";
     public static final String VIEW_LIVE_ANONYMOUSLY = "View live anonymously";
+    public static final String DISABLE_FLAG_SECURE = "Disable FLAG_SECURE";
+    public static final String DISABLE_FLAG_SECURE_DESC = "Allows screenshots and screen recording on protected screens";
 
     public static final String CATEGORY_DISTRACTION_FREE = "Distraction free";
     public static final String DISABLE_STORIES = "Disable stories";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -27,6 +27,7 @@ public class Settings extends BaseSettings {
     public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", false);
+    public static final BooleanSetting DISABLE_FLAG_SECURE = new BooleanSetting("disable_flag_secure", false);
     public static final BooleanSetting DISABLE_STORIES = new BooleanSetting("disable_stories", false);
     public static final BooleanSetting HIDE_STORIES_TRAY = new BooleanSetting("hide_stories_tray", true);
     public static final BooleanSetting DISABLE_EXPLORE = new BooleanSetting("disable_explore", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -59,8 +59,12 @@ public class SettingsStatus {
     public static void viewLiveAnonymously() {
         viewLiveAnonymously = true;
     }
+    public static boolean disableFlagSecure = false;
+    public static void disableFlagSecure() {
+        disableFlagSecure = true;
+    }
     public static boolean ghostSection() {
-        return (viewStoriesAnonymously || viewLiveAnonymously);
+        return (viewStoriesAnonymously || viewLiveAnonymously || disableFlagSecure);
     }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -144,6 +144,15 @@ public class ScreenBuilder {
                     )
             );
         }
+        if (SettingsStatus.disableFlagSecure) {
+            addPreference(category,
+                    helper.switchPreference(
+                            Strings.DISABLE_FLAG_SECURE,
+                            Strings.DISABLE_FLAG_SECURE_DESC,
+                            Settings.DISABLE_FLAG_SECURE
+                    )
+            );
+        }
 
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -32,6 +32,9 @@ public class Pref {
     public static boolean viewLiveAnonymously(){
         return SharedPref.getBooleanPerf(Settings.VIEW_LIVE_ANONYMOUSLY);
     }
+    public static boolean disableFlagSecure(){
+        return SharedPref.getBooleanPerf(Settings.DISABLE_FLAG_SECURE);
+    }
 
     public static boolean disableStories(){
         return SharedPref.getBooleanPerf(Settings.DISABLE_STORIES);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/flagsecure/DisableFlagSecurePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/flagsecure/DisableFlagSecurePatch.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * This file is part of piko.
+ *
+ * Any modifications, derivatives, or substantial rewrites of this file
+ * must retain this copyright notice and the piko attribution
+ * in the source code and version control history.
+ */
+
+package app.crimera.patches.instagram.misc.flagsecure
+
+import app.crimera.patches.instagram.links.interceptUriPatch
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
+
+internal object FlagSecureManagerFingerprint : Fingerprint(
+    strings = listOf("Inconsistency in window FLAG_SECURE state detected!"),
+)
+
+@Suppress("unused")
+val disableFlagSecurePatch =
+    bytecodePatch(
+        name = "Disable FLAG_SECURE",
+        description = "Allows screenshots and screen recording on protected screens like DMs and view-once media.",
+    ) {
+        dependsOn(settingsPatch, interceptUriPatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            val bypassSmali = """
+                ${Constants.PREF_CALL_DESCRIPTOR}->disableFlagSecure()Z
+                move-result v0
+                if-eqz v0, :original
+                return-void
+            """.trimIndent()
+
+            FlagSecureManagerFingerprint.method.apply {
+                addInstructionsWithLabels(
+                    0,
+                    bypassSmali,
+                    ExternalLabel("original", getInstruction(0)),
+                )
+            }
+
+            FlagSecureManagerFingerprint.classDef.methods
+                .filter { method ->
+                    method != FlagSecureManagerFingerprint.method &&
+                        method.returnType == "V" &&
+                        method.parameterTypes.isNotEmpty() &&
+                        method.parameterTypes[0] == "Landroid/view/Window;" &&
+                        method.implementation != null
+                }
+                .forEach { method ->
+                    method.apply {
+                        addInstructionsWithLabels(
+                            0,
+                            bypassSmali,
+                            ExternalLabel("original", getInstruction(0)),
+                        )
+                    }
+                }
+
+            enableSettings("disableFlagSecure")
+        }
+    }
+


### PR DESCRIPTION
### Description
This PR introduces a surgical bytecode-level bypass for `FLAG_SECURE` on Instagram v423.0.0.47.66. Unlike runtime listeners, this implementation targets the internal manager responsible for enforcing window security flags.

### Technical Implementation:
* **Targeting:** Uses a string fingerprint (`"Inconsistency in window FLAG_SECURE state detected!"`) to locate the central `FLAG_SECURE` consistency manager class.
* **Bytecode Injection:** Injects a Smali gate at the entry of the consistency-check method and neutralizes all reference-counting methods within the same class (methods targeting `Landroid/view/Window;`).
* **UI Integration:** Fully integrated into the Piko settings framework with a dedicated toggle under the "Ghost" section.
* **Compatibility:** Verified on Instagram v423. Added necessary wiring in `Strings.java`, `Settings.java`, `Pref.java`, and `ScreenBuilder.java`.

### Why this approach?
This method is more robust than simple layout listeners as it prevents the app's internal security manager from ever applying the flag to the window, effectively neutralizing the protection at the source while maintaining app stability.

### Testing
- Target APK: **Instagram v423.0.0.47.66**
- Architecture: **ARM64-v8a**
- Result: Screenshots and screen recording are enabled in DMs and vanish mode when the toggle is active. No consistency crashes were observed during testing.

---
### 🤖 Disclaimer: Vibe Coding
Please note that this implementation was developed using a **"Vibe Coding"** approach with **Claude 3 Opus (via Cursor)**. While the logic has been thoroughly tested and verified to work perfectly on v423, I recommend a review by the maintainers to ensure the bytecode injection style aligns with the project's long-term architectural standards.