### PR TITLE
refactor: Use `StringRef.str` directly

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
@@ -122,16 +122,6 @@ public class Utils {
         return value;
     }
 
-    public static String strRes(String tag) {
-        try {
-            return str(tag);
-        } catch (Exception e) {
-
-            app.morphe.extension.shared.Utils.showToastShort(tag + " not found");
-        }
-        return tag;
-    }
-
     public static void showRestartAppDialog(Context context) {
         AlertDialog.Builder dialog = new AlertDialog.Builder(context);
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
@@ -29,7 +29,9 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import app.morphe.extension.shared.StringRef;
+import static app.morphe.extension.shared.StringRef.str;
+
+
 import app.morphe.extension.crimera.settings.BooleanSetting;
 import app.morphe.extension.crimera.settings.StringSetting;
 import app.morphe.extension.shared.settings.preference.PikoSharedPrefCategory;
@@ -81,7 +83,7 @@ public class Utils {
     public static boolean redirect(TabLayout$g g) {
         try {
             String tabName = g.c.toString();
-            if (tabName == strRes("bookmarks_title")) {
+            if (tabName == str("bookmarks_title")) {
                 startBookmarkActivity();
                 return true;
             }
@@ -122,7 +124,7 @@ public class Utils {
 
     public static String strRes(String tag) {
         try {
-            return StringRef.str(tag);
+            return str(tag);
         } catch (Exception e) {
 
             app.morphe.extension.shared.Utils.showToastShort(tag + " not found");
@@ -136,11 +138,11 @@ public class Utils {
         LinearLayout ln = new LinearLayout(context);
         ln.setOrientation(LinearLayout.VERTICAL);
 
-        dialog.setTitle(strRes("settings_restart"));
-        dialog.setPositiveButton(strRes("ok"), (dialogInterface, i) -> {
+        dialog.setTitle(str("settings_restart"));
+        dialog.setPositiveButton(str("ok"), (dialogInterface, i) -> {
             app.morphe.extension.shared.Utils.restartApp(context);
         });
-        dialog.setNegativeButton(strRes("cancel"), null);
+        dialog.setNegativeButton(str("cancel"), null);
         dialog.show();
     }
 
@@ -152,10 +154,10 @@ public class Utils {
 
         String content = flag ? "piko_title_feature_flags" : "notification_settings_preferences_category";
 
-        dialog.setTitle(strRes("piko_dialog_delete_title"));
+        dialog.setTitle(str("piko_dialog_delete_title"));
 
-        dialog.setMessage(StringRef.str("piko_dialog_delete_message", strRes(content)));
-        dialog.setPositiveButton(strRes("ok"), (dialogInterface, i) -> {
+        dialog.setMessage(str("piko_dialog_delete_message", str(content)));
+        dialog.setPositiveButton(str("ok"), (dialogInterface, i) -> {
             boolean success = false;
             if (flag) {
                 sp.removeKey(Settings.MISC_FEATURE_FLAGS.key);
@@ -167,7 +169,7 @@ public class Utils {
                 app.morphe.extension.shared.Utils.restartApp(context);
             }
         });
-        dialog.setNegativeButton(strRes("cancel"), null);
+        dialog.setNegativeButton(str("cancel"), null);
         dialog.show();
     }
 
@@ -250,7 +252,7 @@ public class Utils {
                 toast("Failed to rename temp file");
             }
 
-            toast(strRes("exo_download_completed") + ": " + filename);
+            toast(str("exo_download_completed") + ": " + filename);
             ctx.unregisterReceiver(broadcastReceiver);
         }
     }
@@ -276,7 +278,7 @@ public class Utils {
 
         File file = new File(Environment.getExternalStorageDirectory(), getPath(publicFolder, subFolder, filename));
         if (file.exists()) {
-            toast(strRes("exo_download_completed") + ": " + filename);
+            toast(str("exo_download_completed") + ": " + filename);
             return;
         }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/Changelogs.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/Changelogs.java
@@ -9,6 +9,7 @@ package app.morphe.extension.twitter.patches;
 import static android.text.Html.FROM_HTML_MODE_COMPACT;
 
 import static app.morphe.extension.shared.requests.Route.Method.GET;
+import static app.morphe.extension.shared.StringRef.str;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -21,7 +22,6 @@ import org.json.JSONObject;
 
 import java.net.HttpURLConnection;
 
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
 import app.morphe.extension.shared.requests.Route;
@@ -71,9 +71,9 @@ public class Changelogs {
             textView.setPadding(40, 40, 40, 40);
 
             AlertDialog dialog = new AlertDialog.Builder(context)
-                    .setTitle(StringRef.str("piko_changelogs_title"))
+                    .setTitle(str("piko_changelogs_title"))
                     .setView(textView)
-                    .setPositiveButton(StringRef.str("ok"), (dialogInterface, i) -> dialogInterface.dismiss())
+                    .setPositiveButton(str("ok"), (dialogInterface, i) -> dialogInterface.dismiss())
                     .create();
 
             dialog.show();

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/DatabasePatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/DatabasePatch.java
@@ -6,9 +6,10 @@
 
 package app.morphe.extension.twitter.patches;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.StringRef;
 import android.content.Context;
 import com.twitter.util.user.UserIdentifier;
 import android.util.*;
@@ -36,9 +37,9 @@ public class DatabasePatch {
         LinearLayout ln = new LinearLayout(context);
         ln.setOrientation(LinearLayout.VERTICAL);
 
-        builder.setTitle(StringRef.str("piko_pref_db_del_items"));
+        builder.setTitle(str("piko_pref_db_del_items"));
         builder.setMessage(result);
-        builder.setNegativeButton(StringRef.str("ok"), null);
+        builder.setNegativeButton(str("ok"), null);
         builder.show();
     }
 
@@ -51,16 +52,16 @@ public class DatabasePatch {
         LinearLayout ln = new LinearLayout(context);
         ln.setOrientation(LinearLayout.VERTICAL);
 
-        builder.setTitle(StringRef.str("piko_pref_del_from_db"));
+        builder.setTitle(str("piko_pref_del_from_db"));
         builder.setMultiChoiceItems(listItems, checkedItems, (dialog, which, isChecked) -> {
             checkedItems[which] = isChecked;
             String currentItem = selectedItems.get(which);
         });
-        builder.setPositiveButton(StringRef.str("ok"), (dialogInterface, i) -> {
+        builder.setPositiveButton(str("ok"), (dialogInterface, i) -> {
             StringBuilder items = removeFromDB(checkedItems);
             if(items.length()!=0) showItemDialog(context,items.toString());
         });
-        builder.setNegativeButton(StringRef.str("cancel"), null);
+        builder.setNegativeButton(str("cancel"), null);
         builder.show();
     }
 
@@ -72,7 +73,7 @@ public class DatabasePatch {
             String DATABASE_PATH = getDBPath();
             File f = new File(DATABASE_PATH);
             if (!f.exists() && f.isDirectory()) {
-                PikoUtils.toast(StringRef.str("piko_pref_db_not_found"));
+                PikoUtils.toast(str("piko_pref_db_not_found"));
                 return result;
             }
             database = SQLiteDatabase.openDatabase(DATABASE_PATH, null, SQLiteDatabase.OPEN_READWRITE);
@@ -140,7 +141,7 @@ public class DatabasePatch {
                     }
                 }
             } else {
-                PikoUtils.toast(StringRef.str("piko_pref_db_not_open"));
+                PikoUtils.toast(str("piko_pref_db_not_open"));
             }
 
         }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/DownloadPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/DownloadPatch.java
@@ -7,6 +7,8 @@
 
 package app.morphe.extension.twitter.patches;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
@@ -17,7 +19,6 @@ import java.lang.reflect.Method;
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.twitter.Pref;
-import app.morphe.extension.shared.StringRef;
 
 
 public class DownloadPatch {
@@ -76,7 +77,7 @@ public class DownloadPatch {
 
             String mediaLink = getMediaLink(para1);
             app.morphe.extension.shared.Utils.setClipboard(mediaLink);
-            PikoUtils.toast(strRes("link_copied_to_clipboard"));
+            PikoUtils.toast(str("link_copied_to_clipboard"));
         }
         catch (Exception e){
             PikoUtils.toast(e.toString());
@@ -102,9 +103,9 @@ public class DownloadPatch {
         LinearLayout ln = new LinearLayout(context);
         ln.setOrientation(LinearLayout.VERTICAL);
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
-        builder.setTitle(strRes("piko_pref_download_media_link_handle"));
+        builder.setTitle(str("piko_pref_download_media_link_handle"));
 
-        String[] choices = {strRes("download_video_option"), strRes("piko_pref_download_media_link_handle_copy_media_link"),strRes("piko_pref_download_media_link_handle_share_media_link"), strRes("cancel")};
+        String[] choices = {str("download_video_option"), str("piko_pref_download_media_link_handle_copy_media_link"),str("piko_pref_download_media_link_handle_share_media_link"), str("cancel")};
         builder.setItems(choices, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int which) {
@@ -130,8 +131,5 @@ public class DownloadPatch {
         //endfunc
     }
 
-    private static String strRes(String tag) {
-        return StringRef.str(tag);
-    }
     //end
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/RowItem.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/RowItem.java
@@ -6,9 +6,10 @@
 
 package app.morphe.extension.twitter.patches.customise.appIcon;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.StringRef;
 
 public class RowItem {
     public boolean isHeader;
@@ -21,7 +22,7 @@ public class RowItem {
     public static RowItem header(String titleKey) {
         RowItem r = new RowItem();
         r.isHeader = true;
-        r.headerTitle = StringRef.str(titleKey);
+        r.headerTitle = str(titleKey);
         return r;
     }
 
@@ -29,7 +30,7 @@ public class RowItem {
         RowItem r = new RowItem();
         r.isHeader = false;
         r.iconRes = ResourceUtils.getIdentifier(ResourceType.MIPMAP, iconId);
-        r.iconLabel = StringRef.str(labelKey);
+        r.iconLabel = str(labelKey);
         r.componentName = "app.morphe.extension.twitter.appicon"+iconNum;
         return r;
     }
@@ -42,7 +43,7 @@ public class RowItem {
 
     public static RowItem exclusiveIcon(String labelKey, String iconId, String iconNum) {
         RowItem r = icon(labelKey,iconId,iconNum);
-        r.iconLabel+=" "+StringRef.str("piko_app_icon_piko_exclusive");
+        r.iconLabel+=" "+str("piko_app_icon_piko_exclusive");
         return r;
     }
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/FontPickerFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/FontPickerFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.customise.font;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -87,13 +89,13 @@ public class FontPickerFragment extends Fragment {
                 Uri uri = intent.getData();
                 if (hasValidFontHeader(uri)) {
                     if(copyFont(uri)){
-                        toast(StringRef.str("piko_pref_add_font_success"));
+                        toast(str("piko_pref_add_font_success"));
                         app.morphe.extension.twitter.Utils.showRestartAppDialog(getActivity());
                     }else{
-                        toast(StringRef.str("piko_pref_add_font_fail"));
+                        toast(str("piko_pref_add_font_fail"));
                     }
                 } else {
-                    toast(StringRef.str("piko_pref_add_font_desc"));
+                    toast(str("piko_pref_add_font_desc"));
                 }
             }
         }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/FontPickerFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/FontPickerFragment.java
@@ -18,7 +18,6 @@ import java.io.OutputStream;
 import java.io.FileOutputStream;
 import android.app.Fragment;
 import app.morphe.extension.crimera.PikoUtils;
-import app.morphe.extension.shared.StringRef;
 
 
 public class FontPickerFragment extends Fragment {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/UpdateFont.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/font/UpdateFont.java
@@ -6,9 +6,10 @@
 
 package app.morphe.extension.twitter.patches.customise.font;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.os.Build;
 import app.morphe.extension.crimera.PikoUtils;
-import app.morphe.extension.shared.StringRef;
 import android.content.Context;
 import android.graphics.Typeface;
 import android.text.Spannable;
@@ -68,12 +69,12 @@ public class UpdateFont {
         File fontFile = new File(context.getFilesDir(), filename);
         if (fontFile.exists()) {
             if (fontFile.delete()) {
-                PikoUtils.toast(StringRef.str("piko_pref_delete_font_success"));
+                PikoUtils.toast(str("piko_pref_delete_font_success"));
             } else {
-                PikoUtils.toast(StringRef.str("piko_pref_delete_font_fail"));
+                PikoUtils.toast(str("piko_pref_delete_font_fail"));
             }
         } else {
-            PikoUtils.toast(StringRef.str("piko_pref_delete_font_warn"));
+            PikoUtils.toast(str("piko_pref_delete_font_warn"));
         }
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ExportLoginTokenFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.logintoken;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.app.Activity;
@@ -26,7 +28,6 @@ import androidx.annotation.Nullable;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.Utils;
 
 import java.io.OutputStream;
@@ -59,9 +60,9 @@ public class ExportLoginTokenFragment extends Fragment {
                 Account account = (Account) spinner.getSelectedItem();
                 String jsonString = ImportExportLoginTokenPatch.createAccountJsonText(account);
                 Utils.setClipboard(jsonString);
-                Utils.showToastShort(StringRef.str("copied_to_clipboard"));
+                Utils.showToastShort(str("copied_to_clipboard"));
             } catch (Exception e) {
-                Utils.showToastLong(StringRef.str("piko_pref_export_failed", StringRef.str("accounts_title")));
+                Utils.showToastLong(str("piko_pref_export_failed", str("accounts_title")));
                 Logger.printInfo(() -> "Failed to export account to clipboard", e);
             }
         });
@@ -88,15 +89,15 @@ public class ExportLoginTokenFragment extends Fragment {
          */
         if (requestCode == CREATE_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             if (data == null || data.getData() == null) {
-                Utils.showToastLong(StringRef.str("piko_pref_export_no_uri"));
+                Utils.showToastLong(str("piko_pref_export_no_uri"));
                 return;
             }
             try (OutputStream outputStream = getContext().getContentResolver().openOutputStream(data.getData())) {
                 byte[] jsonStringByteArray = ImportExportLoginTokenPatch.createAccountJsonText(accountToSaveToFile).getBytes();
                 outputStream.write(jsonStringByteArray);
-                Utils.showToastShort(StringRef.str("piko_pref_export_success"));
+                Utils.showToastShort(str("piko_pref_export_success"));
             } catch (Exception e) {
-                Utils.showToastLong(StringRef.str("piko_pref_export_failed", StringRef.str("accounts_title")));
+                Utils.showToastLong(str("piko_pref_export_failed", str("accounts_title")));
                 Logger.printInfo(() -> "Failed to export account to a file", e);
             }
         }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportExportLoginTokenPatch.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.logintoken;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.app.Activity;
@@ -23,7 +25,6 @@ import java.util.Iterator;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.Utils;
 
 public class ImportExportLoginTokenPatch {
@@ -75,7 +76,7 @@ public class ImportExportLoginTokenPatch {
             String token = accountJson.optString("token");
             String secret = accountJson.optString("secret");
             if (userName.isEmpty() || token.isEmpty() || secret.isEmpty()) {
-                Utils.showToastLong(StringRef.str("piko_login_token_import_failed_missing_info"));
+                Utils.showToastLong(str("piko_login_token_import_failed_missing_info"));
                 return;
             }
 
@@ -91,7 +92,7 @@ public class ImportExportLoginTokenPatch {
             AccountManager accountManager = AccountManager.get(context);
             boolean succeeded = accountManager.addAccountExplicitly(account, null, newUserData);
             if (!succeeded) {
-                Utils.showToastLong(StringRef.str("piko_login_token_import_failed_already_exist"));
+                Utils.showToastLong(str("piko_login_token_import_failed_already_exist"));
                 return;
             }
 
@@ -103,8 +104,8 @@ public class ImportExportLoginTokenPatch {
             // Since the app begins some process immediately after an account is added,
             // we do not use Utils.restartApp() which calls System.exit(0) for safety.
             new AlertDialog.Builder(context)
-                    .setTitle(StringRef.str("piko_pref_import_success"))
-                    .setMessage(StringRef.str("piko_login_token_import_success_reopen_required"))
+                    .setTitle(str("piko_pref_import_success"))
+                    .setMessage(str("piko_login_token_import_success_reopen_required"))
                     .setPositiveButton(android.R.string.ok, null)
                     .setCancelable(false)
                     .show();

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/logintoken/ImportLoginTokenDialogFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.logintoken;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -14,7 +16,6 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.StringRef;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -27,9 +28,9 @@ public class ImportLoginTokenDialogFragment extends DialogFragment {
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
         String[] items = {
-                StringRef.str("piko_login_token_import_from_text"),
-                StringRef.str("piko_login_token_import_from_file"),
-                StringRef.str("piko_login_token_import_about")
+                str("piko_login_token_import_from_text"),
+                str("piko_login_token_import_from_file"),
+                str("piko_login_token_import_about")
         };
 
         AlertDialog dialog = new AlertDialog.Builder(getContext())
@@ -67,7 +68,7 @@ public class ImportLoginTokenDialogFragment extends DialogFragment {
         // Import from file
         if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             if (data == null || data.getData() == null) {
-                StringRef.str("piko_pref_import_no_uri");
+                str("piko_pref_import_no_uri");
                 return;
             }
             try (BufferedReader reader = new BufferedReader(new InputStreamReader(getContext().getContentResolver().openInputStream(data.getData())))) {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/downloader/NativeDownloader.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/downloader/NativeDownloader.java
@@ -6,12 +6,13 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.downloader;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.AlertDialog;
 import android.content.Context;
 import android.widget.LinearLayout;
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.twitter.Pref;
-import app.morphe.extension.shared.StringRef;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 import java.time.LocalDateTime;
@@ -21,12 +22,8 @@ import app.morphe.extension.twitter.entity.Media;
 import app.morphe.extension.twitter.entity.Tweet;
 
 public class NativeDownloader {
-    private static String strRes(String tag){
-        return StringRef.str(tag);
-    }
-
     public static String downloadString() {
-        return strRes("piko_pref_native_downloader_alert_title");
+        return str("piko_pref_native_downloader_alert_title");
     }
     private static String getExtension(String typ) {
         if (typ.equals("video/mp4")) {
@@ -59,13 +56,13 @@ public class NativeDownloader {
     }
 
     private static void alertBox(Context ctx, String filename, ArrayList<Media> mediaData) throws NoSuchFieldException, IllegalAccessException {
-        String photo = strRes("drafts_empty_photo");
-        String video = strRes("drafts_empty_video");
+        String photo = str("drafts_empty_photo");
+        String video = str("drafts_empty_video");
 
         LinearLayout ln = new LinearLayout(ctx);
         ln.setOrientation(LinearLayout.VERTICAL);
         AlertDialog.Builder builder = new AlertDialog.Builder(ctx);
-        builder.setTitle(strRes("piko_pref_native_downloader_alert_title"));
+        builder.setTitle(str("piko_pref_native_downloader_alert_title"));
 
         int n = mediaData.size();
         String[] choices = new String[n];
@@ -78,12 +75,12 @@ public class NativeDownloader {
         builder.setItems(choices, (dialogInterface, which) -> {
             Media media = mediaData.get(which);
 
-            PikoUtils.toast(strRes("download_started"));
+            PikoUtils.toast(str("download_started"));
             app.morphe.extension.twitter.Utils.downloadFile(media.url, filename + (which + 1), media.ext);
         });
 
-        builder.setNegativeButton(strRes("piko_pref_native_downloader_download_all"), (dialogInterface, index) -> {
-            PikoUtils.toast(strRes("download_started"));
+        builder.setNegativeButton(str("piko_pref_native_downloader_download_all"), (dialogInterface, index) -> {
+            PikoUtils.toast(str("download_started"));
 
             int i = 1;
             for (Media media : mediaData) {
@@ -104,7 +101,7 @@ public class NativeDownloader {
 
             assert media != null;
             if (media.isEmpty()) {
-                PikoUtils.toast(strRes("piko_pref_native_downloader_no_media"));
+                PikoUtils.toast(str("piko_pref_native_downloader_no_media"));
                 return;
             }
 
@@ -112,7 +109,7 @@ public class NativeDownloader {
 
             if (media.size() == 1) {
                 Media item = media.get(0);
-                PikoUtils.toast(strRes("download_started"));
+                PikoUtils.toast(str("download_started"));
                 app.morphe.extension.twitter.Utils.downloadFile(item.url, fileName, item.ext);
                 return;
             }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeFragment.java
@@ -6,6 +6,7 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.readerMode;
 
+import static app.morphe.extension.shared.StringRef.str;
 
 import android.app.Fragment;
 import android.content.Context;
@@ -27,7 +28,6 @@ import java.net.URL;
 
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.Utils;
 
 public class ReaderModeFragment extends Fragment {
@@ -47,7 +47,7 @@ public class ReaderModeFragment extends Fragment {
         @JavascriptInterface
         public void copyText(String text) {
             Utils.setClipboard(text);
-            Utils.showToastShort(StringRef.str("link_copied_to_clipboard"));
+            Utils.showToastShort(str("link_copied_to_clipboard"));
         }
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeTemplate.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeTemplate.java
@@ -6,24 +6,24 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.readerMode;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-
-import app.morphe.extension.shared.StringRef;
 
 import org.json.JSONObject;
 import org.json.JSONArray;
 
 public class ReaderModeTemplate {
 
-  private static final String GROK_ANALYSE_THREAD = StringRef.str("piko_native_reader_mode_grok_thread");
-  private static final String GROK_ANALYSE_AUTHOR = StringRef.str("piko_native_reader_mode_grok_author");
-  private static final String TITLE_SOURCE = StringRef.str("piko_native_reader_mode_source");
-  private static final String TITLE_PUBLISHED = StringRef.str("piko_native_reader_mode_published");
-  private static final String TITLE_TOT_POSTS = StringRef.str("piko_native_reader_mode_total_post");
-  private static final String SHARE_POST = StringRef.str("piko_native_reader_mode_copy_post");
+  private static final String GROK_ANALYSE_THREAD = str("piko_native_reader_mode_grok_thread");
+  private static final String GROK_ANALYSE_AUTHOR = str("piko_native_reader_mode_grok_author");
+  private static final String TITLE_SOURCE = str("piko_native_reader_mode_source");
+  private static final String TITLE_PUBLISHED = str("piko_native_reader_mode_published");
+  private static final String TITLE_TOT_POSTS = str("piko_native_reader_mode_total_post");
+  private static final String SHARE_POST = str("piko_native_reader_mode_copy_post");
 
   private static String getGrokIcon(String slug, String text) {
     return "<a href=\"https://x.com/i/grok?text=" + slug

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeUtils.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/readerMode/ReaderModeUtils.java
@@ -6,11 +6,12 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.readerMode;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.content.Context;
 
 import app.morphe.extension.twitter.settings.ActivityHook;
 import app.morphe.extension.crimera.PikoUtils;
-import app.morphe.extension.shared.StringRef;
 import java.io.File;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -163,9 +164,9 @@ public class ReaderModeUtils {
             }
         }
         if (deleted) {
-            PikoUtils.toast(StringRef.str("piko_native_reader_mode_cache_delete_success"));
+            PikoUtils.toast(str("piko_native_reader_mode_cache_delete_success"));
         } else {
-            PikoUtils.toast(StringRef.str("piko_native_reader_mode_cache_delete_failed"));
+            PikoUtils.toast(str("piko_native_reader_mode_cache_delete_failed"));
         }
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/shareImage/ShareImageHandler.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/shareImage/ShareImageHandler.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.shareImage;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ContentResolver;
@@ -32,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 
 import app.morphe.extension.crimera.PikoUtils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.twitter.Pref;
@@ -49,7 +50,7 @@ public class ShareImageHandler {
 
     public static void shareAsImage(Context context, Object tweetObj) {
         if (!(context instanceof Activity)) {
-            PikoUtils.toast(StringRef.str("piko_share_image_invalid_context"));
+            PikoUtils.toast(str("piko_share_image_invalid_context"));
             return;
         }
 
@@ -61,12 +62,12 @@ public class ShareImageHandler {
 
         try {
             Tweet tweet = new Tweet(tweetObj);
-            PikoUtils.toast(StringRef.str("piko_share_image_capturing"));
+            PikoUtils.toast(str("piko_share_image_capturing"));
             
             View rootView = activity.getWindow().getDecorView().getRootView();
             View tweetView = searchViewTree(rootView, tweet.getTweetId(), 0);
             if (tweetView == null) {
-                PikoUtils.toast(StringRef.str("piko_share_image_view_not_found"));
+                PikoUtils.toast(str("piko_share_image_view_not_found"));
                 return;
             }
             CaptureTarget target = resolveCaptureTarget(activity, rootView, tweetView);
@@ -96,14 +97,14 @@ public class ShareImageHandler {
             }
             
             if (bitmap == null) {
-                PikoUtils.toast(StringRef.str("piko_share_image_capture_failed"));
+                PikoUtils.toast(str("piko_share_image_capture_failed"));
                 return;
             }
 
             shareImage(activity, bitmap, "tweet_" + tweet.getTweetId());
         } catch (Exception e) {
             PikoUtils.logger(e);
-            PikoUtils.toast(StringRef.str("piko_share_image_error", e.getMessage()));
+            PikoUtils.toast(str("piko_share_image_error", e.getMessage()));
         }
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/NativeTranslator.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/NativeTranslator.java
@@ -6,10 +6,11 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.translator;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.content.Context;
 
 import app.morphe.extension.crimera.PikoUtils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.twitter.patches.nativeFeatures.translator.providers.Translate;
 import app.morphe.extension.twitter.patches.nativeFeatures.translator.providers.GTranslate;
 import app.morphe.extension.twitter.patches.nativeFeatures.translator.providers.GTranslateV2;
@@ -27,7 +28,7 @@ public class NativeTranslator {
             Long tweetId = tweet.getTweetId();
             // If text is empty.
             if(text == ""){
-                PikoUtils.logger(StringRef.str("piko_native_translator_zero_text"));
+                PikoUtils.logger(str("piko_native_translator_zero_text"));
                 return;
             }
 
@@ -36,7 +37,7 @@ public class NativeTranslator {
 
             // If both the tweet language and requested language are same.
             if(tweetLang.toLowerCase() == toLang.toLowerCase()){
-                PikoUtils.logger(StringRef.str("translate_tweet_same_language",toLang));
+                PikoUtils.logger(str("translate_tweet_same_language",toLang));
                 return;
             }
             int providerCode = Pref.natveTranslatorProvider();
@@ -60,7 +61,7 @@ public class NativeTranslator {
                 public void onTranslationComplete(String translatedText) {
                     // FxTwitter has multiple sources, so provider name is set after API call.
                     String providerName = translator.getProviderName();
-                    String header = StringRef.str("translate_tweet_link_label",tweetLang,providerName);
+                    String header = str("translate_tweet_link_label",tweetLang,providerName);
 
                     // Update UI with translated text
                     DialogBox dialogBox = new DialogBox(activity,header,translatedText);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/FxTwitterTranslate.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/FxTwitterTranslate.java
@@ -6,6 +6,7 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.translator.providers;
 
+import static app.morphe.extension.shared.StringRef.str;
 import android.os.AsyncTask;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -14,7 +15,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
 import org.json.JSONObject;
-import app.morphe.extension.shared.StringRef;
 
 /*
 * Credits:  https://github.com/FxEmbed/FxEmbed
@@ -100,7 +100,7 @@ public class FxTwitterTranslate implements Translate {
             }
             throw new Exception("Translation failed.");
         } catch (Exception e) {
-            return StringRef.str("translate_tweet_error") +": "+ e.getMessage();
+            return str("translate_tweet_error") +": "+ e.getMessage();
         }
     }
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/GTranslate.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/GTranslate.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.translator.providers;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.os.AsyncTask;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -15,7 +17,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import app.morphe.extension.shared.StringRef;
 
 public class GTranslate implements Translate {
     private static final String BASE_URL = "https://translate.googleapis.com/translate_a/single";
@@ -107,7 +108,7 @@ public class GTranslate implements Translate {
 
             return translatedText.toString();
         } catch (Exception e) {
-            return StringRef.str("translate_tweet_error") +": "+ e.getMessage();
+            return str("translate_tweet_error") +": "+ e.getMessage();
         }
     }
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/GTranslateV2.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/translator/providers/GTranslateV2.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches.nativeFeatures.translator.providers;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.os.AsyncTask;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -15,7 +17,6 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
 import org.json.JSONObject;
-import app.morphe.extension.shared.StringRef;
 
 /*
 * Credits:  https://github.com/cuberkam/free_translate_api
@@ -102,7 +103,7 @@ public class GTranslateV2 implements Translate {
             }
             throw new Exception("destination-text not found");
         } catch (Exception e) {
-            return StringRef.str("translate_tweet_error") +": "+ e.getMessage();
+            return str("translate_tweet_error") +": "+ e.getMessage();
         }
     }
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
@@ -6,7 +6,7 @@
 
 package app.morphe.extension.twitter.settings;
 
-import app.morphe.extension.shared.StringRef;
+import static app.morphe.extension.shared.StringRef.str;
 
 import android.content.Context;
 import android.preference.PreferenceScreen;
@@ -45,13 +45,13 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_premium"));
+            category = preferenceCategory(str("piko_title_premium"));
 
         if (SettingsStatus.enableUndoPosts) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_undo_posts"),
-                            strRes("piko_pref_undo_posts_desc"),
+                            str("piko_pref_undo_posts"),
+                            str("piko_pref_undo_posts_desc"),
                             Settings.PREMIUM_UNDO_POSTS
                     )
             );
@@ -59,8 +59,8 @@ public class ScreenBuilder {
             if (SettingsStatus.enableForcePip) {
                 addPreference(category,
                         helper.switchPreference(
-                                strRes("piko_pref_enable_force_pip"),
-                                strRes("piko_pref_enable_force_pip_desc"),
+                                str("piko_pref_enable_force_pip"),
+                                str("piko_pref_enable_force_pip_desc"),
                                 Settings.PREMIUM_ENABLE_FORCE_PIP
                         )
                 );
@@ -68,7 +68,7 @@ public class ScreenBuilder {
 
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_undo_posts_btn"),
+                            str("piko_pref_undo_posts_btn"),
                             "",
                             Settings.PREMIUM_UNDO_POSTS.key
                     )
@@ -78,7 +78,7 @@ public class ScreenBuilder {
         if (SettingsStatus.navBarCustomisation) {
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("tab_customization_screen_title"),
+                            str("tab_customization_screen_title"),
                             "",
                             Settings.PREMIUM_NAVBAR.key
                     )
@@ -92,23 +92,23 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_download"));
+            category = preferenceCategory(str("piko_title_download"));
         if (SettingsStatus.changeDownloadEnabled) {
             addPreference(category,helper.listPreference(
-                    strRes("piko_pref_download_path"),
-                    strRes("piko_pref_download_path_desc"),
+                    str("piko_pref_download_path"),
+                    str("piko_pref_download_path_desc"),
                     Settings.VID_PUBLIC_FOLDER
             ));
             addPreference(category,helper.editTextPreference(
-                    strRes("piko_pref_download_folder"),
-                    strRes("piko_pref_download_folder_desc"),
+                    str("piko_pref_download_folder"),
+                    str("piko_pref_download_folder_desc"),
                     Settings.VID_SUBFOLDER
             ));
         }
         if (SettingsStatus.mediaLinkHandle) {
             addPreference(category,
                     helper.listPreference(
-                            strRes("piko_pref_download_media_link_handle"),
+                            str("piko_pref_download_media_link_handle"),
                             "",
                             Settings.VID_MEDIA_HANDLE
                     )
@@ -121,11 +121,11 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_ads"));
+            category = preferenceCategory(str("piko_title_ads"));
         if (SettingsStatus.hideAds) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_promoted_posts"),
+                            str("piko_pref_hide_promoted_posts"),
                             "",
                             Settings.ADS_HIDE_PROMOTED_POSTS
                     )
@@ -135,7 +135,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideWTF) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_wtf_section"),
+                            str("piko_pref_wtf_section"),
                             "",
                             Settings.ADS_HIDE_WHO_TO_FOLLOW
                     )
@@ -144,7 +144,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideCTS) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_cts_section"),
+                            str("piko_pref_cts_section"),
                             "",
                             Settings.ADS_HIDE_CREATORS_TO_SUB
                     )
@@ -154,7 +154,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideCTJ) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_ctj_section"),
+                            str("piko_pref_ctj_section"),
                             "",
                             Settings.ADS_HIDE_COMM_TO_JOIN
                     )
@@ -164,7 +164,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideRBMK) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_ryb_section"),
+                            str("piko_pref_ryb_section"),
                             "",
                             Settings.ADS_HIDE_REVISIT_BMK
                     )
@@ -174,7 +174,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideRPinnedPosts) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_pinned_posts_section"),
+                            str("piko_pref_pinned_posts_section"),
                             "",
                             Settings.ADS_HIDE_REVISIT_PINNED_POSTS
                     )
@@ -184,7 +184,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideDetailedPosts) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_related_posts"),
+                            str("piko_pref_hide_related_posts"),
                             "",
                             Settings.ADS_HIDE_DETAILED_POSTS
                     )
@@ -194,7 +194,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hidePremiumPrompt) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_premium_prompt"),
+                            str("piko_pref_hide_premium_prompt"),
                             "",
                             Settings.ADS_HIDE_PREMIUM_PROMPT
                     )
@@ -204,8 +204,8 @@ public class ScreenBuilder {
         if (SettingsStatus.removePremiumUpsell) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_premium_upsell"),
-                            strRes("piko_pref_hide_premium_upsell_desc"),
+                            str("piko_pref_hide_premium_upsell"),
+                            str("piko_pref_hide_premium_upsell_desc"),
                             Settings.ADS_REMOVE_PREMIUM_UPSELL
                     )
             );
@@ -214,8 +214,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideTopPeopleSearch) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_top_people_search"),
-                            strRes("piko_pref_top_people_search_desc"),
+                            str("piko_pref_top_people_search"),
+                            str("piko_pref_top_people_search_desc"),
                             Settings.ADS_HIDE_TOP_PEOPLE_SEARCH
                     )
             );
@@ -223,7 +223,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideTodaysNews) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_todays_news"),
+                            str("piko_pref_hide_todays_news"),
                             "",
                             Settings.ADS_REMOVE_TODAYS_NEW
                     )
@@ -233,7 +233,7 @@ public class ScreenBuilder {
         if (SettingsStatus.deleteFromDb) {
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_del_from_db"),
+                            str("piko_pref_del_from_db"),
                             "",
                             Settings.ADS_DEL_FROM_DB.key,
                             null,
@@ -248,15 +248,15 @@ public class ScreenBuilder {
 
         if (!buildCategory) {
             Preference nativePageDescription = new Preference(context);
-            nativePageDescription.setSummary(strRes("piko_pref_native_page_desc"));
+            nativePageDescription.setSummary(str("piko_pref_native_page_desc"));
             addPreference(nativePageDescription);
         }
 
-        LegacyTwitterPreferenceCategory category = preferenceCategory(strRes("piko_title_native_downloader"));
+        LegacyTwitterPreferenceCategory category = preferenceCategory(str("piko_title_native_downloader"));
         if (SettingsStatus.nativeDownloader) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_title_native_downloader_toggle"),
+                            str("piko_title_native_downloader_toggle"),
                             "",
                             Settings.VID_NATIVE_DOWNLOADER
                     )
@@ -265,26 +265,26 @@ public class ScreenBuilder {
             if (SettingsStatus.inlineDownloadButton) {
                 addPreference(category,
                         helper.switchPreference(
-                                strRes("piko_pref_native_downloader_inline_button"),
-                                strRes("piko_pref_native_downloader_inline_button_desc"),
+                                str("piko_pref_native_downloader_inline_button"),
+                                str("piko_pref_native_downloader_inline_button_desc"),
                                 Settings.VID_INLINE_DOWNLOAD_BUTTON
                         )
                 );
             }
 
             addPreference(category,helper.listPreference(
-                    strRes("piko_pref_download_path"),
-                    strRes("piko_pref_download_path_desc"),
+                    str("piko_pref_download_path"),
+                    str("piko_pref_download_path_desc"),
                     Settings.VID_PUBLIC_FOLDER
             ));
             addPreference(category,helper.editTextPreference(
-                    strRes("piko_pref_download_folder"),
-                    strRes("piko_pref_download_folder_desc"),
+                    str("piko_pref_download_folder"),
+                    str("piko_pref_download_folder_desc"),
                     Settings.VID_SUBFOLDER
             ));
             addPreference(category,
                     helper.listPreference(
-                            strRes("piko_pref_native_downloader_filename_title"),
+                            str("piko_pref_native_downloader_filename_title"),
                             "",
                             Settings.VID_NATIVE_DOWNLOADER_FILENAME
                     )
@@ -292,26 +292,26 @@ public class ScreenBuilder {
         }
 
 
-        category = preferenceCategory(strRes("piko_title_native_translator"));
+        category = preferenceCategory(str("piko_title_native_translator"));
 
         if (SettingsStatus.nativeTranslator) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_native_translator_toggle"),
+                            str("piko_native_translator_toggle"),
                             "",
                             Settings.NATIVE_TRANSLATOR
                     )
             );
             addPreference(category,
                     helper.listPreference(
-                            strRes("piko_native_translator_provider"),
+                            str("piko_native_translator_provider"),
                             "",
                             Settings.NATIVE_TRANSLATOR_PROVIDERS
                     )
             );
             addPreference(category,
                     helper.listPreference(
-                            strRes("piko_native_translator_to_lang"),
+                            str("piko_native_translator_to_lang"),
                             Pref.translatorLanguage(),
                             Settings.NATIVE_TRANSLATOR_LANG
                     )
@@ -319,12 +319,12 @@ public class ScreenBuilder {
 
         }
 
-        category = preferenceCategory(strRes("piko_title_native_reader_mode"));
+        category = preferenceCategory(str("piko_title_native_reader_mode"));
 
         if (SettingsStatus.nativeReaderMode) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_native_reader_mode_toggle"),
+                            str("piko_native_reader_mode_toggle"),
                             "",
                             Settings.NATIVE_READER_MODE
                     )
@@ -332,35 +332,35 @@ public class ScreenBuilder {
 
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_native_reader_mode_pref_text_only_mode"),
+                            str("piko_native_reader_mode_pref_text_only_mode"),
                             "",
                             Settings.NATIVE_READER_MODE_TEXT_ONLY_MODE
                     )
             );
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_native_reader_mode_pref_hide_quoted_posts"),
+                            str("piko_native_reader_mode_pref_hide_quoted_posts"),
                             "",
                             Settings.NATIVE_READER_MODE_HIDE_QUOTED_POST
                     )
             );
             addPreference(category,
                     helper.switchPreference (
-                            strRes("piko_native_reader_mode_pref_no_grok"),
+                            str("piko_native_reader_mode_pref_no_grok"),
                             "",
                             Settings.NATIVE_READER_MODE_NO_GROK
                     )
             );
             addPreference(category,
                     helper.listPreference(
-                            strRes("community_theme_settings_title"),
+                            str("community_theme_settings_title"),
                             "",
                             Settings.NATIVE_READER_MODE_THEME
                     )
             );
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_native_reader_mode_cache_delete"),
+                            str("piko_native_reader_mode_cache_delete"),
                             "",
                             Settings.RESET_READER_MODE_CACHE
                     )
@@ -369,11 +369,11 @@ public class ScreenBuilder {
         }
 
         if (SettingsStatus.shareImage) {
-					  category = preferenceCategory(strRes("piko_share_image_title"));
+					  category = preferenceCategory(str("piko_share_image_title"));
 
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_share_image_toggle"),
+                            str("piko_share_image_toggle"),
                             "",
                             Settings.SHARE_IMAGE_ENABLED
                     )
@@ -381,19 +381,19 @@ public class ScreenBuilder {
 
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_share_image_autocleanup"),
-                            strRes("piko_share_image_autocleanup_desc"),
+                            str("piko_share_image_autocleanup"),
+                            str("piko_share_image_autocleanup_desc"),
                             Settings.SHARE_IMAGE_AUTOCLEANUP
                     )
             );
         }
 
         if (SettingsStatus.browseObject) {
-            category = preferenceCategory(strRes("piko_browse_object_title"));
+            category = preferenceCategory(str("piko_browse_object_title"));
 
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_browse_object_title"),
+                            str("piko_browse_object_title"),
                             "",
                             Settings.BROWSE_OBJECT
                     )
@@ -407,11 +407,11 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_misc"));
+            category = preferenceCategory(str("piko_title_misc"));
         if (SettingsStatus.enableFontMod) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_chirp_font"),
+                            str("piko_pref_chirp_font"),
                             "",
                             Settings.MISC_FONT
                     )
@@ -420,7 +420,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideFAB) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_fab"),
+                            str("piko_pref_hide_fab"),
                             "",
                             Settings.MISC_HIDE_FAB
                     )
@@ -429,7 +429,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideFABBtns) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_fab_menu"),
+                            str("piko_pref_hide_fab_menu"),
                             "",
                             Settings.MISC_HIDE_FAB_BTN
                     )
@@ -439,7 +439,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideRecommendedUsers) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_rec_users"),
+                            str("piko_pref_rec_users"),
                             "",
                             Settings.MISC_HIDE_RECOMMENDED_USERS
                     )
@@ -449,7 +449,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideViewCount) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_view_count"),
+                            str("piko_pref_hide_view_count"),
                             "",
                             Settings.MISC_HIDE_VIEW_COUNT
                     )
@@ -459,8 +459,8 @@ public class ScreenBuilder {
         if (SettingsStatus.roundOffNumbers) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_round_off_numbers"),
-                            strRes("piko_pref_round_off_numbers_desc"),
+                            str("piko_pref_round_off_numbers"),
+                            str("piko_pref_round_off_numbers_desc"),
                             Settings.MISC_ROUND_OFF_NUMBERS
                     )
             );
@@ -469,7 +469,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableDebugMenu) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_debug_menu"),
+                            str("piko_pref_debug_menu"),
                             "",
                             Settings.MISC_DEBUG_MENU
                     )
@@ -479,8 +479,8 @@ public class ScreenBuilder {
         if (SettingsStatus.customSharingDomainEnabled) {
             addPreference(category,
                     helper.editTextPreference(
-                            strRes("piko_pref_custom_share_domain"),
-                            strRes("piko_pref_custom_share_domain_desc"),
+                            str("piko_pref_custom_share_domain"),
+                            str("piko_pref_custom_share_domain_desc"),
                             Settings.CUSTOM_SHARING_DOMAIN
                     )
             );
@@ -489,8 +489,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideSocialProof) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_social_proof"),
-                            strRes("piko_pref_hide_social_proof_desc"),
+                            str("piko_pref_hide_social_proof"),
+                            str("piko_pref_hide_social_proof_desc"),
                             Settings.MISC_HIDE_SOCIAL_PROOF
                     )
             );
@@ -499,8 +499,8 @@ public class ScreenBuilder {
         if (SettingsStatus.removeSearchSuggestions) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_search_suggestion"),
-                            strRes("piko_pref_search_suggestion_desc"),
+                            str("piko_pref_search_suggestion"),
+                            str("piko_pref_search_suggestion_desc"),
                             Settings.MISC_HIDE_SEARCH_SUGGESTIONS
                     )
             );
@@ -509,8 +509,8 @@ public class ScreenBuilder {
         if (SettingsStatus.pauseSearchSuggestions) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_pause_search_suggestion"),
-                            strRes("piko_pref_pause_search_suggestion_desc"),
+                            str("piko_pref_pause_search_suggestion"),
+                            str("piko_pref_pause_search_suggestion_desc"),
                             Settings.MISC_PAUSE_SEARCH_SUGGESTIONS
                     )
             );
@@ -520,8 +520,8 @@ public class ScreenBuilder {
         if (SettingsStatus.disUnifyXChatSystem) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_disunify_xchat_system"),
-                            strRes("piko_disunify_xchat_system_desc"),
+                            str("piko_disunify_xchat_system"),
+                            str("piko_disunify_xchat_system_desc"),
                             Settings.MISC_DISUNIFY_XCHAT_SYSTEM
                     )
             );
@@ -534,11 +534,11 @@ public class ScreenBuilder {
 
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_feature_flags"));
+            category = preferenceCategory(str("piko_title_feature_flags"));
 
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_feature_flags"),
+                        str("piko_pref_feature_flags"),
                         "",
                         Settings.FEATURE_FLAGS,
                         "ic_vector_exiting",
@@ -549,8 +549,8 @@ public class ScreenBuilder {
 
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_import_flags"),
-                        strRes("piko_pref_app_restart_rec"),
+                        str("piko_pref_import_flags"),
+                        str("piko_pref_app_restart_rec"),
                         Settings.IMPORT_FLAGS,
                         "ic_vector_incoming",
                         null
@@ -559,7 +559,7 @@ public class ScreenBuilder {
 
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_export_flags"),
+                        str("piko_pref_export_flags"),
                         "",
                         Settings.EXPORT_FLAGS,
                         "ic_vector_outgoing",
@@ -569,7 +569,7 @@ public class ScreenBuilder {
 
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_reset_flags"),
+                        str("piko_pref_reset_flags"),
                         "",
                         Settings.RESET_FLAGS,
                         "ic_vector_trashcan_stroke",
@@ -586,12 +586,12 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_customisation"));
+            category = preferenceCategory(str("piko_title_customisation"));
         if (SettingsStatus.profileTabCustomisation) {
            addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_profiletabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_profiletabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_PROFILE_TABS
                     )
             );
@@ -599,8 +599,8 @@ public class ScreenBuilder {
         if (SettingsStatus.timelineTabCustomisation) {
            addPreference(category,
                     helper.listPreference(
-                            strRes("piko_pref_customisation_timelinetabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_timelinetabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_TIMELINE_TABS
                     )
             );
@@ -608,8 +608,8 @@ public class ScreenBuilder {
         if (SettingsStatus.exploreTabCustomisation) {
             addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_exploretabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_exploretabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_EXPLORE_TABS
                     )
             );
@@ -617,8 +617,8 @@ public class ScreenBuilder {
         if (SettingsStatus.sideBarCustomisation) {
            addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_sidebartabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_sidebartabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_SIDEBAR_TABS
                     )
             );
@@ -627,8 +627,8 @@ public class ScreenBuilder {
         if (SettingsStatus.navBarCustomisation) {
            addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_navbartabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_navbartabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_NAVBAR_TABS
                     )
             );
@@ -637,8 +637,8 @@ public class ScreenBuilder {
         if (SettingsStatus.inlineBarCustomisation) {
            addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_inlinetabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_inlinetabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_INLINE_TABS
                     )
             );
@@ -647,8 +647,8 @@ public class ScreenBuilder {
         if (SettingsStatus.searchTabCustomisation) {
             addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_searchtabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_searchtabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_SEARCH_TABS
                     )
             );
@@ -657,8 +657,8 @@ public class ScreenBuilder {
         if (SettingsStatus.notificationTabCustomisation) {
             addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_notificationtabs"),
-                            strRes("piko_pref_app_restart_rec"),
+                            str("piko_pref_customisation_notificationtabs"),
+                            str("piko_pref_app_restart_rec"),
                             Settings.CUSTOM_NOTIFICATION_TABS
                     )
             );
@@ -667,7 +667,7 @@ public class ScreenBuilder {
         if (SettingsStatus.defaultReplySortFilter) {
            addPreference(category,
                     helper.listPreference(
-                            strRes("piko_pref_customisation_reply_sorting"),
+                            str("piko_pref_customisation_reply_sorting"),
                             "",
                             Settings.CUSTOM_DEF_REPLY_SORTING
                     )
@@ -677,7 +677,7 @@ public class ScreenBuilder {
         if (SettingsStatus.typeaheadCustomisation) {
             addPreference(category,
                     helper.multiSelectListPref(
-                            strRes("piko_pref_customisation_search_type_ahead"),
+                            str("piko_pref_customisation_search_type_ahead"),
                             "",
                             Settings.CUSTOM_SEARCH_TYPE_AHEAD
                     )
@@ -687,7 +687,7 @@ public class ScreenBuilder {
         if(SettingsStatus.customPostFontSize) {
             addPreference(category,
                     helper.editTextNumPreference(
-                            strRes("piko_pref_customisation_post_font_size"),
+                            str("piko_pref_customisation_post_font_size"),
                             String.valueOf(Pref.setPostFontSize()),
                             Settings.CUSTOM_POST_FONT_SIZE
                     ));
@@ -696,7 +696,7 @@ public class ScreenBuilder {
         if (SettingsStatus.appIconCustomisation) {
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_customisation_change_app_icon"),
+                            str("piko_pref_customisation_change_app_icon"),
                             "",
                             Settings.CHANGE_APP_ICON
                     )
@@ -705,16 +705,16 @@ public class ScreenBuilder {
 
         addPreference(category,
                 helper.switchPreference(
-                        strRes("piko_pref_quick_settings"),
-                        strRes("piko_pref_quick_settings_summary"),
+                        str("piko_pref_quick_settings"),
+                        str("piko_pref_quick_settings_summary"),
                         Settings.MISC_QUICK_SETTINGS_BUTTON
                 )
         );
 
         addPreference(category,
                 helper.switchPreference(
-                        strRes("piko_single_page_settings"),
-                        strRes("piko_single_page_settings_desc")+"\n"+strRes("piko_pref_app_restart_rec"),
+                        str("piko_single_page_settings"),
+                        str("piko_single_page_settings_desc")+"\n"+str("piko_pref_app_restart_rec"),
                         Settings.SINGLE_PAGE_SETTINGS
                 )
         );
@@ -725,13 +725,13 @@ public class ScreenBuilder {
 
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_font"));
+            category = preferenceCategory(str("piko_title_font"));
 
         if(SettingsStatus.customFont) {
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_add_font"),
-                            strRes("piko_pref_add_font_desc"),
+                            str("piko_pref_add_font"),
+                            str("piko_pref_add_font_desc"),
                             Settings.ADD_FONT,
                             "ic_vector_pencil_stroke",
                             null
@@ -741,7 +741,7 @@ public class ScreenBuilder {
 
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_delete_font"),
+                            str("piko_pref_delete_font"),
                             "",
                             Settings.DELETE_FONT,
                             "ic_vector_trashcan_stroke",
@@ -752,8 +752,8 @@ public class ScreenBuilder {
         if(SettingsStatus.customEmojiFont) {
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_add_emoji_font"),
-                            strRes("piko_pref_add_font_desc"),
+                            str("piko_pref_add_emoji_font"),
+                            str("piko_pref_add_font_desc"),
                             Settings.ADD_EMOJI_FONT,
                             "ic_vector_live_heart_stroke",
                             null
@@ -763,7 +763,7 @@ public class ScreenBuilder {
 
             addPreference(category,
                     helper.buttonPreference(
-                            strRes("piko_pref_delete_emoji_font"),
+                            str("piko_pref_delete_emoji_font"),
                             "",
                             Settings.DELETE_EMOJI_FONT,
                             "ic_vector_trashcan_stroke",
@@ -782,11 +782,11 @@ public class ScreenBuilder {
             
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_timeline"));
+            category = preferenceCategory(str("piko_title_timeline"));
         if (SettingsStatus.disableAutoTimelineScroll) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_disable_auto_timeline_scroll"),
+                            str("piko_pref_disable_auto_timeline_scroll"),
                             "",
                             Settings.TIMELINE_DISABLE_AUTO_SCROLL
                     )
@@ -795,8 +795,8 @@ public class ScreenBuilder {
         if (SettingsStatus.showSourceLabel) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_show_post_source"),
-                            strRes("piko_pref_show_post_source_desc"),
+                            str("piko_pref_show_post_source"),
+                            str("piko_pref_show_post_source_desc"),
                             Settings.TIMELINE_SHOW_SOURCE_LABEL
                     )
             );
@@ -804,8 +804,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideLiveThreads) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_live_threads"),
-                            strRes("piko_pref_hide_live_threads_desc"),
+                            str("piko_pref_hide_live_threads"),
+                            str("piko_pref_hide_live_threads_desc"),
                             Settings.TIMELINE_HIDE_LIVETHREADS
                     )
             );
@@ -813,8 +813,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideBanner) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_banner"),
-                            strRes("piko_pref_hide_banner_desc"),
+                            str("piko_pref_hide_banner"),
+                            str("piko_pref_hide_banner_desc"),
                             Settings.TIMELINE_HIDE_BANNER
                     )
             );
@@ -822,7 +822,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideInlineBmk) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_bmk_timeline"),
+                            str("piko_pref_hide_bmk_timeline"),
                             "",
                             Settings.TIMELINE_HIDE_BMK_ICON
                     )
@@ -832,8 +832,8 @@ public class ScreenBuilder {
         if (SettingsStatus.showPollResultsEnabled) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_show_poll_result"),
-                            strRes("piko_pref_show_poll_result_desc"),
+                            str("piko_pref_show_poll_result"),
+                            str("piko_pref_show_poll_result_desc"),
                             Settings.TIMELINE_SHOW_POLL_RESULTS
                     )
             );
@@ -842,8 +842,8 @@ public class ScreenBuilder {
         if (SettingsStatus.unshortenlink) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_unshorten_link"),
-                            strRes("piko_pref_unshorten_link_desc"),
+                            str("piko_pref_unshorten_link"),
+                            str("piko_pref_unshorten_link_desc"),
                             Settings.TIMELINE_UNSHORT_URL
                     )
             );
@@ -852,7 +852,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideCommunityNote) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_community_notes"),
+                            str("piko_pref_hide_community_notes"),
                             "",
                             Settings.MISC_HIDE_COMM_NOTES
                     )
@@ -862,8 +862,8 @@ public class ScreenBuilder {
         if (SettingsStatus.forceTranslate) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_force_translate"),
-                            strRes("piko_pref_force_translate_desc"),
+                            str("piko_pref_force_translate"),
+                            str("piko_pref_force_translate_desc"),
                             Settings.TIMELINE_HIDE_FORCE_TRANSLATE
                     )
             );
@@ -872,8 +872,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hidePromoteButton) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_quick_promote"),
-                            strRes("piko_pref_hide_quick_promote_desc"),
+                            str("piko_pref_hide_quick_promote"),
+                            str("piko_pref_hide_quick_promote_desc"),
                             Settings.TIMELINE_HIDE_PROMOTE_BUTTON
                     )
             );
@@ -882,8 +882,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideImmersivePlayer) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_immersive_player"),
-                            strRes("piko_pref_hide_immersive_player_desc"),
+                            str("piko_pref_hide_immersive_player"),
+                            str("piko_pref_hide_immersive_player_desc"),
                             Settings.TIMELINE_HIDE_IMMERSIVE_PLAYER
                     )
             );
@@ -891,8 +891,8 @@ public class ScreenBuilder {
         if (SettingsStatus.enableVidAutoAdvance) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_enable_vid_auto_advance"),
-                            strRes("piko_pref_enable_vid_auto_advance_desc"),
+                            str("piko_pref_enable_vid_auto_advance"),
+                            str("piko_pref_enable_vid_auto_advance_desc"),
                             Settings.TIMELINE_ENABLE_VID_AUTO_ADVANCE
                     )
             );
@@ -900,7 +900,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideHiddenReplies) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_hidden_replies"),
+                            str("piko_pref_hide_hidden_replies"),
                             "",
                             Settings.TIMELINE_HIDE_HIDDEN_REPLIES
                     )
@@ -909,8 +909,8 @@ public class ScreenBuilder {
         if (SettingsStatus.enableForceHD) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_force_hd"),
-                            strRes("piko_pref_force_hd_desc"),
+                            str("piko_pref_force_hd"),
+                            str("piko_pref_force_hd_desc"),
                             Settings.TIMELINE_ENABLE_VID_FORCE_HD
                     )
             );
@@ -918,8 +918,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideNudgeButton) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_nudge_button"),
-                            strRes("piko_pref_hide_nudge_button_desc"),
+                            str("piko_pref_hide_nudge_button"),
+                            str("piko_pref_hide_nudge_button_desc"),
                             Settings.TIMELINE_HIDE_NUDGE_BUTTON
                     )
             );
@@ -927,7 +927,7 @@ public class ScreenBuilder {
         if (SettingsStatus.showSensitiveMedia) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_show_sensitive_media"),
+                            str("piko_pref_show_sensitive_media"),
                             "",
                             Settings.TIMELINE_SHOW_SENSITIVE_MEDIA
                     )
@@ -936,7 +936,7 @@ public class ScreenBuilder {
         if (SettingsStatus.hideCommBadge) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_community_badge"),
+                            str("piko_pref_hide_community_badge"),
                             "",
                             Settings.TIMELINE_HIDE_COMM_BADGE
                     )
@@ -945,8 +945,8 @@ public class ScreenBuilder {
         if (SettingsStatus.hideNavbarBadge) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_badge_nav_bar"),
-                            strRes("piko_pref_hide_badge_nav_bar_desc"),
+                            str("piko_pref_hide_badge_nav_bar"),
+                            str("piko_pref_hide_badge_nav_bar_desc"),
                             Settings.TIMELINE_HIDE_NAVBAR_BADGE
                     )
             );
@@ -955,16 +955,16 @@ public class ScreenBuilder {
         if (SettingsStatus.hidePostMetrics) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_post_inline_metrics"),
-                            strRes("piko_pref_hide_post_inline_metrics_desc"),
+                            str("piko_pref_hide_post_inline_metrics"),
+                            str("piko_pref_hide_post_inline_metrics_desc"),
                             Settings.TIMELINE_HIDE_POST_INLINE_METRICS
                     )
             );
 
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_hide_post_detailed_metrics"),
-                            strRes("piko_pref_hide_post_detailed_metrics_desc"),
+                            str("piko_pref_hide_post_detailed_metrics"),
+                            str("piko_pref_hide_post_detailed_metrics_desc"),
                             Settings.TIMELINE_HIDE_POST_DETAILED_METRICS
                     )
             );
@@ -975,13 +975,13 @@ public class ScreenBuilder {
     public void buildLoggingSection(boolean buildCategory) {
         LegacyTwitterPreferenceCategory category = null;
         if (buildCategory)
-            category = preferenceCategory(strRes("piko_title_logging"));
+            category = preferenceCategory(str("piko_title_logging"));
 
         if (SettingsStatus.serverResponseLogging) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_server_response_logging"),
-                            strRes("piko_pref_server_response_logging_desc"),
+                            str("piko_pref_server_response_logging"),
+                            str("piko_pref_server_response_logging_desc"),
                             Settings.LOG_RES
                     )
             );
@@ -990,8 +990,8 @@ public class ScreenBuilder {
         if (SettingsStatus.serverResponseLoggingOverwriteFile) {
             addPreference(category,
                     helper.switchPreference(
-                            strRes("piko_pref_server_response_logging_file_overwrite"),
-                            strRes("piko_pref_server_response_logging_file_overwrite_desc"),
+                            str("piko_pref_server_response_logging_file_overwrite"),
+                            str("piko_pref_server_response_logging_file_overwrite_desc"),
                             Settings.LOG_RES_OVRD
                     )
             );
@@ -1002,13 +1002,13 @@ public class ScreenBuilder {
     public void buildExportSection(boolean buildCategory){
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_backup"));
+            category = preferenceCategory(str("piko_title_backup"));
 
 
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_import_settings"),
-                        strRes("piko_pref_app_restart_rec"),
+                        str("piko_pref_import_settings"),
+                        str("piko_pref_app_restart_rec"),
                         Settings.IMPORT_PREF,
                         "ic_vector_incoming",
                         null
@@ -1017,7 +1017,7 @@ public class ScreenBuilder {
         );
        addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_export_settings"),
+                        str("piko_pref_export_settings"),
                         "",
                         Settings.EXPORT_PREF,
                         "ic_vector_outgoing",
@@ -1027,7 +1027,7 @@ public class ScreenBuilder {
 
        addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_reset_settings"),
+                        str("piko_pref_reset_settings"),
                         "",
                         Settings.RESET_PREF,
                         "ic_vector_trashcan_stroke",
@@ -1038,7 +1038,7 @@ public class ScreenBuilder {
        if (SettingsStatus.exportLoginToken) {
            addPreference(category,
                    helper.buttonPreference(
-                           StringRef.str("piko_pref_import_login_token"),
+                           str("piko_pref_import_login_token"),
                            "",
                            Settings.IMPORT_LOGIN_TOKEN,
                            "ic_vector_passkey",
@@ -1047,7 +1047,7 @@ public class ScreenBuilder {
            );
            addPreference(category,
                    helper.buttonPreference(
-                           StringRef.str("piko_pref_export_login_token"),
+                           str("piko_pref_export_login_token"),
                            "",
                            Settings.EXPORT_LOGIN_TOKEN,
                            "ic_vector_passkey",
@@ -1060,10 +1060,10 @@ public class ScreenBuilder {
     public void buildPikoSection(boolean buildCategory){
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
-            category = preferenceCategory(strRes("piko_title_about"));
+            category = preferenceCategory(str("piko_title_about"));
         addPreference(category,
                 helper.buttonPreference(
-                        strRes("piko_pref_patch_info"),
+                        str("piko_pref_patch_info"),
                         "",
                         Settings.PATCH_INFO
                 )
@@ -1074,7 +1074,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enablePremiumSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_premium"),
+                            str("piko_title_premium"),
                             "",
                             Settings.PREMIUM_SECTION,
                             "ic_vector_twitter",null
@@ -1084,7 +1084,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableDownloadSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_download"),
+                            str("piko_title_download"),
                             "",
                             Settings.DOWNLOAD_SECTION,
                             "ic_vector_incoming",null
@@ -1094,7 +1094,7 @@ public class ScreenBuilder {
         if (SettingsStatus.featureFlagsEnabled) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_feature_flags"),
+                            str("piko_title_feature_flags"),
                             "",
                             Settings.FLAGS_SECTION,
                             "ic_vector_flag",null
@@ -1104,7 +1104,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableAdsSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_ads"),
+                            str("piko_title_ads"),
                             "",
                             Settings.ADS_SECTION,
                             "ic_vector_accessibility_alt",null
@@ -1114,7 +1114,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableNativeSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_native"),
+                            str("piko_title_native"),
                             "",
                             Settings.NATIVE_SECTION,
                             "ic_vector_flask_stroke",null
@@ -1124,7 +1124,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableMiscSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_misc"),
+                            str("piko_title_misc"),
                             "",
                             Settings.MISC_SECTION,
                             "ic_vector_heartline",null
@@ -1134,7 +1134,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableCustomisationSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_customisation"),
+                            str("piko_title_customisation"),
                             "",
                             Settings.CUSTOMISE_SECTION,
                             "ic_vector_paintbrush_stroke",null
@@ -1144,7 +1144,7 @@ public class ScreenBuilder {
         if (SettingsStatus.fontSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_font"),
+                            str("piko_title_font"),
                             "",
                             Settings.FONT_SECTION,
                             "ic_vector_at",null
@@ -1155,7 +1155,7 @@ public class ScreenBuilder {
         if (SettingsStatus.enableTimelineSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_timeline"),
+                            str("piko_title_timeline"),
                             "",
                             Settings.TIMELINE_SECTION,
                             "ic_vector_timeline_stroke",null
@@ -1166,7 +1166,7 @@ public class ScreenBuilder {
         if (SettingsStatus.loggingSection()) {
             addPreference(
                     helper.buttonPreference(
-                            strRes("piko_title_logging"),
+                            str("piko_title_logging"),
                             "",
                             Settings.LOGGING_SECTION,
                             "ic_vector_bug_stroke",null
@@ -1176,7 +1176,7 @@ public class ScreenBuilder {
    
         addPreference(
                 helper.buttonPreference(
-                        strRes("piko_title_backup"),
+                        str("piko_title_backup"),
                         "",
                         Settings.BACKUP_SECTION,
                         "ic_vector_layers_stroke",null
@@ -1185,7 +1185,7 @@ public class ScreenBuilder {
         
         addPreference(
                 helper.buttonPreference(
-                        strRes("piko_pref_patch_info"),
+                        str("piko_pref_patch_info"),
                         "",
                         Settings.PATCH_INFO,
                         "ic_vector_accessibility_circle",null
@@ -1201,9 +1201,6 @@ public class ScreenBuilder {
         return preferenceCategory;
     }
 
-    public String strRes(String tag) {
-        return StringRef.str(tag);
-    }
 
 
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/BackupPrefFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/BackupPrefFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.settings.fragments;
 
+import app.morphe.extension.shared.StringRef.str;
+
 import android.app.Fragment;
 import android.content.Intent;
 import android.net.Uri;
@@ -17,7 +19,6 @@ import java.text.SimpleDateFormat;
 import java.util.*;
 
 import app.morphe.extension.twitter.Utils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.twitter.settings.Settings;
 
 public class BackupPrefFragment extends Fragment {
@@ -41,9 +42,9 @@ public class BackupPrefFragment extends Fragment {
             OutputStream openOutputStream = getActivity().getContentResolver().openOutputStream(uri);
             openOutputStream.write(bytes);
             openOutputStream.close();
-            toast(StringRef.str("piko_pref_export_success"));
+            toast(str("piko_pref_export_success"));
         } catch (IOException e) {
-            toast(StringRef.str("piko_pref_export_failed",prefTag));
+            toast(str("piko_pref_export_failed",prefTag));
         }
     }
 
@@ -54,7 +55,7 @@ public class BackupPrefFragment extends Fragment {
             uri = intent.getData();
         }
         if (uri == null) {
-            toast(StringRef.str("piko_pref_export_no_uri"));
+            toast(str("piko_pref_export_no_uri"));
 
         }
         else if (i2 == -1) {
@@ -76,11 +77,11 @@ public class BackupPrefFragment extends Fragment {
 
         if (featureFlag) {
             this.prefData = Utils.getStringPref(Settings.MISC_FEATURE_FLAGS);
-            prefTag = StringRef.str("piko_title_feature_flags");
+            prefTag = str("piko_title_feature_flags");
             startIntent("feature_flags", 1);
         } else {
             this.prefData = Utils.getAll(true);
-            prefTag = StringRef.str("notification_settings_preferences_category");
+            prefTag = str("notification_settings_preferences_category");
             startIntent("backup", 1);
         }
     }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/BackupPrefFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/BackupPrefFragment.java
@@ -6,7 +6,7 @@
 
 package app.morphe.extension.twitter.settings.fragments;
 
-import app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.shared.StringRef.str;
 
 import android.app.Fragment;
 import android.content.Intent;

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/RestorePrefFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/RestorePrefFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.settings.fragments;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
@@ -17,7 +19,6 @@ import java.io.InputStreamReader;
 
 import android.app.Fragment;
 import app.morphe.extension.twitter.Utils;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.twitter.settings.Settings;
 
 public class RestorePrefFragment extends Fragment {
@@ -49,19 +50,19 @@ public class RestorePrefFragment extends Fragment {
     public static void receiveFileForRestore(Uri uri, Context context) {
         String jsonString = readFileContent(uri);
         boolean sts = false;
-        String prefTag = StringRef.str("notification_settings_preferences_category");
+        String prefTag = str("notification_settings_preferences_category");
         if(featureFlag){
             sts = Utils.setStringPref(Settings.MISC_FEATURE_FLAGS.key,jsonString);
-            prefTag = StringRef.str("piko_title_feature_flags");
+            prefTag = str("piko_title_feature_flags");
         }else{
             sts = Utils.setAll(jsonString);
 
         }
         if(sts){
-            toast(StringRef.str("piko_pref_import_success"));
+            toast(str("piko_pref_import_success"));
         }
         else{
-            toast(StringRef.str("piko_pref_import_failed",prefTag));
+            toast(str("piko_pref_import_failed",prefTag));
         }
 
         Utils.showRestartAppDialog(context);
@@ -79,7 +80,7 @@ public class RestorePrefFragment extends Fragment {
                 receiveFileForRestore(uri,getActivity());
             }
             else {
-                toast(StringRef.str("piko_pref_import_no_uri"));
+                toast(str("piko_pref_import_no_uri"));
             }
         }
         getFragmentManager().popBackStack();

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.settings.fragments;
 
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.text.*;
 import android.text.style.ForegroundColorSpan;
 import android.graphics.Color;
@@ -16,7 +18,6 @@ import android.preference.*;
 import app.morphe.extension.shared.Utils;
 import com.twitter.ui.widget.LegacyTwitterPreferenceCategory;
 import java.util.*;
-import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.twitter.settings.ActivityHook;
 import app.morphe.extension.twitter.settings.SettingsStatus;
 import app.morphe.extension.twitter.patches.Changelogs;
@@ -28,7 +29,7 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
     @Override
     public void onResume() {
         super.onResume();
-        ActivityHook.toolbar.setTitle(strRes("piko_pref_patch_info"));
+        ActivityHook.toolbar.setTitle(str("piko_pref_patch_info"));
     }
 
     @Override
@@ -38,111 +39,111 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
 
         PreferenceManager preferenceManager = getPreferenceManager();
         PreferenceScreen screen = preferenceManager.createPreferenceScreen(context);
-        LegacyTwitterPreferenceCategory verPref = preferenceCategory(strRes("piko_pref_version_info"), screen);
+        LegacyTwitterPreferenceCategory verPref = preferenceCategory(str("piko_pref_version_info"), screen);
         verPref.addPreference(
                 buttonPreference(
-                        strRes("piko_pref_app_version"),
+                        str("piko_pref_app_version"),
                         Utils.getAppVersionName(),
-                        strRes("piko_pref_app_version")
+                        str("piko_pref_app_version")
                 )
         );
         verPref.addPreference(
                 buttonPreference(
-                        strRes("piko_title_piko_patches"),
+                        str("piko_title_piko_patches"),
                         Utils.getPatchesReleaseVersion(),
-                        strRes("piko_title_piko_patches")
+                        str("piko_title_piko_patches")
                 )
         );
         verPref.addPreference(
                 buttonPreference(
-                        strRes("piko_changelogs_title"),
+                        str("piko_changelogs_title"),
                         "",
-                        strRes("piko_changelogs_title")
+                        str("piko_changelogs_title")
                 )
         );
         verPref.addPreference(
                 buttonPreference(
-                        strRes("piko_settings_supported_links"),
+                        str("piko_settings_supported_links"),
                         "",
-                        strRes("piko_settings_supported_links")
+                        str("piko_settings_supported_links")
                 )
         );
 
         TreeMap<String,Boolean> flags = new TreeMap();
-        flags.put(strRes("piko_pref_video_download"),SettingsStatus.enableVidDownload);
-        flags.put(strRes("piko_pref_undo_posts"),SettingsStatus.enableUndoPosts);
-        flags.put(strRes("tab_customization_screen_title"),SettingsStatus.navBarCustomisation);
-        flags.put(strRes("piko_pref_download"),SettingsStatus.changeDownloadEnabled);
-        flags.put(strRes("piko_pref_download_media_link_handle"),SettingsStatus.mediaLinkHandle);
-        flags.put(strRes("piko_pref_hide_promoted_posts"),SettingsStatus.hideAds);
-        flags.put(strRes("piko_pref_wtf_section"),SettingsStatus.hideWTF);
-        flags.put(strRes("piko_pref_cts_section"),SettingsStatus.hideCTS);
-        flags.put(strRes("piko_pref_ctj_section"),SettingsStatus.hideCTJ);
-        flags.put(strRes("piko_pref_ryb_section"),SettingsStatus.hideRBMK);
-        flags.put(strRes("piko_pref_pinned_posts_section"),SettingsStatus.hideRPinnedPosts);
-        flags.put(strRes("piko_pref_hide_related_posts"),SettingsStatus.hideDetailedPosts);
-        flags.put(strRes("piko_pref_chirp_font"),SettingsStatus.enableFontMod);
-        flags.put(strRes("piko_pref_hide_fab"),SettingsStatus.hideFAB);
-        flags.put(strRes("piko_pref_hide_fab_menu"),SettingsStatus.hideFABBtns);
-        flags.put(strRes("piko_pref_show_sensitive_media"),SettingsStatus.showSensitiveMedia);
-        flags.put(strRes("piko_pref_selectable_text"),SettingsStatus.selectableText);
-        flags.put(strRes("piko_pref_rec_users"),SettingsStatus.hideRecommendedUsers);
-        flags.put(strRes("piko_pref_custom_share_domain"),SettingsStatus.customSharingDomainEnabled);
-        flags.put(strRes("piko_pref_feature_flags"),SettingsStatus.featureFlagsEnabled);
-        flags.put(strRes("piko_pref_customisation_profiletabs"),SettingsStatus.profileTabCustomisation);
-        flags.put(strRes("piko_pref_customisation_timelinetabs"),SettingsStatus.timelineTabCustomisation);
-        flags.put(strRes("piko_pref_customisation_exploretabs"),SettingsStatus.exploreTabCustomisation);
-        flags.put(strRes("piko_pref_customisation_navbartabs"),SettingsStatus.navBarCustomisation);
-        flags.put(strRes("piko_pref_customisation_sidebartabs"),SettingsStatus.sideBarCustomisation);
-        flags.put(strRes("piko_pref_disable_auto_timeline_scroll"),SettingsStatus.disableAutoTimelineScroll);
-        flags.put(strRes("piko_pref_hide_live_threads"),SettingsStatus.hideLiveThreads);
-        flags.put(strRes("piko_pref_hide_view_count"),SettingsStatus.hideViewCount);
-        flags.put(strRes("piko_pref_hide_banner"),SettingsStatus.hideBanner);
-        flags.put(strRes("piko_pref_hide_bmk_timeline"),SettingsStatus.hideInlineBmk);
-        flags.put(strRes("piko_pref_show_poll_result"),SettingsStatus.showPollResultsEnabled);
-        flags.put(strRes("community_notes_title"),SettingsStatus.hideCommunityNote);
-        flags.put(strRes("piko_pref_hide_quick_promote"),SettingsStatus.hidePromoteButton);
-        flags.put(strRes("piko_pref_hide_immersive_player"),SettingsStatus.hideImmersivePlayer);
-        flags.put(strRes("piko_pref_clear_tracking_params"),SettingsStatus.cleartrackingparams);
-        flags.put(strRes("piko_pref_unshorten_link"),SettingsStatus.unshortenlink);
-        flags.put(strRes("piko_pref_force_translate"),SettingsStatus.forceTranslate);
-        flags.put(strRes("piko_pref_round_off_numbers"),SettingsStatus.roundOffNumbers);
-        flags.put(strRes("piko_pref_customisation_inlinetabs"),SettingsStatus.inlineBarCustomisation);
-        flags.put(strRes("piko_pref_debug_menu"),SettingsStatus.enableDebugMenu);
-        flags.put(strRes("piko_pref_hide_premium_prompt"),SettingsStatus.hidePremiumPrompt);
-        flags.put(strRes("piko_pref_hide_hidden_replies"),SettingsStatus.hideHiddenReplies);
-        flags.put(strRes("piko_pref_del_from_db"),SettingsStatus.deleteFromDb);
-        flags.put(strRes("piko_title_native_downloader"),SettingsStatus.nativeDownloader);
-        flags.put(strRes("piko_pref_native_downloader_inline_button"),SettingsStatus.inlineDownloadButton);
-        flags.put(strRes("piko_share_image_title"),SettingsStatus.shareImage);
-        flags.put(strRes("piko_browse_object_title"),SettingsStatus.browseObject);
-        flags.put(strRes("piko_title_native_reader_mode"),SettingsStatus.nativeReaderMode);
-        flags.put(strRes("piko_pref_enable_vid_auto_advance"),SettingsStatus.enableVidAutoAdvance);
-        flags.put(strRes("piko_pref_enable_force_pip"),SettingsStatus.enableForcePip);
-        flags.put(strRes("piko_pref_hide_premium_upsell"),SettingsStatus.removePremiumUpsell);
-        flags.put(strRes("piko_pref_customisation_reply_sorting"),SettingsStatus.defaultReplySortFilter);
-        flags.put(strRes("piko_pref_force_hd"),SettingsStatus.enableForceHD);
-        flags.put(strRes("piko_pref_hide_nudge_button"),SettingsStatus.hideNudgeButton);
-        flags.put(strRes("piko_pref_hide_social_proof"),SettingsStatus.hideSocialProof);
-        flags.put(strRes("piko_pref_hide_community_badge"),SettingsStatus.hideCommBadge);
-        flags.put(strRes("piko_title_native_translator"),SettingsStatus.nativeTranslator);
-        flags.put(strRes("piko_pref_customisation_post_font_size"),SettingsStatus.customPostFontSize);
-        flags.put(strRes("piko_pref_top_people_search"),SettingsStatus.hideTopPeopleSearch);
-        flags.put(strRes("piko_pref_customisation_searchtabs"),SettingsStatus.searchTabCustomisation);
-        flags.put(strRes("piko_pref_hide_todays_news"),SettingsStatus.hideTodaysNews);
-        flags.put(strRes("piko_pref_server_response_logging"),SettingsStatus.serverResponseLogging);
-        flags.put(strRes("piko_pref_show_post_source"),SettingsStatus.showSourceLabel);
-        flags.put(strRes("piko_changelogs_title"),SettingsStatus.showChangelogsPatchEnabled);
-        flags.put(strRes("piko_pref_pause_search_suggestion"),SettingsStatus.pauseSearchSuggestions);
-        flags.put(strRes("piko_pref_search_suggestion"),SettingsStatus.removeSearchSuggestions);
-        flags.put(strRes("piko_pref_customisation_change_app_icon"),SettingsStatus.appIconCustomisation);
-        flags.put(strRes("piko_pref_hide_badge_nav_bar"),SettingsStatus.hideNavbarBadge);
-        flags.put(strRes("piko_pref_hide_post_inline_metrics"),SettingsStatus.hidePostMetrics);
-        flags.put(strRes("piko_disunify_xchat_system"),SettingsStatus.disUnifyXChatSystem);
-        flags.put(strRes("piko_legacy_share_link"),SettingsStatus.legacyShareLink);
-        flags.put(strRes("piko_pref_export_login_token"),SettingsStatus.exportLoginToken);
+        flags.put(str("piko_pref_video_download"),SettingsStatus.enableVidDownload);
+        flags.put(str("piko_pref_undo_posts"),SettingsStatus.enableUndoPosts);
+        flags.put(str("tab_customization_screen_title"),SettingsStatus.navBarCustomisation);
+        flags.put(str("piko_pref_download"),SettingsStatus.changeDownloadEnabled);
+        flags.put(str("piko_pref_download_media_link_handle"),SettingsStatus.mediaLinkHandle);
+        flags.put(str("piko_pref_hide_promoted_posts"),SettingsStatus.hideAds);
+        flags.put(str("piko_pref_wtf_section"),SettingsStatus.hideWTF);
+        flags.put(str("piko_pref_cts_section"),SettingsStatus.hideCTS);
+        flags.put(str("piko_pref_ctj_section"),SettingsStatus.hideCTJ);
+        flags.put(str("piko_pref_ryb_section"),SettingsStatus.hideRBMK);
+        flags.put(str("piko_pref_pinned_posts_section"),SettingsStatus.hideRPinnedPosts);
+        flags.put(str("piko_pref_hide_related_posts"),SettingsStatus.hideDetailedPosts);
+        flags.put(str("piko_pref_chirp_font"),SettingsStatus.enableFontMod);
+        flags.put(str("piko_pref_hide_fab"),SettingsStatus.hideFAB);
+        flags.put(str("piko_pref_hide_fab_menu"),SettingsStatus.hideFABBtns);
+        flags.put(str("piko_pref_show_sensitive_media"),SettingsStatus.showSensitiveMedia);
+        flags.put(str("piko_pref_selectable_text"),SettingsStatus.selectableText);
+        flags.put(str("piko_pref_rec_users"),SettingsStatus.hideRecommendedUsers);
+        flags.put(str("piko_pref_custom_share_domain"),SettingsStatus.customSharingDomainEnabled);
+        flags.put(str("piko_pref_feature_flags"),SettingsStatus.featureFlagsEnabled);
+        flags.put(str("piko_pref_customisation_profiletabs"),SettingsStatus.profileTabCustomisation);
+        flags.put(str("piko_pref_customisation_timelinetabs"),SettingsStatus.timelineTabCustomisation);
+        flags.put(str("piko_pref_customisation_exploretabs"),SettingsStatus.exploreTabCustomisation);
+        flags.put(str("piko_pref_customisation_navbartabs"),SettingsStatus.navBarCustomisation);
+        flags.put(str("piko_pref_customisation_sidebartabs"),SettingsStatus.sideBarCustomisation);
+        flags.put(str("piko_pref_disable_auto_timeline_scroll"),SettingsStatus.disableAutoTimelineScroll);
+        flags.put(str("piko_pref_hide_live_threads"),SettingsStatus.hideLiveThreads);
+        flags.put(str("piko_pref_hide_view_count"),SettingsStatus.hideViewCount);
+        flags.put(str("piko_pref_hide_banner"),SettingsStatus.hideBanner);
+        flags.put(str("piko_pref_hide_bmk_timeline"),SettingsStatus.hideInlineBmk);
+        flags.put(str("piko_pref_show_poll_result"),SettingsStatus.showPollResultsEnabled);
+        flags.put(str("community_notes_title"),SettingsStatus.hideCommunityNote);
+        flags.put(str("piko_pref_hide_quick_promote"),SettingsStatus.hidePromoteButton);
+        flags.put(str("piko_pref_hide_immersive_player"),SettingsStatus.hideImmersivePlayer);
+        flags.put(str("piko_pref_clear_tracking_params"),SettingsStatus.cleartrackingparams);
+        flags.put(str("piko_pref_unshorten_link"),SettingsStatus.unshortenlink);
+        flags.put(str("piko_pref_force_translate"),SettingsStatus.forceTranslate);
+        flags.put(str("piko_pref_round_off_numbers"),SettingsStatus.roundOffNumbers);
+        flags.put(str("piko_pref_customisation_inlinetabs"),SettingsStatus.inlineBarCustomisation);
+        flags.put(str("piko_pref_debug_menu"),SettingsStatus.enableDebugMenu);
+        flags.put(str("piko_pref_hide_premium_prompt"),SettingsStatus.hidePremiumPrompt);
+        flags.put(str("piko_pref_hide_hidden_replies"),SettingsStatus.hideHiddenReplies);
+        flags.put(str("piko_pref_del_from_db"),SettingsStatus.deleteFromDb);
+        flags.put(str("piko_title_native_downloader"),SettingsStatus.nativeDownloader);
+        flags.put(str("piko_pref_native_downloader_inline_button"),SettingsStatus.inlineDownloadButton);
+        flags.put(str("piko_share_image_title"),SettingsStatus.shareImage);
+        flags.put(str("piko_browse_object_title"),SettingsStatus.browseObject);
+        flags.put(str("piko_title_native_reader_mode"),SettingsStatus.nativeReaderMode);
+        flags.put(str("piko_pref_enable_vid_auto_advance"),SettingsStatus.enableVidAutoAdvance);
+        flags.put(str("piko_pref_enable_force_pip"),SettingsStatus.enableForcePip);
+        flags.put(str("piko_pref_hide_premium_upsell"),SettingsStatus.removePremiumUpsell);
+        flags.put(str("piko_pref_customisation_reply_sorting"),SettingsStatus.defaultReplySortFilter);
+        flags.put(str("piko_pref_force_hd"),SettingsStatus.enableForceHD);
+        flags.put(str("piko_pref_hide_nudge_button"),SettingsStatus.hideNudgeButton);
+        flags.put(str("piko_pref_hide_social_proof"),SettingsStatus.hideSocialProof);
+        flags.put(str("piko_pref_hide_community_badge"),SettingsStatus.hideCommBadge);
+        flags.put(str("piko_title_native_translator"),SettingsStatus.nativeTranslator);
+        flags.put(str("piko_pref_customisation_post_font_size"),SettingsStatus.customPostFontSize);
+        flags.put(str("piko_pref_top_people_search"),SettingsStatus.hideTopPeopleSearch);
+        flags.put(str("piko_pref_customisation_searchtabs"),SettingsStatus.searchTabCustomisation);
+        flags.put(str("piko_pref_hide_todays_news"),SettingsStatus.hideTodaysNews);
+        flags.put(str("piko_pref_server_response_logging"),SettingsStatus.serverResponseLogging);
+        flags.put(str("piko_pref_show_post_source"),SettingsStatus.showSourceLabel);
+        flags.put(str("piko_changelogs_title"),SettingsStatus.showChangelogsPatchEnabled);
+        flags.put(str("piko_pref_pause_search_suggestion"),SettingsStatus.pauseSearchSuggestions);
+        flags.put(str("piko_pref_search_suggestion"),SettingsStatus.removeSearchSuggestions);
+        flags.put(str("piko_pref_customisation_change_app_icon"),SettingsStatus.appIconCustomisation);
+        flags.put(str("piko_pref_hide_badge_nav_bar"),SettingsStatus.hideNavbarBadge);
+        flags.put(str("piko_pref_hide_post_inline_metrics"),SettingsStatus.hidePostMetrics);
+        flags.put(str("piko_disunify_xchat_system"),SettingsStatus.disUnifyXChatSystem);
+        flags.put(str("piko_legacy_share_link"),SettingsStatus.legacyShareLink);
+        flags.put(str("piko_pref_export_login_token"),SettingsStatus.exportLoginToken);
 
-        LegacyTwitterPreferenceCategory patPref = preferenceCategory(strRes("piko_pref_patches"), screen);
+        LegacyTwitterPreferenceCategory patPref = preferenceCategory(str("piko_pref_patches"), screen);
 
         for (Map.Entry<String, Boolean> entry : flags.entrySet()) {
             String resName = entry.getKey();
@@ -152,7 +153,7 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
                     buttonPreference2(
                             resName,
                             sts,
-                            strRes("piko_pref_patches")
+                            str("piko_pref_patches")
                     )
             );
         }
@@ -178,7 +179,7 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
     }
 
     private Preference buttonPreference2(String title, Boolean inc, String key) {
-        String summary = inc ? strRes("piko_pref_included"):strRes("piko_pref_excluded");
+        String summary = inc ? str("piko_pref_included"):str("piko_pref_excluded");
         String colorHex = inc ? "#008FC4":"#DE0025";
         Preference preference = new Preference(context);
         preference.setKey(key);
@@ -193,20 +194,17 @@ public class SettingsAboutFragment extends PreferenceFragment implements Prefere
     @Override
     public boolean onPreferenceClick(Preference preference) {
         String key = preference.getKey();
-        if ( (key.equals(strRes("piko_pref_app_version"))) || (key.equals(strRes("piko_title_piko_patches"))) ) {
+        if ( (key.equals(str("piko_pref_app_version"))) || (key.equals(str("piko_title_piko_patches"))) ) {
             String summary = preference.getSummary().toString();
             Utils.setClipboard(summary);
-            Utils.showToastShort(strRes("copied_to_clipboard")+": "+ summary);
-        }else if (key.equals(strRes("piko_settings_supported_links"))){
+            Utils.showToastShort(str("copied_to_clipboard")+": "+ summary);
+        }else if (key.equals(str("piko_settings_supported_links"))){
             app.morphe.extension.crimera.PikoUtils.openDefaultLinks();
-        }else if (key.equals(strRes("piko_changelogs_title"))){
+        }else if (key.equals(str("piko_changelogs_title"))){
             Changelogs.showChangelogDialog(context);
         }
 
         return true;
     }
 
-    private static String strRes(String tag) {
-        return StringRef.str(tag);
-    }
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsFragment.java
@@ -6,7 +6,8 @@
 
 package app.morphe.extension.twitter.settings.fragments;
 
-import app.morphe.extension.shared.StringRef;
+import static app.morphe.extension.shared.StringRef.str;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.preference.*;
@@ -23,7 +24,7 @@ public class SettingsFragment extends PreferenceFragment {
     @Override
     public void onResume() {
         super.onResume();
-        ActivityHook.toolbar.setTitle(StringRef.str("piko_title_settings"));
+        ActivityHook.toolbar.setTitle(str("piko_title_settings"));
     }
 
     @Override

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/hooks/ShareMenuButtonInitHook.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/hooks/ShareMenuButtonInitHook.kt
@@ -6,7 +6,7 @@
 
 package app.crimera.patches.twitter.misc.shareMenu.hooks
 
-import app.crimera.patches.twitter.utils.Constants.UTILS_DESCRIPTOR
+import app.crimera.patches.twitter.utils.Constants.STRING_REF_DESCRIPTOR
 import app.crimera.utils.instructionToString
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
@@ -51,7 +51,7 @@ fun setButtonText(
                             ins as Instruction21c
                             """
                             const-string v${ins.registerA}, "$stringId"
-                            invoke-static {v${ins.registerA}},$UTILS_DESCRIPTOR;->strRes(Ljava/lang/String;)Ljava/lang/String;
+                            invoke-static {v${ins.registerA}},$STRING_REF_DESCRIPTOR;->str(Ljava/lang/String;)Ljava/lang/String;
                             move-result-object v${ins.registerA}
                             """.trimIndent()
                         }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
@@ -45,6 +45,7 @@ object Constants {
             ).excluding(null)
 
     const val INTEGRATIONS_PACKAGE = "Lapp/morphe/extension/twitter"
+    const val STRING_REF_DESCRIPTOR = "Lapp/morphe/extension/shared/StringRef"
     const val UTILS_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/Utils"
     const val ACTIVITY_SETTINGS_CLASS = "$INTEGRATIONS_PACKAGE/settings"
     const val ACTIVITY_HOOK_CLASS = "$ACTIVITY_SETTINGS_CLASS/ActivityHook;"


### PR DESCRIPTION
Follow-up to https://github.com/crimera/piko/pull/845#issuecomment-4189708560.

Adds a static import for `StringRef.str` across extension classes and replaces all `StringRef.str(...)` / `strRes(...)` wrapper call sites with the statically-imported `str(...)`.
