### PR TITLE
fix(Twitter - Customize Navigation Bar items): Sometimes the order of navigation buttons is reset

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/FeatureSwitchPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/FeatureSwitchPatch.java
@@ -6,6 +6,8 @@
 
 package app.morphe.extension.twitter.patches;
 
+import static app.morphe.extension.twitter.patches.VersionCheckPatch.IS_11_95_OR_GREATER;
+
 import app.morphe.extension.twitter.Pref;
 import app.morphe.extension.twitter.Utils;
 import app.morphe.extension.twitter.settings.Settings;
@@ -40,6 +42,11 @@ public class FeatureSwitchPatch {
 
     private static void navbarFix() {
         addFlag("subscriptions_feature_1008", true);
+
+        if (IS_11_95_OR_GREATER) {
+            // Added in 11.95.0-aplha.0. This flag should be disabled for the patch to work properly.
+            addFlag("subscriptions_feature_1008_sunset", false);
+        }
     }
 
     private static void immersivePlayer() {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/VersionCheckPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/VersionCheckPatch.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.twitter.patches;
+
+import app.morphe.extension.shared.Utils;
+
+public class VersionCheckPatch {
+    private static String majorVersionName;
+
+    private static String getMajorVersionName() {
+        if (majorVersionName == null) {
+            String versionName = Utils.getAppVersionName();
+            // 11.95.0-alpha.0 > 11.95.0
+            majorVersionName = versionName.split("-")[0];
+        }
+
+        return majorVersionName;
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    private static boolean isVersionOrGreater(String version) {
+        return getMajorVersionName().compareTo(version) >= 0;
+    }
+
+    public static final boolean IS_11_95_OR_GREATER = isVersionOrGreater("11.95.0");
+}

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/Customise.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/Customise.java
@@ -8,37 +8,98 @@ package app.morphe.extension.twitter.patches.customise;
 
 import java.util.*;
 import java.lang.reflect.Field;
+
 import app.morphe.extension.twitter.Pref;
 import app.morphe.extension.crimera.PikoUtils;
 import com.twitter.model.json.search.JsonTypeaheadResponse;
 import app.morphe.extension.twitter.entity.Debug;
-public class Customise {
 
+@SuppressWarnings("unused")
+public class Customise {
     private static void logger(Object j){
         PikoUtils.logger(j);
     }
 
-    public static List navBar(List inp){
-        try{
-            ArrayList choices = Pref.customNavbar();
-
-            if(choices.isEmpty()) return inp;
-
-            List list2 = new ArrayList<>(inp);
-            Iterator itr = list2.iterator();
-
-            while (itr.hasNext()) {
-                Object obj = itr.next();
-                String itemStr = obj.toString();
-                if(choices.contains(itemStr)){
-                    inp.remove(obj);
+    /**
+     * Injection point.
+     */
+    public static List<?> navBar(List<?> inp){
+        try {
+            ArrayList<?> choices = Pref.customNavbar();
+            if (!choices.isEmpty()) {
+                for (Object obj : inp) {
+                    if (obj == null) continue;
+                    String itemStr = obj.toString();
+                    if (choices.contains(itemStr)) {
+                        inp.remove(obj);
+                    }
                 }
             }
-
-        }catch (Exception e){
+        } catch (Exception e){
             logger(e);
         }
         return inp;
+    }
+
+    /**
+     * Injection point.
+     * @param inp           ArrayList composed of TabCustomizationItems.
+     * @param fieldName1    Field name of TabCustomizationItem.
+     * @param fieldName2    Field name of Enum.
+     */
+    public static ArrayList<?> navBar(ArrayList<?> inp, String fieldName1, String fieldName2){
+        try {
+            ArrayList<?> choices = Pref.customNavbar();
+            if (!choices.isEmpty()) {
+                for (Object obj : inp) {
+                    var cls = new Debug(obj);
+                    Object tabCustomizationItem = cls.getField(fieldName1);
+                    if (tabCustomizationItem != null) {
+                        var cls2 = new Debug(tabCustomizationItem);
+                        if (cls2.getField(fieldName2) instanceof String itemStr) {
+                            // Since the name of the new Enum is all uppercase, convert all values in the string array to uppercase for comparison.
+                            if (choices.contains(itemStr.toUpperCase())) {
+                                inp.remove(obj);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e){
+            logger(e);
+        }
+        return inp;
+    }
+
+    /**
+     * Injection point.
+     * @param map A map with Enum and TabCustomizationItem as key-value pairs.
+     *            This map is used as a cache.
+     */
+    public static Map<Object, Object> navBar(Map<Object, Object> map) {
+        try {
+            ArrayList<?> choices = Pref.customNavbar();
+            if (!choices.isEmpty()) {
+                if (!map.isEmpty()) {
+                    // Starting with 11.90.1-release.0, this Map can be immutable.
+                    // To avoid exceptions, create a new Map.
+                    Map<Object, Object> newMap = Collections.synchronizedMap(new LinkedHashMap<>());
+                    for (Map.Entry<Object, Object> entry : map.entrySet()) {
+                        Object key = entry.getKey();
+                        if (key == null) continue;
+                        // Since the name of the new Enum is all uppercase, convert all values in the string array to uppercase for comparison.
+                        String itemStr = key.toString().toUpperCase();
+                        if (!choices.contains(itemStr)) {
+                            newMap.put(key, map.get(key));
+                        }
+                    }
+                    return newMap;
+                }
+            }
+        } catch (Exception e){
+            logger(e);
+        }
+        return map;
     }
 
     public static ArrayList profiletabs(ArrayList inp){
@@ -52,7 +113,6 @@ public class Customise {
             Iterator itr = inp.iterator();
 
             while (itr.hasNext()) {
-
                 Object obj = itr.next();
                 Class<?> clazz = obj.getClass();
                 Field field = clazz.getDeclaredField("g");
@@ -112,9 +172,11 @@ public class Customise {
 
             while (itr.hasNext()) {
                 Object obj = itr.next();
-                String itemStr = obj.toString();
-                if(choices.contains(itemStr)){
-                    list2.remove(obj);
+                if (obj != null) {
+                    String itemStr = obj.toString();
+                    if(choices.contains(itemStr)){
+                        list2.remove(obj);
+                    }
                 }
             }
             return list2;

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
@@ -11,32 +11,95 @@ import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
 import app.crimera.patches.twitter.utils.flagSettings
+import app.crimera.patches.twitter.utils.is_11_88_stable_or_greater
+import app.crimera.patches.twitter.utils.versionCheckPatch
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.checkCast
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
-import app.morphe.patcher.extensions.InstructionExtensions.removeInstruction
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.string
+import app.morphe.util.getFreeRegisterProvider
+import app.morphe.util.getReference
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 
-private object CustomiseNavBarFingerprint : Fingerprint(
+private const val TAB_CUSTOMIZATION_CLASS_PREFIX = "Lcom/twitter/subscriptions/tabcustomization/model/"
+
+private object CustomiseNavBarParentFingerprint : Fingerprint(
     returnType = "V",
-    strings =
-        listOf(
-            "tabCustomizationPreferences",
-            "communitiesUtils",
-            "subscriptionsFeatures",
-        ),
+    strings = listOf(
+        "tabCustomizationPreferences"
+    )
 )
 
-private object NavBarFixFingerprint : Fingerprint(
+private object CustomiseNavBarFingerprint : Fingerprint(
+    classFingerprint = CustomiseNavBarParentFingerprint,
     returnType = "Ljava/util/List;",
-    filters =
-        listOf(
-            string("subscriptions_feature_1008"),
+    filters = listOf(
+        string("subscriptions_feature_1008"),
+        opcode(
+            opcode = Opcode.MOVE_RESULT,
+            location = MatchAfterWithin(5)
         ),
+        checkCast("Ljava/lang/Iterable;"),
+        opcode(Opcode.RETURN_OBJECT)
+    )
+)
+
+private object CustomiseNavBarSecondaryFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    filters = listOf(
+        string("subscriptions_feature_1008"),
+        opcode(
+            opcode = Opcode.MOVE_RESULT,
+            location = MatchAfterWithin(5)
+        ),
+        string("currentSelectedElements"),
+        opcode(Opcode.RETURN_OBJECT)
+    )
+)
+
+private object CustomiseNavBarSecondaryInitFingerprint : Fingerprint(
+    classFingerprint = CustomiseNavBarSecondaryFingerprint,
+    name = "<init>",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "Ljava/util/ArrayList;"
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "Ljava/util/Map;"
+        )
+    )
+)
+
+private object CustomiseNavBarSecondaryMapFingerprint : Fingerprint(
+    classFingerprint = CustomiseNavBarSecondaryFingerprint,
+    parameters = listOf(TAB_CUSTOMIZATION_CLASS_PREFIX),
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = TAB_CUSTOMIZATION_CLASS_PREFIX,
+            type = TAB_CUSTOMIZATION_CLASS_PREFIX
+        ),
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            definingClass = TAB_CUSTOMIZATION_CLASS_PREFIX,
+            type = TAB_CUSTOMIZATION_CLASS_PREFIX,
+            location = MatchAfterWithin(3)
+        ),
+        opcode(Opcode.THROW)
+    )
 )
 
 @Suppress("unused")
@@ -45,34 +108,91 @@ val customiseNavBarPatch =
         name = "Customize Navigation Bar items",
     ) {
         compatibleWith(COMPATIBILITY_X)
-        dependsOn(settingsPatch)
+
+        dependsOn(
+            settingsPatch,
+            versionCheckPatch
+        )
 
         execute {
 
-            val method = CustomiseNavBarFingerprint.classDef.methods.last { it.returnType == "Ljava/util/List;" }
-            val instructions = method.instructions
+            CustomiseNavBarFingerprint.let {
+                it.method.apply {
+                    val listIndex = it.instructionMatches.last().index
+                    val listRegister =
+                        getInstruction<OneRegisterInstruction>(listIndex).registerA
 
-            val returnObj_loc = instructions.last { it.opcode == Opcode.RETURN_OBJECT }.location.index
-            val r0 = method.getInstruction<OneRegisterInstruction>(returnObj_loc).registerA
+                    addInstructions(
+                        listIndex,
+                        """
+                            invoke-static { v$listRegister }, $CUSTOMISE_DESCRIPTOR;->navBar(Ljava/util/List;)Ljava/util/List;
+                            move-result-object v$listRegister
+                        """
+                    )
 
-            val METHOD =
-                """
-                invoke-static {v$r0}, $CUSTOMISE_DESCRIPTOR;->navBar(Ljava/util/List;)Ljava/util/List;
-                move-result-object v$r0
-                """.trimIndent()
+                    val booleanIndex = it.instructionMatches[1].index
+                    val booleanRegister =
+                        getInstruction<OneRegisterInstruction>(booleanIndex).registerA
 
-            method.addInstructions(returnObj_loc, METHOD)
+                    addInstruction(
+                        booleanIndex + 1,
+                        "const/4 v$booleanRegister, 0x1"
+                    )
+                }
+            }
 
-            // credits aero
-            val methods2 = NavBarFixFingerprint.method
-            val loc2 =
-                methods2
-                    .instructions
-                    .first { it.opcode == Opcode.IF_NEZ }
-                    .location.index
-            methods2.removeInstruction(loc2)
-            methods2.removeInstruction(loc2)
-            methods2.removeInstruction(loc2)
+            if (is_11_88_stable_or_greater) {
+                val (listField, mapField) =
+                    with(CustomiseNavBarSecondaryInitFingerprint.instructionMatches) {
+                        Pair(
+                            first().instruction.getReference<FieldReference>()!!,
+                            last().instruction.getReference<FieldReference>()!!,
+                        )
+                    }
+
+                val (navBarFieldName1, navBarFieldName2) =
+                    with(CustomiseNavBarSecondaryMapFingerprint.instructionMatches) {
+                        Pair(
+                            first().instruction.getReference<FieldReference>()!!.name,
+                            this[1].instruction.getReference<FieldReference>()!!.name,
+                        )
+                    }
+
+                CustomiseNavBarSecondaryFingerprint.let {
+                    it.method.apply {
+                        val listIndex = it.instructionMatches.last().index
+                        val listRegister = getInstruction<OneRegisterInstruction>(listIndex).registerA
+                        val mapRegister = getFreeRegisterProvider(listIndex, 1).getFreeRegister()
+                        val freeRegisterProvider = getFreeRegisterProvider(listIndex, 2, listRegister, mapRegister)
+                        val freeRegister1 = freeRegisterProvider.getFreeRegister()
+                        val freeRegister2 = freeRegisterProvider.getFreeRegister()
+
+                        addInstructions(
+                            listIndex,
+                            """
+                                const-string v$freeRegister1, "$navBarFieldName1"
+                                const-string v$freeRegister2, "$navBarFieldName2"
+                                invoke-static { v$listRegister, v$freeRegister1, v$freeRegister2 }, $CUSTOMISE_DESCRIPTOR;->navBar(Ljava/util/ArrayList;Ljava/lang/String;Ljava/lang/String;)Ljava/util/ArrayList;
+                                move-result-object v$listRegister
+                                iput-object v$listRegister, p0, $listField
+                                iget-object v$mapRegister, p0, $mapField
+                                invoke-static { v$mapRegister }, $CUSTOMISE_DESCRIPTOR;->navBar(Ljava/util/Map;)Ljava/util/Map;
+                                move-result-object v$mapRegister
+                                iput-object v$mapRegister, p0, $mapField                                
+                            """
+                        )
+
+                        val booleanIndex = it.instructionMatches[1].index
+                        val booleanRegister =
+                            getInstruction<OneRegisterInstruction>(booleanIndex).registerA
+
+                        addInstruction(
+                            booleanIndex + 1,
+                            "const/4 v$booleanRegister, 0x1"
+                        )
+                    }
+                }
+            }
 
             enableSettings("navBarCustomisation")
             flagSettings("navbarFix")

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/customize/navbar/CustomiseNavBarPatch.kt
@@ -11,7 +11,7 @@ import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.Constants.CUSTOMISE_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
 import app.crimera.patches.twitter.utils.flagSettings
-import app.crimera.patches.twitter.utils.is_11_88_stable_or_greater
+import app.crimera.patches.twitter.utils.is_11_88_or_greater
 import app.crimera.patches.twitter.utils.versionCheckPatch
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
@@ -141,7 +141,7 @@ val customiseNavBarPatch =
                 }
             }
 
-            if (is_11_88_stable_or_greater) {
+            if (is_11_88_or_greater) {
                 val (listField, mapField) =
                     with(CustomiseNavBarSecondaryInitFingerprint.instructionMatches) {
                         Pair(

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/disUnifyXChatSystem/DisUnifyXChatSystemPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/disUnifyXChatSystem/DisUnifyXChatSystemPatch.kt
@@ -10,7 +10,7 @@ import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X_11_69
 import app.crimera.patches.twitter.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
-import app.crimera.patches.twitter.utils.is_11_69_stable_or_greater
+import app.crimera.patches.twitter.utils.is_11_70_or_greater
 import app.crimera.patches.twitter.utils.versionCheckPatch
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
@@ -39,32 +39,29 @@ val disUnifyXchatSystemPatch =
         dependsOn(settingsPatch, versionCheckPatch)
 
         execute {
+            if (is_11_70_or_greater) {
+                return@execute Logger.getLogger(this::class.java.name).warning(
+                    "The patch \"Disunify xchat system\" is force succeeded and does not work on any version above 11.69.\n" +
+                            "Please unselect the patch if you are using a version higher than 11.69."
+                )
+            }
 
-            if (!is_11_69_stable_or_greater) {
-                XchatSubSystemUserCheckFingerprint
-                    .apply {
-                        val strIndx = stringMatches.first { it.string == "userId" }.index
-                        method.apply {
-                            addInstructionsWithLabels(
-                                0,
-                                """
+            XchatSubSystemUserCheckFingerprint
+                .apply {
+                    val strIndx = stringMatches.first { it.string == "userId" }.index
+                    method.apply {
+                        addInstructionsWithLabels(
+                            0,
+                            """
                                 invoke-static {}, $PREF_DESCRIPTOR;->disUnifyXChatSystem()Z
                                 move-result v0
                                 if-nez v0, :piko
                                 return v0
-                                """.trimIndent(),
-                                ExternalLabel("piko", instructions[strIndx]),
-                            )
-                            enableSettings("disUnifyXChatSystem")
-                        }
+                            """.trimIndent(),
+                            ExternalLabel("piko", instructions[strIndx]),
+                        )
+                        enableSettings("disUnifyXChatSystem")
                     }
-            } else {
-                Logger
-                    .getLogger(
-                        this::class.java.name,
-                    ).warning(
-                        "The patch \"Disunify xchat system\" is force succeeded and does not work on any version above 11.69.\nPlease unselect the patch if you are using a version higher than 11.69.",
-                    )
-            }
+                }
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/fingerprints/ActionEnumsFingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/shareMenu/fingerprints/ActionEnumsFingerprint.kt
@@ -6,7 +6,7 @@
 
 package app.crimera.patches.twitter.misc.shareMenu.fingerprints
 
-import app.crimera.patches.twitter.utils.is_11_92_stable_or_greater
+import app.crimera.patches.twitter.utils.is_11_92_or_greater
 import app.crimera.utils.InitMethod
 import app.crimera.utils.indexOfLastFilledNewArrayRange
 import app.crimera.utils.indexOfLastNewInstance
@@ -203,9 +203,9 @@ fun addActionV2(name: String): String {
 
 context(patchContext: BytecodePatchContext)
 fun addAction(name: String): String {
-    if (is_11_92_stable_or_greater) {
-        return addActionV2(name)
+    return if (is_11_92_or_greater) {
+        addActionV2(name)
     } else {
-        return addActionV1(name)
+        addActionV1(name)
     }
 }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
@@ -11,25 +11,27 @@ import kotlin.properties.Delegates
 
 // Based on https://github.com/MorpheApp/morphe-patches/blob/main/patches/src/main/kotlin/app/morphe/patches/reddit/misc/version/VersionCheckPatch.kt
 
-var is_11_92_stable_or_greater: Boolean by Delegates.notNull()
+// For XChat Subsystem patch.
+var is_11_70_or_greater: Boolean by Delegates.notNull()
     private set
-var is_11_88_stable_or_greater: Boolean by Delegates.notNull()
+
+// For Customize Navigation Bar items patch.
+var is_11_88_or_greater: Boolean by Delegates.notNull()
     private set
-var is_11_69_stable_or_greater: Boolean by Delegates.notNull()
+
+// For share menu button enum init.
+var is_11_92_or_greater: Boolean by Delegates.notNull()
     private set
 
 val versionCheckPatch =
     bytecodePatch {
         execute {
-            val versionName = packageMetadata.versionName
+            val versionCode = packageMetadata.versionCode.toInt()
 
-            fun isEqualsOrGreaterThan(version: String): Boolean = versionName >= version
+            fun isEqualsOrGreaterThan(version: Int): Boolean = versionCode >= version
 
-            // For share menu button enum init.
-            is_11_92_stable_or_greater = isEqualsOrGreaterThan("11.92.0-release.0")
-            // For Customize Navigation Bar items patch.
-            is_11_88_stable_or_greater = isEqualsOrGreaterThan("11.88.0-release.0")
-            // For XChat Subsystem patch.
-            is_11_69_stable_or_greater = isEqualsOrGreaterThan("11.69.0-release.0")
+            is_11_70_or_greater = isEqualsOrGreaterThan(311700000)
+            is_11_88_or_greater = isEqualsOrGreaterThan(311880000)
+            is_11_92_or_greater = isEqualsOrGreaterThan(311920000)
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
@@ -13,6 +13,8 @@ import kotlin.properties.Delegates
 
 var is_11_92_stable_or_greater: Boolean by Delegates.notNull()
     private set
+var is_11_88_stable_or_greater: Boolean by Delegates.notNull()
+    private set
 var is_11_69_stable_or_greater: Boolean by Delegates.notNull()
     private set
 
@@ -25,6 +27,8 @@ val versionCheckPatch =
 
             // For share menu button enum init.
             is_11_92_stable_or_greater = isEqualsOrGreaterThan("11.92.0-release.0")
+            // For Customize Navigation Bar items patch.
+            is_11_88_stable_or_greater = isEqualsOrGreaterThan("11.88.0-release.0")
             // For XChat Subsystem patch.
             is_11_69_stable_or_greater = isEqualsOrGreaterThan("11.69.0-release.0")
         }


### PR DESCRIPTION
### Fixed an issue where the order of navigation buttons would sometimes be reset.

- There was an issue where bookmark buttons would not be displayed on the navigation bar, or the order of navigation buttons would be reset.

- In `11.88.0-release.0`, a new method for managing navigation bar items was added.

- The issue was fix by patching this method.

### Fixed an issue where the patch failed in 11.95.0-alpha.0+.

- The patch has been rewritten according to the latest Morphe Patcher syntax.

- Additionally, there were cases where the patch did not work due to [experimental flags](https://github.com/Swakshan/X-Flags/blob/a70477107e862755810448092ddcd3cb76107582/flags/x/x_flags_android_alpha.json#L4795) added in 11.95.0-alpha.0; this has also been fixed.

*Tested versions: 11.69.0-release.0, 11.88.0-release.0, 11.93.0-release.0, 11.95.1-release.0.*