### PR TITLE
chore: Correct an outdated info in settings Native features page

### DIFF
--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -26,7 +26,7 @@
 
     <!-- Native -->
     <string name="piko_title_native">Native features</string>
-    <string name="piko_pref_native_page_desc">These Piko native features are available in the share menu of posts.</string>
+    <string name="piko_pref_native_page_desc">These Piko native features are available in the post menu.</string>
     <string name="piko_title_native_downloader">Native downloader</string>
     <string name="piko_title_native_downloader_toggle">Enable native downloader</string>
     <string name="piko_pref_native_downloader_inline_button">Show download button inline</string>


### PR DESCRIPTION
Native features are no longer available at the share menu unless patching older versions