### PR TITLE
perf(Instagram - Customise story ring size): Clarify standard size in the setting

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -121,6 +121,7 @@ public class Strings {
     public static final String UNLOCK_PLUS_BENEFITS = langInstance.UNLOCK_PLUS_BENEFITS;
     public static final String UNLOCK_PLUS_BENEFITS_DESC = langInstance.UNLOCK_PLUS_BENEFITS_DESC;
     public static final String CUSTOMISE_STORY_RING_SIZE = langInstance.CUSTOMISE_STORY_RING_SIZE;
+    public static final String CUSTOMISE_STORY_RING_SIZE_DESC = langInstance.CUSTOMISE_STORY_RING_SIZE_DESC;
 
     public static final String CATEGORY_DOWNLOAD_MEDIA = langInstance.CATEGORY_DOWNLOAD_MEDIA;
     public static final String ENABLE_DOWNLOAD = langInstance.ENABLE_DOWNLOAD;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -111,6 +111,7 @@ public class DefaultStrings {
     public static String UNLOCK_PLUS_BENEFITS = "Unlock Plus benefits";
     public static String UNLOCK_PLUS_BENEFITS_DESC = "Unlock 'Plus' subscription benefits that are checked locally. USE IT AT YOUR OWN RISK";
     public static String CUSTOMISE_STORY_RING_SIZE = "Customise story ring size";
+    public static String CUSTOMISE_STORY_RING_SIZE_DESC = "Enter the percentage of story ring size. 100 is the standard and maximum size.";
 
     public static String CATEGORY_DOWNLOAD_MEDIA = "Download media";
     public static String ENABLE_DOWNLOAD = "Enable download";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -111,7 +111,7 @@ public class DefaultStrings {
     public static String UNLOCK_PLUS_BENEFITS = "Unlock Plus benefits";
     public static String UNLOCK_PLUS_BENEFITS_DESC = "Unlock 'Plus' subscription benefits that are checked locally. USE IT AT YOUR OWN RISK";
     public static String CUSTOMISE_STORY_RING_SIZE = "Customise story ring size";
-    public static String CUSTOMISE_STORY_RING_SIZE_DESC = "Enter the percentage of story ring size. 100 is the standard size.";
+    public static String CUSTOMISE_STORY_RING_SIZE_DESC = "Change the size of story ring by a percentage (Default is 100)";
 
     public static String CATEGORY_DOWNLOAD_MEDIA = "Download media";
     public static String ENABLE_DOWNLOAD = "Enable download";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -111,7 +111,7 @@ public class DefaultStrings {
     public static String UNLOCK_PLUS_BENEFITS = "Unlock Plus benefits";
     public static String UNLOCK_PLUS_BENEFITS_DESC = "Unlock 'Plus' subscription benefits that are checked locally. USE IT AT YOUR OWN RISK";
     public static String CUSTOMISE_STORY_RING_SIZE = "Customise story ring size";
-    public static String CUSTOMISE_STORY_RING_SIZE_DESC = "Enter the percentage of story ring size. 100 is the standard and maximum size.";
+    public static String CUSTOMISE_STORY_RING_SIZE_DESC = "Enter the percentage of story ring size. 100 is the standard size.";
 
     public static String CATEGORY_DOWNLOAD_MEDIA = "Download media";
     public static String ENABLE_DOWNLOAD = "Enable download";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -59,7 +59,7 @@ public class Settings {
     public static final BooleanSetting STORIES_AUDIO_AUTOPLAY = new BooleanSetting("stories_audio_autoplay", false);
     public static final BooleanSetting UNLOCK_PLUS_BENEFITS = new BooleanSetting("unlock_plus_benefits", false);
     public static final StringSetting CHANGE_LIKE_ANIMATION = new StringSetting("change_like_animation", "ARES_LIKE_ACTIVATION");
-    public static final StringSetting CUSTOMISE_STORY_RING_SIZE = new StringSetting("customise_story_ring_size", "70.0f");
+    public static final StringSetting CUSTOMISE_STORY_RING_SIZE = new StringSetting("customise_story_ring_size", "70");
     public static final BooleanSetting ENABLE_MORE_OPTIONS_ON_POST = new BooleanSetting("enable_more_option_on_post", true);
 
     public static final BooleanSetting DISABLE_DOUBLE_TAP_LIKE_POST = new BooleanSetting("disable_double_tap_like_post", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -59,7 +59,7 @@ public class Settings {
     public static final BooleanSetting STORIES_AUDIO_AUTOPLAY = new BooleanSetting("stories_audio_autoplay", false);
     public static final BooleanSetting UNLOCK_PLUS_BENEFITS = new BooleanSetting("unlock_plus_benefits", false);
     public static final StringSetting CHANGE_LIKE_ANIMATION = new StringSetting("change_like_animation", "ARES_LIKE_ACTIVATION");
-    public static final StringSetting CUSTOMISE_STORY_RING_SIZE = new StringSetting("customise_story_ring_size", "70");
+    public static final StringSetting CUSTOMISE_STORY_RING_SIZE = new StringSetting("customise_story_ring_size", "100");
     public static final BooleanSetting ENABLE_MORE_OPTIONS_ON_POST = new BooleanSetting("enable_more_option_on_post", true);
 
     public static final BooleanSetting DISABLE_DOUBLE_TAP_LIKE_POST = new BooleanSetting("disable_double_tap_like_post", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -487,7 +487,7 @@ public class ScreenBuilder {
             addPreference(category,
                     helper.editTextNumPreference(
                             Strings.CUSTOMISE_STORY_RING_SIZE,
-                            "",
+                            Strings.CUSTOMISE_STORY_RING_SIZE_DESC,
                             Settings.CUSTOMISE_STORY_RING_SIZE
                     ));
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -236,7 +236,7 @@ public class Pref {
 
     public static float customiseStoryRingSize() {
         try {
-            return Float.valueOf(SharedPref.getStringPref(Settings.CUSTOMISE_STORY_RING_SIZE));
+            return Float.parseFloat(SharedPref.getStringPref(Settings.CUSTOMISE_STORY_RING_SIZE));
         } catch (Exception ex) {
             return 100.0f;
         }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/stories/customiseStoryRingSize/CustomiseStoryRingSizePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/stories/customiseStoryRingSize/CustomiseStoryRingSizePatch.kt
@@ -15,17 +15,14 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.literal
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.util.indexOfFirstLiteralInstructionOrThrow
 import app.morphe.util.registersUsed
-
-internal const val HUNDRED = 100.0f
 
 internal object StoryRingBuilderFingerprint : Fingerprint(
     returnType = "V",
     filters =
         listOf(
             literal(66.0f),
-            literal(HUNDRED),
+            literal(100.0f),
             literal(3.75),
         ),
 )
@@ -40,18 +37,20 @@ val customiseStoryRingSizePatch =
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
-            StoryRingBuilderFingerprint.method.apply {
-                val ringSizeLiteralIndex = indexOfFirstLiteralInstructionOrThrow(HUNDRED)
-                val register = getInstruction(ringSizeLiteralIndex).registersUsed[0]
+            StoryRingBuilderFingerprint.let {
+                it.method.apply {
+                    val ringSizeLiteralIndex = it.instructionMatches[1].index
+                    val register = getInstruction(ringSizeLiteralIndex).registersUsed[0]
 
-                addInstructions(
-                    ringSizeLiteralIndex + 1,
-                    """
-                    $PREF_CALL_DESCRIPTOR->customiseStoryRingSize()F
-                    move-result v$register
-                    """.trimIndent(),
-                )
-                enableSettings("customiseStoryRingSize")
+                    addInstructions(
+                        ringSizeLiteralIndex + 1,
+                        """
+                            $PREF_CALL_DESCRIPTOR->customiseStoryRingSize()F
+                            move-result v$register
+                        """
+                    )
+                    enableSettings("customiseStoryRingSize")
+                }
             }
         }
     }


### PR DESCRIPTION
After the default settings value for this patch has been changed to 70, some users didn't know how to revert to the stock Instagram size, so I added the original value and instructions on how to set it in the settings screen.

Also, I removed the unnecessary ".0f" from the default value.
Since neither "." nor "f" can be entered in this setting, the ".0f" was meaningless.
I could allow decimal point input, but nobody would want to set the size down to the decimal point.

Furthermore, I changed `Float.valueOf()` to `Float.parseFloat()` because the IDE warned that the former was useless because it returns a non-primitive `Float` object.
I confirmed `parseFloat()` can parse "70.0f" and the size changes correctly.

---

p.s. This is the first time I've seen the code for the Instagram patches (Kotlin side).
I noticed that you're not using `instructionMatches` at all.
Do you know Morphe's instructionMatches feature?
This allows each element of the instruction filter of the fingerprint to be used later within a patch.

To demonstrate a practical use case for it, I've refactored this patch using instructionMatches.
Before the introduction of instruction filters, it was necessary to match a specific literal value (in this case, `100.0f`) using a custom fingerprint and then use `indexOfFirstLiteralInstruction` within the patch to search for that literal again.
But now, if you specify an instruction in the filter, you can directly access the filter's matched instructions within the patch.
Therefore, you can write the patch more concisely.
It's no longer needed to extract the literal `100.0f` as a constant.

Another example is my [ImportExportLoginTokenPatch.kt](https://github.com/crimera/piko/blob/b2ca52c692016d2808917b48be3bb9e14010e1e3/patches/src/main/kotlin/app/crimera/patches/twitter/misc/login/ImportExportLoginTokenPatch.kt#L39-L41).
Here, I used `it.instructionMatches.last().index` to add an instruction immediately after the move-result-object of the layout inflator calling and receive that result.

Instruction filters are one of Morphe's most distinctive features compared to the old Patcher.
<sup>It was also the direct cause of the split between ReVanced and Morphe.</sup>
This makes my experience writing patches in Morphe enjoyable.
I assume you will continue to develop new patches for Instagram, you can incorporate this new feature when you create a new patch.

For more details, please see here. (There is a point to note [when adding instructions for multiple matches](https://github.com/MorpheApp/morphe-patcher/blob/main/docs/2_2_1_fingerprinting.md#:~:text=Be%20careful%20if%20making%20more%20than%201%20modification%20to%20the%20same%20method%2E))
https://github.com/MorpheApp/morphe-patcher/blob/main/docs/2_2_1_fingerprinting.md

I just wanted to let you know in case you didn't know it yet.