### PR TITLE
fix(Instagram): Warn when external downloader package is unset

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Strings.java
@@ -157,6 +157,7 @@ public class Strings {
     public static final String DOWNLOAD_WITH_EXTERNAL_DOWNLOADER = langInstance.DOWNLOAD_WITH_EXTERNAL_DOWNLOADER;
     public static final String EXTERNAL_DOWNLOADER_PACKAGE_NAME = langInstance.EXTERNAL_DOWNLOADER_PACKAGE_NAME;
     public static final String EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_FOUND = langInstance.EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_FOUND;
+    public static final String EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_SET = langInstance.EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_SET;
 
     public static final String POST_OPTIONS = langInstance.POST_OPTIONS;
     public static final String COPY_POST_DESCRIPTION = langInstance.COPY_POST_DESCRIPTION;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/translations/DefaultStrings.java
@@ -142,6 +142,7 @@ public class DefaultStrings {
     public static String DOWNLOAD_WITH_EXTERNAL_DOWNLOADER = "Download with external downloader";
     public static String EXTERNAL_DOWNLOADER_PACKAGE_NAME = "External downloader package name";
     public static String EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_FOUND = "External downloader package name not found";
+    public static String EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_SET = "Please set the external downloader package name";
 
     public static String POST_OPTIONS = "Post options";
     public static String COPY_POST_DESCRIPTION = "Copy post description";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
@@ -239,8 +239,13 @@ public class DownloadUtils {
 
     public static void externalDownloader(Object mediaObject, int currentMediaIndex){
         try {
-            String link = Links.generatePostLink(mediaObject, currentMediaIndex);
             String packageName = Pref.externalDownloaderPackageName();
+            packageName = packageName == null ? "" : packageName.trim();
+            if(packageName.isEmpty()){
+                PikoUtils.toast(Strings.EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_SET);
+                return;
+            }
+            String link = Links.generatePostLink(mediaObject, currentMediaIndex);
             ActivityHook.openLink(link, packageName);
         } catch (Exception e){
             PikoUtils.logger(e);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
@@ -82,15 +82,11 @@ public class ActivityHook {
         intent.setType("text/plain");
         intent.putExtra(Intent.EXTRA_TEXT, url);
         intent.setPackage(packageName);
-
-
-        try {
-            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-            PikoUtils.getContext().startActivity(intent);
+         try {
+            launchActivity(intent);
         } catch (Exception e) {
             PikoUtils.toast(Strings.EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_FOUND);
-            PikoUtils.logger(e);
+            Logger.printException(() -> "openLink failure", e);
         }
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
@@ -10,7 +10,6 @@ package app.morphe.extension.instagram.settings;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.content.ComponentName;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.constants.Strings;
@@ -86,10 +85,12 @@ public class ActivityHook {
 
 
         try {
-            launchActivity(intent);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            PikoUtils.getContext().startActivity(intent);
         } catch (Exception e) {
             PikoUtils.toast(Strings.EXTERNAL_DOWNLOADER_PACKAGE_NAME_NOT_FOUND);
-            Logger.printException(() -> "openLink failure", e);
+            PikoUtils.logger(e);
         }
     }
 


### PR DESCRIPTION
When "Download with external downloader" is enabled but the external downloader package name is empty, Piko still tries to launch an `ACTION_SEND` intent with an empty package name. That results in a generic Activity launch failure message instead of telling the user what needs to be configured.
This change checks the external downloader package name before generating the share link or launching the activity. If the package name is not set or only contains whitespace, Piko now shows a toast asking the user to set the external downloader package name and stops there. If a package name is set, the existing external downloader flow continues with the trimmed package name.

## Testing
- `.\gradlew.bat :patches:checkStringResources`