### PR TITLE
bump: Add `11.99.0-release.1` to supported versions list (Requires Piko-Shim)

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
@@ -13,25 +13,19 @@ object Constants {
             appIconColor = 0x000000,
             targets =
                 listOf(
-                    // Beta
-                    AppTarget(
-                        version = "11.80.0-alpha.1",
-                        description = "Last alpha version without PairIP protection",
-                    ),
-                    // Beta
-                    AppTarget(
-                        version = "11.82.0-beta.1",
-                        description = "Last beta version without PairIP protection",
-                    ),
-                    // Stable
                     AppTarget(
                         version = "11.81.0-release.0",
                         description = "Last stable version without PairIP protection",
                     ),
-                    // PairIP version
+                    // PairIP-ripped version
                     AppTarget(
                         version = "11.99.0-release-ripped.1",
                         description = "Make sure the APK is PairIP bypassed (Check the support group)",
+                    ),
+                    // Shim version, can be dropped once APKMirror uploads 12.0.0-release.0
+                    AppTarget(
+                        version = "11.99.0-release.1",
+                        description = "Requires Piko-Shim to be included",
                     ),
                     // Shim version
                     AppTarget(


### PR DESCRIPTION
A very quick hotfix.

The upload of version 12.0.0 on APKMirror is delayed.
And APKs of 12.0.0 uploaded to other websites are unstable because they often lack dpi, architecture, and language splits.

The target version `11.99.0-release.1` is also included in Piko-Shim patches, so it works well when they are combined.

Tested on my phone.