### PR TITLE
feat(Instagram): Add `Clone` patch

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -18,8 +18,8 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import java.util.ArrayList;
 
+import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.utils.Pref;
-import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.entity.InstagramDialogBox;
 import app.morphe.extension.instagram.settings.ActivityHook;
 import app.morphe.extension.shared.Logger;
@@ -169,7 +169,7 @@ public class UI {
                         String selectedOption = options.get(which);
 
                         if (selectedOption.equals(Strings.GOTO_PIKO_SETTINGS)) {
-                            ActivityHook.openLink("instagram://profile");
+                            PikoUtils.openUrl("instagram://profile");
                         }
                     }
                 } catch (Exception e) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -85,7 +85,7 @@ public class MediaData extends Entity {
         return new UserData(userData);
     }
 
-    public HashSet getMentionSet() throws Exception {
+    public HashSet<UserData> getMentionSet() throws Exception {
         Object result =  super.getMethod(this.getExtendedData(), "methodName");
         if (result != null) {
             List userInteractionList = (List) result;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/story/ViewStoryMentionsPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/story/ViewStoryMentionsPatch.java
@@ -8,22 +8,16 @@
 package app.morphe.extension.instagram.patches.story;
 
 
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Set;
 import java.util.HashSet;
 import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 
+import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.shared.Utils;
 import app.morphe.extension.instagram.entity.InstagramDialogBox;
 import app.morphe.extension.instagram.entity.UserData;
 import app.morphe.extension.instagram.entity.MediaData;
-import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.constants.Strings;
-import app.morphe.extension.instagram.settings.ActivityHook;
 
 
 public class ViewStoryMentionsPatch {
@@ -35,10 +29,9 @@ public class ViewStoryMentionsPatch {
         } catch (Exception ex){
             Logger.printException(() -> "Failed viewMentions", ex);
         }
-        return;
     }
 
-    private static void showCopyDialog(final Context context,HashSet<UserData> mentionSet) throws Exception{
+    private static void showCopyDialog(final Context context,HashSet<UserData> mentionSet) {
         InstagramDialogBox dialog = new InstagramDialogBox(context);
 
         if(mentionSet!=null) {
@@ -52,13 +45,10 @@ public class ViewStoryMentionsPatch {
                 items[i] = userData.getFullname()+" ( @"+userData.getUsername()+")";
             }
 
-            dialog.addDialogMenuItems(items, new DialogInterface.OnClickListener() {
-                @Override
-                public void onClick(DialogInterface d, int which) {
-                    UserData userData = (UserData) snapshot[which];
-                    String username = userData.getUsername();
-                    ActivityHook.openLink("instagram://user?username="+username);
-                }
+            dialog.addDialogMenuItems(items, (d, which) -> {
+                UserData userData = (UserData) snapshot[which];
+                String username = userData.getUsername();
+                PikoUtils.openUrl("instagram://user?username="+username);
             });
         }else{
             dialog.setMessage(Strings.VSM_NO_MENTIONS);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
@@ -62,7 +62,7 @@ val clonePatch = resourcePatch(
 
     execute {
         val newPackageName = packageName!!
-        val providerReplacements = mutableSetOf<Pair<String, String>>()
+        val providerReplacements = mutableListOf<Pair<String, String>>()
 
         document("AndroidManifest.xml").use { document ->
             val manifest = document.documentElement

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
@@ -1,0 +1,170 @@
+package app.crimera.patches.instagram.misc.clone
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.patch.stringOption
+import app.morphe.util.asSequence
+import app.morphe.util.findElementByAttributeValue
+import app.morphe.util.findMutableMethodOf
+import app.morphe.util.forEachChildElement
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21c
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableStringReference
+import org.w3c.dom.Element
+import kotlin.collections.forEach
+
+private const val ORIGINAL_PACKAGE_NAME = "com.instagram.android"
+
+@Suppress("unused")
+val clonePatch = resourcePatch(
+    name = "Clone",
+    description = "Changes the package name and the app name. " +
+            "This allows you to install the patched app alongside the original Instagram app.\n" +
+            "Caution: Do not select the official Morphe's \"Change package name\" universal patch.",
+    default = false,
+) {
+    compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+    val packageName by stringOption(
+        key = "packageName",
+        default = "com.instagram.android.piko",
+        title = "Package name",
+        description = "A new package name for the patched app.",
+        required = true,
+    ) {
+        it!!.matches(Regex("^[a-z]\\w*(\\.[a-z]\\w*)+$"))
+    }
+
+    val appName by stringOption(
+        key = "appName",
+        default = "Piko Instagram",
+        title = "App name",
+        description = "A new app name (label). Entering \"Instagram\" will skip changing the app name.",
+        required = true,
+    )
+
+    var bytecodePatchContext: BytecodePatchContext? = null
+
+    dependsOn(
+        // Expose the bytecode context to use it within a ResourcePatch
+        bytecodePatch {
+            execute {
+                bytecodePatchContext = this
+            }
+        }
+    )
+
+    execute {
+        val newPackageName = packageName!!
+        val providerReplacements = mutableSetOf<Pair<String, String>>()
+
+        document("AndroidManifest.xml").use { document ->
+            val manifest = document.documentElement
+
+            // Change package name
+            manifest.setAttribute("package", newPackageName)
+
+            // Rename custom permissions
+            val permissions = manifest.getElementsByTagName("permission")
+            val usesPermissions = manifest.getElementsByTagName("uses-permission")
+
+            permissions.asSequence().map { it as Element }.forEach {
+                val oldName = it.getAttribute("android:name")
+                if (oldName.startsWith('.'))
+                    return@forEach
+                val newName = oldName.replace(ORIGINAL_PACKAGE_NAME, newPackageName)
+                it.setAttribute("android:name", newName)
+
+                // Rename a corresponding uses-permission as well if it exists
+                usesPermissions.findElementByAttributeValue("android:name", oldName)
+                    ?.setAttribute("android:name", newName)
+            }
+
+            // Rename provider authorities
+            val providers = manifest.getElementsByTagName("provider").asSequence().map { it as Element }
+            for (provider in providers) {
+                val oldAuthority = provider.getAttribute("android:authorities")
+                val newAuthority = if (oldAuthority.startsWith("$ORIGINAL_PACKAGE_NAME.")) {
+                    oldAuthority.replaceFirst(ORIGINAL_PACKAGE_NAME, newPackageName)
+                } else {
+                    "${newPackageName}_$oldAuthority"
+                }
+
+                provider.setAttribute("android:authorities", newAuthority)
+                providerReplacements.add(oldAuthority to newAuthority)
+            }
+        }
+
+        // Change app name
+        if (!appName.isNullOrEmpty() && appName != "Instagram") {
+            // The string "Instagram" is not localized and only exists in "values".
+            // Resource names vary depending on the build.
+            document("res/values/strings.xml").use { document ->
+                document.documentElement.forEachChildElement {
+                    if (it.textContent == "Instagram") {
+                        it.textContent = appName
+                    }
+                }
+            }
+        }
+
+        // Replace all instances of the string "com.instagram.android" in the bytecode to fix
+        // the issue where video stories only play audio.
+        // Also rename providers just in case.
+        context(bytecodePatchContext!!) {
+            transformStringReferences { string ->
+                if (string == ORIGINAL_PACKAGE_NAME)
+                    return@transformStringReferences newPackageName
+
+                val matchedReplacement = providerReplacements.find { string.contains(it.first) }
+                if (matchedReplacement == null)
+                    return@transformStringReferences null
+
+                val (oldAuthority, newAuthority) = matchedReplacement
+                return@transformStringReferences string.replaceFirst(oldAuthority, newAuthority)
+            }
+        }
+        bytecodePatchContext = null
+    }
+}
+
+// Taken from:
+// https://github.com/MorpheApp/morphe-patches/blob/a8a566774ec8b99c02ce60fdc81ff5258c3b0caf/patches/src/main/kotlin/app/morphe/patches/shared/misc/gms/GmsCoreSupportPatch.kt#L91
+// Slightly modified
+context(patchContext: BytecodePatchContext)
+private fun transformStringReferences(transform: (str: String) -> String?) {
+    patchContext.getAllClassesWithStrings().forEach { classDef ->
+        val mutableClass by lazy {
+            patchContext.mutableClassDefBy(classDef)
+        }
+
+        classDef.methods.forEach { method ->
+            val mutableMethod by lazy {
+                mutableClass.findMutableMethodOf(method)
+            }
+
+            method.implementation?.instructions?.forEachIndexed { index, instruction ->
+                val string = instruction.getReference<StringReference>()?.string
+                    ?: return@forEachIndexed
+
+                // Apply transformation.
+                val transformedString = transform(string) ?: return@forEachIndexed
+
+                mutableMethod.replaceInstruction(
+                    index,
+                    BuilderInstruction21c(
+                        Opcode.CONST_STRING,
+                        (instruction as OneRegisterInstruction).registerA,
+                        ImmutableStringReference(transformedString),
+                    )
+                )
+            }
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/clone/ClonePatch.kt
@@ -62,6 +62,8 @@ val clonePatch = resourcePatch(
 
     execute {
         val newPackageName = packageName!!
+
+        /** Pairs of the original authority and the renamed authority */
         val providerReplacements = mutableListOf<Pair<String, String>>()
 
         document("AndroidManifest.xml").use { document ->
@@ -123,11 +125,12 @@ val clonePatch = resourcePatch(
                     return@transformStringReferences newPackageName
 
                 val matchedReplacement = providerReplacements.find { string.contains(it.first) }
-                if (matchedReplacement == null)
-                    return@transformStringReferences null
 
-                val (oldAuthority, newAuthority) = matchedReplacement
-                return@transformStringReferences string.replaceFirst(oldAuthority, newAuthority)
+                if (matchedReplacement != null) {
+                    string.replaceFirst(matchedReplacement.first, matchedReplacement.second)
+                } else {
+                    null
+                }
             }
         }
         bytecodePatchContext = null


### PR DESCRIPTION
Supersedes PRs: #1259 #1261 #1262

Closes: #1037 #1094 #1098 #1164

This patch changes the package name and app name (label) of the app.
The differences from the official Morphe's "Change package name" universal patch are:

- Properly rename permissions and providers to prevent conflicts with the official app.
- Fixes the issue where video stories only play audio.
- Contains custom branding name functionality.

### About the name "Clone"

Initially, I was planning to follow the ReVanced/Morphe convention and create two patches: "Change package name" and "Custom branding name".
However, for the following reasons, I decided to combine them into a single “Clone” patch.

- In the Instagram modding community, the term "Clone" is commonly used.
- My guess is that no one would change the package name without changing the app name. So, there's no point in making the two patches selectable independently.

### Other matters to be discussed

Currently, the default values for this patch are as follows:

- Package name: `com.instagram.android.piko`
- App name: `Piko Instagram`

However, @Manishrdy had used the following name in a previous pull request:

- Package name: `com.pikogram.android`
- App name: `Pikogram`

In my case, since the name "Pikogram" is not used anywhere in the official piko project, I used the simpler name "Piko Instagram".
However, if Swak likes the name "Pikogram," we can switch to that instead, or any other names.
Please note that "Instagram Piko" is not recommended, as the AOSP launcher is likely to omit the string and make it indistinguishable as "Instagra...".

Also, this patch can includes the custom branding app icon feature in the future. But since Piko Instagram does not currently have any branding (logo), this is outside the scope of this pull request.