### PR TITLE
fix: typo in `PIKO_DEBUG_DESC`

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -151,7 +151,7 @@ public class DefaultStrings {
     public static String OK = "OK";
     public static String DELETED = "Deleted";
     public static String PIKO_DEBUG = "Piko debug";
-    public static String PIKO_DEBUG_DESC = "Adds debug option on some of the componenets for testing";
+    public static String PIKO_DEBUG_DESC = "Adds debug option on some of the components for testing";
     public static String PIKO_EXPORT_EXPERIMENT_LIST = "Export experiment list";
     public static String PIKO_EXPORT_EXPERIMENT_MAPPINGS = "Export experiment mappings";
 


### PR DESCRIPTION
Fix typo in `PIKO_DEBUG_DESC`: `componenets` -> `components`.