### PR TITLE
chore: Localize toast messages

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/shareImage/ShareImageHandler.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/nativeFeatures/shareImage/ShareImageHandler.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.shared.StringRef;
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.twitter.Pref;
@@ -48,7 +49,7 @@ public class ShareImageHandler {
 
     public static void shareAsImage(Context context, Object tweetObj) {
         if (!(context instanceof Activity)) {
-            PikoUtils.toast("Invalid context");
+            PikoUtils.toast(StringRef.str("piko_share_image_invalid_context"));
             return;
         }
 
@@ -60,12 +61,12 @@ public class ShareImageHandler {
 
         try {
             Tweet tweet = new Tweet(tweetObj);
-            PikoUtils.toast("Capturing tweet...");
+            PikoUtils.toast(StringRef.str("piko_share_image_capturing"));
             
             View rootView = activity.getWindow().getDecorView().getRootView();
             View tweetView = searchViewTree(rootView, tweet.getTweetId(), 0);
             if (tweetView == null) {
-                PikoUtils.toast("Tweet view not found");
+                PikoUtils.toast(StringRef.str("piko_share_image_view_not_found"));
                 return;
             }
             CaptureTarget target = resolveCaptureTarget(activity, rootView, tweetView);
@@ -95,14 +96,14 @@ public class ShareImageHandler {
             }
             
             if (bitmap == null) {
-                PikoUtils.toast("Failed to capture image");
+                PikoUtils.toast(StringRef.str("piko_share_image_capture_failed"));
                 return;
             }
 
             shareImage(activity, bitmap, "tweet_" + tweet.getTweetId());
         } catch (Exception e) {
             PikoUtils.logger(e);
-            PikoUtils.toast("Error: " + e.getMessage());
+            PikoUtils.toast(StringRef.str("piko_share_image_error", e.getMessage()));
         }
     }
 

--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -41,6 +41,11 @@
     <string name="piko_share_image_toggle">Enable Share Tweet as Image</string>
     <string name="piko_share_image_autocleanup">Auto-cleanup captures</string>
     <string name="piko_share_image_autocleanup_desc">Remove captures older than 24 hours when enabled</string>
+    <string name="piko_share_image_invalid_context">Invalid context</string>
+    <string name="piko_share_image_capturing">Capturing tweet...</string>
+    <string name="piko_share_image_view_not_found">Tweet view not found</string>
+    <string name="piko_share_image_capture_failed">Failed to capture image</string>
+    <string name="piko_share_image_error">Error: %s</string>
 
     <string name="piko_title_native_translator">Native post translation</string>
     <string name="piko_native_translator_toggle">Enable native post translation</string>


### PR DESCRIPTION
Replaces five hardcoded English strings in ShareImageHandler with `StringRef.str()` calls, consistent with the rest of the codebase.

Add the corresponding string keys to the base strings.xml:
```
- piko_share_image_invalid_context
- piko_share_image_capturing
- piko_share_image_view_not_found
- piko_share_image_capture_failed
- piko_share_image_error (%s format arg for the exception message)
```
