### PR TITLE
feat(Instagram): Add Rename package patch

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
@@ -1,0 +1,303 @@
+package app.crimera.patches.instagram.misc.renamePackage
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.patch.stringOption
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+private const val ORIGINAL_PACKAGE = "com.instagram.android"
+private const val ORIGINAL_NAMESPACE_PREFIX = "com.instagram"
+private val PACKAGE_NAME_REGEX = Regex("^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*){2,}$")
+private val NAMESPACE_WORD_REGEX =
+    Regex("(?<![A-Za-z0-9_])" + Regex.escape(ORIGINAL_NAMESPACE_PREFIX) + "(?![A-Za-z0-9_])")
+
+private const val MAIN_ACTION = "android.intent.action.MAIN"
+private const val LAUNCHER_CATEGORY = "android.intent.category.LAUNCHER"
+
+private val SKIP_CLASS_REFERENCE_ATTRS: Set<Pair<String, String>> =
+    setOf(
+        "application" to "android:name",
+        "application" to "android:backupAgent",
+        "application" to "android:appComponentFactory",
+        "application" to "android:zygotePreloadName",
+        "activity" to "android:name",
+        "activity" to "android:parentActivityName",
+        "service" to "android:name",
+        "receiver" to "android:name",
+        "provider" to "android:name",
+        "instrumentation" to "android:name",
+        "activity-alias" to "android:targetActivity",
+        "meta-data" to "android:value",
+    )
+
+private var newPackageName: String? = null
+private var newAppLabel: String? = null
+
+/**
+ * Internal companion. The main bytecode patch declares this dependsOn, so it
+ * runs alongside. The actual work happens; finalize so it can read the package
+ * and label set during execute. Leaves the manifest untouched if those values
+ * were never set, which means the user did not enable Rename package.
+ */
+
+internal val renamePackageManifestPatch =
+    resourcePatch(
+        description = "Manifest edits for the Rename package patch.",
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        finalize {
+            val newPkg = newPackageName ?: return@finalize
+            val newLabel = newAppLabel ?: return@finalize
+            val newNamespacePrefix = newPkg.substringBeforeLast(".")
+
+            var applicationLabelReference: String? = null
+
+            document("AndroidManifest.xml").use { document ->
+                val manifest = document.documentElement
+                    ?: throw IllegalStateException(
+                        "Rename package: <manifest> root not found.",
+                    )
+
+                val applicationNodes = manifest.getElementsByTagName("application")
+                if (applicationNodes.length > 0) {
+                    applicationLabelReference =
+                        (applicationNodes.item(0) as Element).getAttribute("android:label")
+                }
+
+                manifest.setAttribute("package", newPkg)
+                rewritePackageReferences(manifest, newNamespacePrefix)
+                overrideLauncherLabels(manifest, newLabel)
+            }
+
+            val labelStringName = applicationLabelReference?.let { parseLabelStringName(it) }
+                ?: return@finalize
+
+            // Cosmetic override. The label-string resource id varies by IG version, and the
+            // launcher icon already picks up the new label via the activity-alias path above.
+            // A miss here means App Info still reads "Instagram" — not worth failing the whole
+            // patch over.
+            runCatching {
+                document("res/values/strings.xml").use { stringsDoc ->
+                    val strings = stringsDoc.getElementsByTagName("string")
+                    for (i in 0 until strings.length) {
+                        val element = strings.item(i) as Element
+                        if (element.getAttribute("name") == labelStringName) {
+                            element.textContent = newLabel
+                            return@use
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+/**
+ * Main user-facing patch. Carries the packageName and appLabel options, rewrites
+ * matching string literals in dex, and triggers the manifest companion to run.
+ */
+@Suppress("unused")
+val renamePackagePatch =
+    bytecodePatch(
+        name = "Rename package",
+        description = "Renames the patched app's package and label so it installs alongside the " +
+            "original Instagram instead of replacing it. Rewrites the manifest, launcher icon " +
+            "labels, AND critical dex strings (custom intent actions, content provider URIs, " +
+            "notification channel ids, FB-permissions) so push, RTC and ContentProvider-backed " +
+            "features keep working. A new package means a fresh login, no Play Store updates, " +
+            "and Play Protect may warn about the clone on install.",
+        default = false,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+        dependsOn(renamePackageManifestPatch)
+
+        val packageName by stringOption(
+            key = "packageName",
+            default = "com.pikogram.android",
+            title = "Package name",
+            description = "New package name for the cloned app. Must be a valid Java package " +
+                "with AT LEAST 3 segments (e.g. com.pikogram.android). The patch derives a " +
+                "namespace prefix by dropping the last segment — that prefix replaces " +
+                "com.instagram everywhere, so a 2-segment package would collapse the IG " +
+                "sub-namespaces to single-word identifiers and collide with other apps. " +
+                "Cannot be com.instagram.android.",
+            required = true,
+        ) { value -> value != null && PACKAGE_NAME_REGEX.matches(value) && value != ORIGINAL_PACKAGE }
+
+        val appLabel by stringOption(
+            key = "appLabel",
+            default = "Pikogram",
+            title = "App label",
+            description = "Name shown on the home screen and in app settings.",
+            required = true,
+        ) { value -> !value.isNullOrBlank() }
+
+        execute {
+            val newPkg = packageName!!
+            val newLabel = appLabel!!.trim()
+            val newNamespacePrefix = newPkg.substringBeforeLast(".")
+
+            newPackageName = newPkg
+            newAppLabel = newLabel
+
+            val newReplacement = Regex.escapeReplacement(newNamespacePrefix)
+
+            val instagramClassNames = mutableSetOf<String>()
+            classDefForEach { classDef ->
+                val type = classDef.type
+                if (type.startsWith("Lcom/instagram/") && type.endsWith(";")) {
+                    instagramClassNames +=
+                        type.substring(1, type.length - 1).replace('/', '.')
+                }
+            }
+
+            classDefForEach { classDef ->
+                val hasMatch =
+                    classDef.methods.any { method ->
+                        method.implementation?.instructions?.any { instruction ->
+                            instruction.isConstString() &&
+                                instruction.constStringValue()?.let {
+                                    NAMESPACE_WORD_REGEX.containsMatchIn(it) &&
+                                        it !in instagramClassNames
+                                } == true
+                        } == true
+                    }
+                if (!hasMatch) return@classDefForEach
+
+                mutableClassDefBy(classDef).methods.forEach { method ->
+                    val implementation = method.implementation ?: return@forEach
+                    implementation.instructions.toList().forEachIndexed { index, instruction ->
+                        if (!instruction.isConstString()) return@forEachIndexed
+                        val original = instruction.constStringValue() ?: return@forEachIndexed
+                        if (!NAMESPACE_WORD_REGEX.containsMatchIn(original)) return@forEachIndexed
+
+                        if (original in instagramClassNames) return@forEachIndexed
+
+                        val rewritten = NAMESPACE_WORD_REGEX.replace(original, newReplacement)
+                        val register = (instruction as OneRegisterInstruction).registerA
+
+                        method.replaceInstruction(
+                            index,
+                            "const-string v$register, \"${rewritten.toSmaliEscaped()}\"",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+/** True if this instruction is a const-string or const-string/jumbo. */
+private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.isConstString(): Boolean =
+    opcode == Opcode.CONST_STRING || opcode == Opcode.CONST_STRING_JUMBO
+
+/** The string this const-string instruction loads, or null if it is not one. */
+private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.constStringValue(): String? =
+    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
+
+/**
+ * Walks the element tree and rewrites every attribute value matching the
+ * com.instagram word-boundary regex. Skips entries in SKIP_CLASS_REFERENCE_ATTRS,
+ * which hold Java class names that must keep pointing at the original
+ * com.instagram.* classes in dex.
+ */
+private fun rewritePackageReferences(element: Element, newNamespacePrefix: String) {
+    val replacement = Regex.escapeReplacement(newNamespacePrefix)
+    val tagName = element.tagName
+
+    val attributes = element.attributes
+    for (i in 0 until attributes.length) {
+        val attribute = attributes.item(i)
+        if ((tagName to attribute.nodeName) in SKIP_CLASS_REFERENCE_ATTRS) continue
+        val original = attribute.nodeValue ?: continue
+        val rewritten = NAMESPACE_WORD_REGEX.replace(original, replacement)
+        if (rewritten != original) attribute.nodeValue = rewritten
+    }
+
+    val children = element.childNodes
+    for (i in 0 until children.length) {
+        val child = children.item(i)
+        if (child.nodeType == Node.ELEMENT_NODE) {
+            rewritePackageReferences(child as Element, newNamespacePrefix)
+        }
+    }
+}
+
+/**
+ * Sets android:label on every activity and activity-alias whose intent filter
+ * declares both MAIN and LAUNCHER. The home-screen icon reads this, separate
+ * from the application-level label.
+ */
+private fun overrideLauncherLabels(manifest: Element, newLabel: String) {
+    fun visit(node: Node) {
+        if (node is Element
+            && (node.tagName == "activity" || node.tagName == "activity-alias")
+            && hasLauncherIntentFilter(node)) {
+            node.setAttribute("android:label", newLabel)
+        }
+        val children = node.childNodes
+        for (i in 0 until children.length) visit(children.item(i))
+    }
+    visit(manifest)
+}
+
+/** True if the element has an intent-filter with both action MAIN and category LAUNCHER. */
+private fun hasLauncherIntentFilter(element: Element): Boolean {
+    val filters = element.getElementsByTagName("intent-filter")
+    return (0 until filters.length).any { i ->
+        val filter = filters.item(i) as Element
+        filter.hasChildWithAttribute("action", MAIN_ACTION) &&
+            filter.hasChildWithAttribute("category", LAUNCHER_CATEGORY)
+    }
+}
+
+private fun Element.hasChildWithAttribute(tag: String, expectedName: String): Boolean {
+    val children = getElementsByTagName(tag)
+    return (0 until children.length).any { i ->
+        (children.item(i) as Element).getAttribute("android:name") == expectedName
+    }
+}
+
+/**
+ * Resolves the string-resource name behind a binary AXML attribute value like
+ * the manifest's <application android:label>. Handles symbolic ("@string/foo"),
+ * aapt2-style numeric ("@0x7f130001"), and bare-int forms. Returns null when the
+ * value doesn't look like a resource reference, in which case the strings.xml
+ * override is silently skipped and the launcher-alias label still applies.
+ */
+private fun parseLabelStringName(attributeValue: String): String? {
+    Regex("^@string/(.+)$").find(attributeValue)?.let { return it.groupValues[1] }
+    Regex("^@0x([0-9a-fA-F]+)$").find(attributeValue)?.let { return "string_0x${it.groupValues[1]}" }
+    attributeValue.toIntOrNull()?.let { return "string_0x${it.toString(16).padStart(8, '0')}" }
+    return null
+}
+
+/**
+ * Escapes characters that break a smali double-quoted string literal: backslash,
+ * double quote, the standard whitespace controls (\n \r \t \b), and any other
+ * control character via \uXXXX.
+ */
+private fun String.toSmaliEscaped(): String {
+    val out = StringBuilder(length + 8)
+    for (c in this) {
+        when {
+            c == '\\' -> out.append("\\\\")
+            c == '"' -> out.append("\\\"")
+            c == '\n' -> out.append("\\n")
+            c == '\r' -> out.append("\\r")
+            c == '\t' -> out.append("\\t")
+            c == '\b' -> out.append("\\b")
+            c.code < 0x20 || c.code == 0x7F ->
+                out.append("\\u%04x".format(c.code))
+            else -> out.append(c)
+        }
+    }
+    return out.toString()
+}


### PR DESCRIPTION
## What this adds

A new Instagram patch — **Rename package** — that lets the user install the patched build alongside the original Play Store Instagram, by renaming the package and label at patch time.

Two patch options:
- `packageName` (default `com.pikogram.android`) — must be a valid Java package with at least 3 segments
- `appLabel` (default `Pikogram`) — display name

## How it works

The patch derives a namespace prefix from the user's package by stripping the last segment (`com.pikogram.android` → `com.pikogram`) and applies it to every word-boundary `com.instagram` reference. That covers:

- the app package itself (`com.instagram.android.*`)
- sibling sub-namespaces (`com.instagram.fileprovider`, `com.instagram.barcelona.*`, `com.instagram.contentprovider.*`, `com.instagram.quicksnap.*`, etc.) — these are system-wide-unique ContentProvider authorities; **renaming them is what unblocks side-by-side install with Play Store IG**
- custom permissions, intent actions, notification channel ids, launcher activity-alias names

Implementation splits into a user-facing `bytecodePatch` (carries the options, rewrites dex string literals) and an internal `resourcePatch` (rewrites the manifest in `finalize{}`, derives the application-label string-resource name dynamically from `<application android:label>`).

## Smali / dex behaviour (re: "is this just a package name change?")

It does rewrite at the smali level — every `const-string` literal across every dex file is checked against the namespace regex, with one important exception. A pre-pass indexes every `com.instagram.*` class type descriptor in the dex (`Lcom/instagram/X/Y;`), and the rewriter skips any string literal that exactly matches one of those dotted names. Without that skip, reflection calls like `Class.forName("com.instagram.process.instagram.InstagramApplicationForMainProcess")` (which `InstagramAppShell.onCreate` actually does) would crash at startup, because we never rename type descriptors — only literals.

What the patch does **not** add is method-body hooks (intercepting `getPackageName()`, bypassing signature checks, replacing method bodies, injecting helpers). Held off on those because adding hooks without a known failure is speculative. Happy to add targeted hooks if the maintainers see something specific that breaks.

## Manifest-side selectivity

Class-reference attributes are skipped during the manifest rewrite, since the actual Java classes stay at their original `com.instagram.*` paths in dex:

- `<application>` — `android:name`, `android:backupAgent`, `android:appComponentFactory`, `android:zygotePreloadName`
- `<activity>` — `android:name`, `android:parentActivityName`
- `<service>`, `<receiver>`, `<provider>`, `<instrumentation>` — `android:name`
- `<activity-alias>` — `android:targetActivity`
- `<meta-data>` — `android:value` (commonly a class ref for libraries like Google Cast)

`<activity-alias android:name>` intentionally stays in the rewrite — that's a logical component identifier, not a real Java class.

## Tested

`com.instagram.android` v426.0.0.37.68 on a Galaxy S25 Ultra:
- Patching completes without smali errors
- Clone launches past `WaitingForStringsActivity`, reaches sign-in, login works
- Official Play Store Instagram installs alongside without ContentProvider authority conflicts
- Story regression: viewing, posting from camera and gallery, notifications, tap-to-open, replies — all pass
- Home-screen icon, install dialog, and App Info all read the chosen label

## Known caveats

- No Play Store updates for the clone (expected for any package rename)
- A few Meta cross-product integrations (FCM push from Meta's servers, Family Center, deeplinks targeting `com.instagram.android` externally) may degrade silently — not crashes
- Play Protect may warn on install since the icon matches Instagram's but the signing cert is the patcher's

## What's left out

- Dynamic version support: the patch reads the application-label string-resource name from the manifest at patch time, so the label override works across IG versions without a hardcoded resource id. Otherwise the patch is structure-driven and should survive most IG version bumps.
