### PR TITLE
Add option to use Pictures folder

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -41,6 +41,9 @@ public class Strings {
     public static final String IMPORT_ID_MAPPING = langInstance.IMPORT_ID_MAPPING;
     public static final String DOWNLOAD_ID_MAPPING = langInstance.DOWNLOAD_ID_MAPPING;
 
+    public static final String USE_PICTURES_FOLDER = langInstance.USE_PICTURES_FOLDER;
+    public static final String USE_PICTURES_FOLDER_DESC = langInstance.USE_PICTURES_FOLDER_DESC;
+
     public static final String CATEGORY_LINKS = langInstance.CATEGORY_LINKS;
     public static final String OPEN_LINKS_EXTERNALLY = langInstance.OPEN_LINKS_EXTERNALLY;
     public static final String OPEN_LINKS_EXTERNALLY_DESC = langInstance.OPEN_LINKS_EXTERNALLY_DESC;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -126,6 +126,8 @@ public class DefaultStrings {
     public static String COPY_POST_OWNER_FULLNAME = "Copy post owner fullname";
     public static String ENABLE_MORE_OPTIONS_ON_POST = "Enable more option on post";
     public static String ENABLE_MORE_OPTIONS_ON_POST_DESC = "Get more options on long pressing the post";
+    public static String USE_PICTURES_FOLDER = "Use Pictures folder";
+    public static String USE_PICTURES_FOLDER_DESC = "Instead of Downloads";
 
     public static String CATEGORY_HIDE_NAVIGATION_BUTTONS = "Hide navigation buttons";
     public static String HIDE_NAVIGATION_FEED = "Hide Feed button";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -127,7 +127,7 @@ public class DefaultStrings {
     public static String ENABLE_MORE_OPTIONS_ON_POST = "Enable more option on post";
     public static String ENABLE_MORE_OPTIONS_ON_POST_DESC = "Get more options on long pressing the post";
     public static String USE_PICTURES_FOLDER = "Use Pictures folder";
-    public static String USE_PICTURES_FOLDER_DESC = "Instead of Downloads";
+    public static String USE_PICTURES_FOLDER_DESC = "Instead of Downloads. App restart required.";
 
     public static String CATEGORY_HIDE_NAVIGATION_BUTTONS = "Hide navigation buttons";
     public static String HIDE_NAVIGATION_FEED = "Hide Feed button";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
@@ -42,12 +42,14 @@ import app.morphe.extension.crimera.ObjectBrowser;
 
 public class DownloadUtils {
     private static boolean ENABLE_DIRECT_DOWNLOAD;
+    private static boolean PICTURES_FOLDER;
     private static boolean SPLIT_BY_USERNAME;
     private static boolean DEBUG;
 
     static {
         ENABLE_DIRECT_DOWNLOAD = Pref.enableDirectDownload() && SettingsStatus.downloadMedia;
         SPLIT_BY_USERNAME = Pref.downloadUsernameFolder() && SettingsStatus.downloadMedia;
+        PICTURES_FOLDER = Pref.downloadPicturesFolder() && SettingsStatus.downloadMedia;
         DEBUG = Pref.pikoDebug();
     }
 
@@ -179,6 +181,7 @@ public class DownloadUtils {
 
     public static void downloadFile(Context ctx, String url, String username, String downloadFilename) {
         String publicFolder = Environment.DIRECTORY_DOWNLOADS;
+        if (PICTURES_FOLDER) publicFolder = Environment.DIRECTORY_PICTURES;
         String subFolder = Strings.DEFAULT_PIKO_FOLDER;
         boolean isAudioFile = username.equals(Strings.DEFAULT_AUDIO_FOLDER);
         // If it's audio file, then file name need not have username_.

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -67,6 +67,7 @@ public class Settings {
     public static final BooleanSetting ENABLE_DOWNLOAD = new BooleanSetting("enable_download", true);
     public static final BooleanSetting ENABLE_DIRECT_DOWNLOAD = new BooleanSetting("enable_direct_download", false);
     public static final BooleanSetting DOWNLOAD_USERNAME_FOLDER = new BooleanSetting("download_username_folder", false);
+    public static final BooleanSetting DOWNLOAD_PICTURES_FOLDER = new BooleanSetting("download_pictures_folder", true);
 
 
     public static final BooleanSetting HIDE_NAVIGATION_FEED = new BooleanSetting("hide_navigation_feed", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -531,6 +531,14 @@ public class ScreenBuilder {
 
         addPreference(category,
                 helper.switchPreference(
+                        Strings.USE_PICTURES_FOLDER,
+                        Strings.USE_PICTURES_FOLDER_DESC,
+                        Settings.DOWNLOAD_PICTURES_FOLDER
+                )
+        );
+
+        addPreference(category,
+                helper.switchPreference(
                         Strings.ENABLE_DIRECT_DOWNLOAD,
                         Strings.ENABLE_DIRECT_DOWNLOAD_DESC,
                         Settings.ENABLE_DIRECT_DOWNLOAD

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -71,8 +71,7 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.STORIES_AUDIO_AUTOPLAY);
     }
 
-    public
-    static boolean disableStories() {
+    public static boolean disableStories() {
         return SharedPref.getBooleanPref(Settings.DISABLE_STORIES);
     }
 
@@ -175,6 +174,10 @@ public class Pref {
 
     public static boolean downloadUsernameFolder() {
         return SharedPref.getBooleanPref(Settings.DOWNLOAD_USERNAME_FOLDER);
+    }
+
+    public static boolean downloadPicturesFolder() {
+        return SharedPref.getBooleanPref(Settings.DOWNLOAD_PICTURES_FOLDER);
     }
 
     public static boolean hideNavigationFeed() {


### PR DESCRIPTION
Instead of Downloads.
Enabled by default.

Seems to need an app restart to apply.
Im not sure if I missed anything there.

Can also be used as a base for a proper folder picker? XD