### PR TITLE
feat(Instagram): Add Rename package patch

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
@@ -1,0 +1,258 @@
+package app.crimera.patches.instagram.misc.renamePackage
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.patch.stringOption
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+
+private const val ORIGINAL_PACKAGE = "com.instagram.android"
+private const val ORIGINAL_NAMESPACE_PREFIX = "com.instagram"
+private val PACKAGE_NAME_REGEX = Regex("^[a-z][a-z0-9_]*(\\.[a-z][a-z0-9_]*)+$")
+private val NAMESPACE_WORD_REGEX =
+    Regex("(?<![A-Za-z0-9_])" + Regex.escape(ORIGINAL_NAMESPACE_PREFIX) + "(?![A-Za-z0-9_])")
+
+private const val MAIN_ACTION = "android.intent.action.MAIN"
+private const val LAUNCHER_CATEGORY = "android.intent.category.LAUNCHER"
+
+private val SKIP_CLASS_REFERENCE_ATTRS: Set<Pair<String, String>> =
+    setOf(
+        "application" to "android:name",
+        "application" to "android:backupAgent",
+        "application" to "android:appComponentFactory",
+        "application" to "android:zygotePreloadName",
+        "activity" to "android:name",
+        "activity" to "android:parentActivityName",
+        "service" to "android:name",
+        "receiver" to "android:name",
+        "provider" to "android:name",
+        "instrumentation" to "android:name",
+        "activity-alias" to "android:targetActivity",
+        "meta-data" to "android:value",
+    )
+
+private var newPackageName: String? = null
+private var newAppLabel: String? = null
+
+/**
+ * Internal companion. The main bytecode patch declares this dependsOn, so it
+ * runs alongside. The actual work happens; finalize so it can read the package
+ * and label set during execute. Leaves the manifest untouched if those values
+ * were never set, which means the user did not enable Rename package.
+ */
+
+internal val renamePackageManifestPatch =
+    resourcePatch(
+        description = "Manifest edits for the Rename package patch.",
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        finalize {
+            val newPkg = newPackageName ?: return@finalize
+            val newLabel = newAppLabel ?: return@finalize
+            val newNamespacePrefix = newPkg.substringBeforeLast(".")
+
+            document("AndroidManifest.xml").use { document ->
+                val manifest = document.documentElement
+                    ?: throw IllegalStateException(
+                        "Rename package: <manifest> root not found.",
+                    )
+
+                manifest.setAttribute("package", newPkg)
+                rewritePackageReferences(manifest, newNamespacePrefix)
+                overrideLauncherLabels(manifest, newLabel)
+            }
+        }
+    }
+
+/**
+ * Main user-facing patch. Carries the packageName and appLabel options, rewrites
+ * matching string literals in dex, and triggers the manifest companion to run.
+ */
+@Suppress("unused")
+val renamePackagePatch =
+    bytecodePatch(
+        name = "Rename package",
+        description = "Renames the patched app's package and label so it installs alongside the " +
+            "original Instagram instead of replacing it. Rewrites the manifest, launcher icon " +
+            "labels, AND critical dex strings (custom intent actions, content provider URIs, " +
+            "notification channel ids, FB-permissions) so push, RTC and ContentProvider-backed " +
+            "features keep working. A new package means a fresh login, no Play Store updates, " +
+            "and Play Protect may warn about the clone on install.",
+        default = false,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+        dependsOn(renamePackageManifestPatch)
+
+        val packageName by stringOption(
+            key = "packageName",
+            default = "com.pikogram.android",
+            title = "Package name",
+            description = "New package name for the cloned app. Must be a valid Java package " +
+                "(e.g. com.pikogram.android). Cannot be com.instagram.android.",
+            required = true,
+        ) { value -> value != null && PACKAGE_NAME_REGEX.matches(value) && value != ORIGINAL_PACKAGE }
+
+        val appLabel by stringOption(
+            key = "appLabel",
+            default = "Pikogram",
+            title = "App label",
+            description = "Name shown on the home screen and in app settings.",
+            required = true,
+        ) { value -> !value.isNullOrBlank() }
+
+        execute {
+            val newPkg = packageName!!
+            val newLabel = appLabel!!.trim()
+            val newNamespacePrefix = newPkg.substringBeforeLast(".")
+
+            newPackageName = newPkg
+            newAppLabel = newLabel
+
+            val newReplacement = Regex.escapeReplacement(newNamespacePrefix)
+
+            val instagramClassNames = mutableSetOf<String>()
+            classDefForEach { classDef ->
+                val type = classDef.type
+                if (type.startsWith("Lcom/instagram/") && type.endsWith(";")) {
+                    instagramClassNames +=
+                        type.substring(1, type.length - 1).replace('/', '.')
+                }
+            }
+
+            classDefForEach { classDef ->
+                val hasMatch =
+                    classDef.methods.any { method ->
+                        method.implementation?.instructions?.any { instruction ->
+                            instruction.isConstString() &&
+                                instruction.constStringValue()?.let {
+                                    NAMESPACE_WORD_REGEX.containsMatchIn(it) &&
+                                        it !in instagramClassNames
+                                } == true
+                        } == true
+                    }
+                if (!hasMatch) return@classDefForEach
+
+                mutableClassDefBy(classDef).methods.forEach { method ->
+                    val implementation = method.implementation ?: return@forEach
+                    implementation.instructions.toList().forEachIndexed { index, instruction ->
+                        if (!instruction.isConstString()) return@forEachIndexed
+                        val original = instruction.constStringValue() ?: return@forEachIndexed
+                        if (!NAMESPACE_WORD_REGEX.containsMatchIn(original)) return@forEachIndexed
+
+                        if (original in instagramClassNames) return@forEachIndexed
+
+                        val rewritten = NAMESPACE_WORD_REGEX.replace(original, newReplacement)
+                        val register = (instruction as OneRegisterInstruction).registerA
+
+                        method.replaceInstruction(
+                            index,
+                            "const-string v$register, \"${rewritten.toSmaliEscaped()}\"",
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+/** True if this instruction is a const-string or const-string/jumbo. */
+private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.isConstString(): Boolean =
+    opcode == Opcode.CONST_STRING || opcode == Opcode.CONST_STRING_JUMBO
+
+/** The string this const-string instruction loads, or null if it is not one. */
+private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.constStringValue(): String? =
+    ((this as? ReferenceInstruction)?.reference as? StringReference)?.string
+
+/**
+ * Walks the element tree and rewrites every attribute value matching the
+ * com.instagram word-boundary regex. Skips entries in SKIP_CLASS_REFERENCE_ATTRS,
+ * which hold Java class names that must keep pointing at the original
+ * com.instagram.* classes in dex.
+ */
+private fun rewritePackageReferences(element: Element, newNamespacePrefix: String) {
+    val replacement = Regex.escapeReplacement(newNamespacePrefix)
+    val tagName = element.tagName
+
+    val attributes = element.attributes
+    for (i in 0 until attributes.length) {
+        val attribute = attributes.item(i)
+        if ((tagName to attribute.nodeName) in SKIP_CLASS_REFERENCE_ATTRS) continue
+        val original = attribute.nodeValue ?: continue
+        val rewritten = NAMESPACE_WORD_REGEX.replace(original, replacement)
+        if (rewritten != original) attribute.nodeValue = rewritten
+    }
+
+    val children = element.childNodes
+    for (i in 0 until children.length) {
+        val child = children.item(i)
+        if (child.nodeType == Node.ELEMENT_NODE) {
+            rewritePackageReferences(child as Element, newNamespacePrefix)
+        }
+    }
+}
+
+/**
+ * Sets android:label on every activity and activity-alias whose intent filter
+ * declares both MAIN and LAUNCHER. The home-screen icon reads this, separate
+ * from the application-level label.
+ */
+private fun overrideLauncherLabels(manifest: Element, newLabel: String) {
+    fun visit(node: Node) {
+        if (node is Element
+            && (node.tagName == "activity" || node.tagName == "activity-alias")
+            && hasLauncherIntentFilter(node)) {
+            node.setAttribute("android:label", newLabel)
+        }
+        val children = node.childNodes
+        for (i in 0 until children.length) visit(children.item(i))
+    }
+    visit(manifest)
+}
+
+/** True if the element has an intent-filter with both action MAIN and category LAUNCHER. */
+private fun hasLauncherIntentFilter(element: Element): Boolean {
+    val filters = element.getElementsByTagName("intent-filter")
+    return (0 until filters.length).any { i ->
+        val filter = filters.item(i) as Element
+        filter.hasChildWithAttribute("action", MAIN_ACTION) &&
+            filter.hasChildWithAttribute("category", LAUNCHER_CATEGORY)
+    }
+}
+
+private fun Element.hasChildWithAttribute(tag: String, expectedName: String): Boolean {
+    val children = getElementsByTagName(tag)
+    return (0 until children.length).any { i ->
+        (children.item(i) as Element).getAttribute("android:name") == expectedName
+    }
+}
+
+
+/**
+ * Escapes characters that break a smali double-quoted string literal: backslash,
+ * double quote, the standard whitespace controls (\n \r \t \b), and any other
+ * control character via \uXXXX.
+ */
+private fun String.toSmaliEscaped(): String {
+    val out = StringBuilder(length + 8)
+    for (c in this) {
+        when {
+            c == '\\' -> out.append("\\\\")
+            c == '"' -> out.append("\\\"")
+            c == '\n' -> out.append("\\n")
+            c == '\r' -> out.append("\\r")
+            c == '\t' -> out.append("\\t")
+            c == '\b' -> out.append("\\b")
+            c.code < 0x20 || c.code == 0x7F ->
+                out.append("\\u%04x".format(c.code))
+            else -> out.append(c)
+        }
+    }
+    return out.toString()
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/renamePackage/RenamePackagePatch.kt
@@ -40,6 +40,7 @@ private val SKIP_CLASS_REFERENCE_ATTRS: Set<Pair<String, String>> =
 
 private var newPackageName: String? = null
 private var newAppLabel: String? = null
+private var knownInstagramClassNames: Set<String> = emptySet()
 
 /**
  * Internal companion. The main bytecode patch declares this dependsOn, so it
@@ -126,6 +127,7 @@ val renamePackagePatch =
                         type.substring(1, type.length - 1).replace('/', '.')
                 }
             }
+            knownInstagramClassNames = instagramClassNames.toSet()
 
             classDefForEach { classDef ->
                 val hasMatch =
@@ -174,7 +176,10 @@ private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.constS
  * Walks the element tree and rewrites every attribute value matching the
  * com.instagram word-boundary regex. Skips entries in SKIP_CLASS_REFERENCE_ATTRS,
  * which hold Java class names that must keep pointing at the original
- * com.instagram.* classes in dex.
+ * com.instagram.* classes in dex. Also skips activity-alias android:name when
+ * the value is the FQCN of a real class in the dex — dex code references those
+ * aliases via Class.forName / CONST_CLASS and would resolve to the original
+ * com.instagram.* path regardless of what we put in the manifest.
  */
 private fun rewritePackageReferences(element: Element, newNamespacePrefix: String) {
     val replacement = Regex.escapeReplacement(newNamespacePrefix)
@@ -183,8 +188,13 @@ private fun rewritePackageReferences(element: Element, newNamespacePrefix: Strin
     val attributes = element.attributes
     for (i in 0 until attributes.length) {
         val attribute = attributes.item(i)
-        if ((tagName to attribute.nodeName) in SKIP_CLASS_REFERENCE_ATTRS) continue
+        val attrName = attribute.nodeName
+        if ((tagName to attrName) in SKIP_CLASS_REFERENCE_ATTRS) continue
         val original = attribute.nodeValue ?: continue
+        if (tagName == "activity-alias"
+            && attrName == "android:name"
+            && original in knownInstagramClassNames
+        ) continue
         val rewritten = NAMESPACE_WORD_REGEX.replace(original, replacement)
         if (rewritten != original) attribute.nodeValue = rewritten
     }


### PR DESCRIPTION
## What

Adds a Rename package patch under Instagram. The patched build installs alongside the official Play Store Instagram instead of replacing it — different package name, different signing cert, two icons on the home screen.

Two options: `packageName` (default `com.pikogram.android`) and `appLabel` (default `Pikogram`).

## How

Two patches.

A user-facing `bytecodePatch` rewrites `com.instagram.*` string literals across every dex file. A pre-pass indexes every `com.instagram.*` class type descriptor in the dex first, and the rewriter skips literals that exactly match — that keeps `Class.forName("com.instagram.X")` calls working.

An internal `resourcePatch` rewrites the manifest in `finalize{}`: package attribute, `com.instagram` references in identifier attributes (authorities, permissions, intent actions), and launcher activity-alias labels. Class-reference attributes like `<application android:name>`, `<activity android:name>`, `<activity-alias android:targetActivity>`, and `<meta-data android:value>` are left alone, because the Java classes those point at still live at their original `com.instagram.*` paths in dex.

The two patches share package + label state via top-level vars; the bytecode side writes, the resource side reads in `finalize`. Morphe's resource and bytecode contexts are separate APIs so this is the path of least resistance for a feature that needs both.

## Differences from the prior attempt (#1261)

Took the feedback and slimmed:
- Dropped the `strings.xml` application-label override. App Info reads "Instagram" again; home-screen icon still shows the chosen label via the activity-alias path. Cosmetic regression only.
- Dropped the 3-segment package-name requirement. Standard Java package format is now accepted.
- Slimmed the option-description text.

Kept what the review flagged as unneeded, but that on-device testing shows is load-bearing:
- The broad `com.instagram` namespace rewrite (not just `com.instagram.android`). Sibling sub-namespaces like `com.instagram.fileprovider`, `com.instagram.contentprovider.*`, `com.instagram.barcelona.*`, `com.instagram.liteprovider.*` and others are ContentProvider authorities. Android enforces system-wide uniqueness on authorities at install time. If the patched app keeps claiming them, installing the official Instagram alongside fails with an authority-already-claimed error. Verified on device both ways: with the narrow rewrite Play Store install fails, with the broader rewrite it succeeds.

## Smali / dex behavior

This isn't just a manifest rename. Every `const-string` literal across the dex is checked against the namespace regex and rewritten when it matches, with the class-name spare above keeping reflection refs intact. There's no method-body hook (no `getPackageName` interception, no signature-check bypass, no injected helper class). Held off on those because the cases we tested work without them. Happy to add targeted hooks if specific failures show up.

## Tested

`com.instagram.android` v426.0.0.37.68 on a Galaxy S25 Ultra:
- Patching completes
- Clone launches, login works
- Story regression flow (view, post from camera and gallery, notifications, tap-to-open, reply) — no crashes across 3 minutes of active use, confirmed via logcat
- Official Play Store Instagram installs alongside without authority conflicts
- The only errors in logcat are `SecurityException` from `com.facebook.katana.liteprovider.FirstPartyUserValuesLiteProvider` and `com.facebook.messaging.liteprovider.FamilyAppsUserValuesLiteProvider` rejecting calls from the clone. Those are FB and Messenger refusing the clone because their providers pin on Meta's signing cert. No clone can pass those checks regardless of approach.

## Caveats

- No Play Store updates for the clone (expected for any package rename)
- Meta cross-product features that pin on the signing cert won't work (FB Family Center, FB account backup, Family of Apps integrations) — visible as the SecurityExceptions above
- Play Protect may warn on install since the icon and identity match Instagram but the cert doesn't match Meta's
