### PR TITLE
feat(Instagram): Make ghost mode quick toggle locations customizable

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -47,6 +47,7 @@ public class UI {
     public static final String DRAWABLE_CODE_ICON = "fb_ic_code_outline_24";
     public static final String DRAWABLE_FRAME_CROSSED_ICON = "fb_ic_frames_cross_outline_16";
     public static final String DRAWABLE_LINK_ICON = "fb_ic_link_outline_24";
+    public static final String PIKO_SETTINGS_GEAR_TAG = "piko_settings_action_bar_button";
 
 
     public static int getThemedColour() {
@@ -112,9 +113,29 @@ public class UI {
         return null;
     }
 
+    public static View findDirectChildWithTag(ViewGroup viewGroup, Object tag) {
+        if (viewGroup == null || tag == null) {
+            return null;
+        }
+
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            if (tag.equals(child.getTag())) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+
     public static void pikoSettingsGear(ViewGroup viewGroup) {
         try {
             if (viewGroup == null) {
+                return;
+            }
+
+            View existingView = findDirectChildWithTag(viewGroup, PIKO_SETTINGS_GEAR_TAG);
+            if (existingView instanceof ImageView) {
                 return;
             }
 
@@ -122,6 +143,7 @@ public class UI {
             if (imageView == null) {
                 return;
             }
+            imageView.setTag(PIKO_SETTINGS_GEAR_TAG);
 
             Context context = viewGroup.getContext();
             boolean isFirstTime = Pref.firstTimePiko();

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/DMActionBar.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/DMActionBar.java
@@ -7,50 +7,14 @@
 
 package app.morphe.extension.instagram.patches.actionbar;
 
-import static app.morphe.extension.instagram.utils.IgStr.str;
-
-import android.content.Context;
-import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 
-import app.morphe.extension.shared.Utils;
-import app.morphe.extension.instagram.settings.SettingsStatus;
-import app.morphe.extension.instagram.utils.Pref;
 import app.morphe.extension.shared.Logger;
-import app.morphe.extension.instagram.constants.UI;
 
 public class DMActionBar {
-    private static final String HIDE_ICON_NAME = "design_ic_visibility_off";
-    private static final String SHOW_ICON_NAME = "design_ic_visibility";
-
     public static void addActionBarButton(ViewGroup viewGroup) {
         try {
-            boolean togglePreference = Pref.enableGhostModeQuickToggle();
-            boolean hasGhostSection = SettingsStatus.ghostSection();
-            if(togglePreference && hasGhostSection){
-                boolean ghostModeToggle = Pref.getTurnOnAllGhostModes();
-
-                String iconStr = ghostModeToggle ? HIDE_ICON_NAME:SHOW_ICON_NAME;
-                ImageView imageView = UI.addImageViewToViewGroup(viewGroup, iconStr, null);
-                imageView.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        try {
-                            boolean ghostModeToggle= !Pref.getTurnOnAllGhostModes();
-                            String iconStr = ghostModeToggle ? HIDE_ICON_NAME:SHOW_ICON_NAME;
-                            Pref.setTurnOnAllGhostModes(ghostModeToggle);
-                            UI.setThemedIcon(imageView,iconStr);
-
-                            String toastStr = ghostModeToggle ? str("piko_ghost_modes_on") : str("piko_ghost_modes_default");
-                            Utils.showToastShort(toastStr);
-                        } catch (Exception ex) {
-                            Logger.printException(() -> "ghost icon click failed: ", ex);
-                        }
-                    }
-                });
-            }
-
+            GhostModeQuickToggle.addToDirectThreadActionBar(viewGroup);
         } catch (Exception e) {
             Logger.printException(() -> "addActionBarButton failure", e);
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/GhostModeQuickToggle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/GhostModeQuickToggle.java
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2026 piko <https://github.com/crimera/piko>
  *
- * See the included NOTICE file for GPLv3 Section 7(b) terms that apply to this code.
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
  */
 
 package app.morphe.extension.instagram.patches.actionbar;
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.WeakHashMap;
 
 import app.morphe.extension.instagram.constants.UI;
+import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.utils.Pref;
 import app.morphe.extension.shared.Logger;
@@ -42,10 +43,14 @@ public class GhostModeQuickToggle {
     private static final String ACTION_BAR_VIEW_TAG = "piko_ghost_mode_quick_toggle_action_bar";
     private static final int DIRECT_INBOX_MODEL_OFFSET_DP = 10;
     private static final int MAX_NATIVE_ANCHOR_SIZE_DP = 96;
-    private static final String DIRECT_INBOX_LEADING_CLASS_NAME = "X.5Sf";
-    private static final String DIRECT_INBOX_TITLE_CLASS_NAME = "X.L6U";
-    private static final String DIRECT_INBOX_ACTION_CLASS_NAME = "X.5Sp";
-    private static final String DIRECT_INBOX_PLACEMENT_CLASS_NAME = "X.5So";
+    private static final String DIRECT_INBOX_LEADING_CLASS_NAME = "directInboxLeadingClassName";
+    private static final String DIRECT_INBOX_TITLE_CLASS_NAME = "directInboxTitleClassName";
+    private static final String DIRECT_INBOX_ACTION_CLASS_NAME = "directInboxActionClassName";
+    private static final String DIRECT_INBOX_PLACEMENT_CLASS_NAME = "directInboxPlacementClassName";
+    private static final String DIRECT_INBOX_MODEL_LEADING_FIELD_NAME = "directInboxModelLeadingFieldName";
+    private static final String DIRECT_INBOX_MODEL_TITLE_FIELD_NAME = "directInboxModelTitleFieldName";
+    private static final String DIRECT_INBOX_MODEL_ACTIONS_FIELD_NAME = "directInboxModelActionsFieldName";
+    private static final String DIRECT_INBOX_ACTION_PLACEMENT_FIELD_NAME = "directInboxActionPlacementFieldName";
     private static final ArrayList<WeakReference<ImageView>> BUTTONS = new ArrayList<>();
     private static final Set<ViewGroup> HOME_ACTION_BARS =
             Collections.newSetFromMap(new WeakHashMap<ViewGroup, Boolean>());
@@ -202,13 +207,11 @@ public class GhostModeQuickToggle {
             Class<?> actionClass = Class.forName(DIRECT_INBOX_ACTION_CLASS_NAME, false, classLoader);
             Class<?> placementClass = Class.forName(DIRECT_INBOX_PLACEMENT_CLASS_NAME, false, classLoader);
             Object endPlacement = Enum.valueOf((Class<Enum>) placementClass.asSubclass(Enum.class), "END");
-            Field leadingField = declaredUniqueFieldByType(modelClass, leadingClass);
-            Field titleField = declaredUniqueFieldByType(modelClass, titleClass);
-            Field actionsField = declaredActionListField(modelClass, actionBarModel, actionClass);
+            Entity modelEntity = new Entity(actionBarModel);
 
-            Object leading = leadingField.get(actionBarModel);
-            Object title = titleField.get(actionBarModel);
-            Object actionsObject = actionsField.get(actionBarModel);
+            Object leading = modelEntity.getField(DIRECT_INBOX_MODEL_LEADING_FIELD_NAME);
+            Object title = modelEntity.getField(DIRECT_INBOX_MODEL_TITLE_FIELD_NAME);
+            Object actionsObject = modelEntity.getField(DIRECT_INBOX_MODEL_ACTIONS_FIELD_NAME);
             if (!(actionsObject instanceof List)) {
                 return actionBarModel;
             }
@@ -232,7 +235,6 @@ public class GhostModeQuickToggle {
             int insertIndex = findDirectInboxInsertIndex(
                     newActions,
                     actionClass,
-                    placementClass,
                     endPlacement
             );
             newActions.add(insertIndex, pikoAction);
@@ -460,14 +462,13 @@ public class GhostModeQuickToggle {
     private static int findDirectInboxInsertIndex(
             List<?> actions,
             Class<?> actionClass,
-            Class<?> placementClass,
             Object endPlacement
     ) {
         try {
-            Field placementField = declaredUniqueFieldByType(actionClass, placementClass);
             for (int i = actions.size() - 1; i >= 0; i--) {
                 Object action = actions.get(i);
-                if (actionClass.isInstance(action) && endPlacement.equals(placementField.get(action))) {
+                if (actionClass.isInstance(action)
+                        && endPlacement.equals(new Entity(action).getField(DIRECT_INBOX_ACTION_PLACEMENT_FIELD_NAME))) {
                     return i;
                 }
             }
@@ -588,101 +589,6 @@ public class GhostModeQuickToggle {
             ViewGroup viewGroup = (ViewGroup) parent;
             viewGroup.removeView(view);
         }
-    }
-
-    private static Field declaredUniqueFieldByType(Class<?> cls, Class<?> fieldType) throws NoSuchFieldException {
-        Field match = null;
-        for (Field field : cls.getDeclaredFields()) {
-            if (fieldType.isAssignableFrom(field.getType())) {
-                if (match != null) {
-                    throw new NoSuchFieldException("Multiple " + fieldType.getName() + " fields in " + cls.getName());
-                }
-                match = field;
-            }
-        }
-
-        if (match == null) {
-            throw new NoSuchFieldException(fieldType.getName());
-        }
-
-        match.setAccessible(true);
-        return match;
-    }
-
-    private static Field declaredActionListField(
-            Class<?> cls,
-            Object instance,
-            Class<?> actionClass
-    ) throws NoSuchFieldException, IllegalAccessException {
-        Field onlyListField = null;
-        Field onlyEmptyListField = null;
-        int listFieldCount = 0;
-        int emptyListFieldCount = 0;
-
-        for (Field field : cls.getDeclaredFields()) {
-            if (!List.class.isAssignableFrom(field.getType())) {
-                continue;
-            }
-
-            listFieldCount++;
-            field.setAccessible(true);
-            Object value = field.get(instance);
-            if (value instanceof List) {
-                List<?> list = (List<?>) value;
-                if (isNonEmptyActionList(list, directInboxActionListItemClass(actionClass))) {
-                    return field;
-                }
-
-                if (list.isEmpty()) {
-                    emptyListFieldCount++;
-                    onlyEmptyListField = field;
-                }
-            }
-
-            onlyListField = field;
-        }
-
-        if (emptyListFieldCount == 1 && onlyEmptyListField != null) {
-            return onlyEmptyListField;
-        }
-
-        if (listFieldCount == 1 && onlyListField != null) {
-            return onlyListField;
-        }
-
-        throw new NoSuchFieldException("action list in " + cls.getName());
-    }
-
-    private static Class<?> directInboxActionListItemClass(Class<?> actionClass) {
-        for (Class<?> iface : actionClass.getInterfaces()) {
-            String name = iface.getName();
-            if (!name.startsWith("java.") && !name.startsWith("kotlin.")) {
-                return iface;
-            }
-        }
-
-        return actionClass;
-    }
-
-    private static boolean isNonEmptyActionList(List<?> list, Class<?> listItemClass) {
-        if (list.isEmpty()) {
-            return false;
-        }
-
-        boolean hasAction = false;
-        for (Object item : list) {
-            if (item == null) {
-                continue;
-            }
-
-            if (!listItemClass.isInstance(item)) {
-                return false;
-            }
-
-            hasAction = true;
-        }
-
-        return hasAction;
     }
 
     private static int iconResId() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/GhostModeQuickToggle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/GhostModeQuickToggle.java
@@ -1,0 +1,740 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 Section 7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.actionbar;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import android.content.Context;
+import android.os.Looper;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+import android.widget.ImageView;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
+
+import app.morphe.extension.instagram.constants.UI;
+import app.morphe.extension.instagram.settings.SettingsStatus;
+import app.morphe.extension.instagram.utils.Pref;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+
+public class GhostModeQuickToggle {
+    private static final String HIDE_ICON_NAME = "design_ic_visibility_off";
+    private static final String SHOW_ICON_NAME = "design_ic_visibility";
+    private static final String ACTION_BAR_VIEW_TAG = "piko_ghost_mode_quick_toggle_action_bar";
+    private static final int DIRECT_INBOX_MODEL_OFFSET_DP = 10;
+    private static final int MAX_NATIVE_ANCHOR_SIZE_DP = 96;
+    private static final String DIRECT_INBOX_LEADING_CLASS_NAME = "X.5Sf";
+    private static final String DIRECT_INBOX_TITLE_CLASS_NAME = "X.L6U";
+    private static final String DIRECT_INBOX_ACTION_CLASS_NAME = "X.5Sp";
+    private static final String DIRECT_INBOX_PLACEMENT_CLASS_NAME = "X.5So";
+    private static final ArrayList<WeakReference<ImageView>> BUTTONS = new ArrayList<>();
+    private static final Set<ViewGroup> HOME_ACTION_BARS =
+            Collections.newSetFromMap(new WeakHashMap<ViewGroup, Boolean>());
+    private static final Set<ViewGroup> DIRECT_THREAD_ACTION_BARS =
+            Collections.newSetFromMap(new WeakHashMap<ViewGroup, Boolean>());
+    private static final Set<Object> DIRECT_INBOX_ACTIONS =
+            Collections.newSetFromMap(new WeakHashMap<Object, Boolean>());
+    private static final Set<ViewGroup> PENDING_ACTION_BAR_ORDER_UPDATES =
+            Collections.newSetFromMap(new WeakHashMap<ViewGroup, Boolean>());
+
+    public static void addToHomeActionBar(ViewGroup viewGroup) {
+        trackActionBar(HOME_ACTION_BARS, viewGroup);
+        addToActionBar(viewGroup, Pref.showGhostModeQuickToggleHome());
+    }
+
+    public static void addToDirectThreadActionBar(ViewGroup viewGroup) {
+        trackActionBar(DIRECT_THREAD_ACTION_BARS, viewGroup);
+        addToActionBar(viewGroup, Pref.showGhostModeQuickToggleDirectThread());
+    }
+
+    public static void refreshActionBarButtons() {
+        refreshActionBars(HOME_ACTION_BARS, Pref.showGhostModeQuickToggleHome(), true);
+        refreshActionBars(DIRECT_THREAD_ACTION_BARS, Pref.showGhostModeQuickToggleDirectThread(), false);
+    }
+
+    private static void trackActionBar(Set<ViewGroup> actionBars, ViewGroup viewGroup) {
+        if (viewGroup == null) {
+            return;
+        }
+
+        synchronized (actionBars) {
+            actionBars.add(viewGroup);
+        }
+    }
+
+    private static void refreshActionBars(
+            Set<ViewGroup> actionBars,
+            final boolean showOnSurface,
+            final boolean keepOrderStable
+    ) {
+        ArrayList<ViewGroup> snapshot;
+        synchronized (actionBars) {
+            snapshot = new ArrayList<>(actionBars);
+        }
+
+        for (final ViewGroup viewGroup : snapshot) {
+            if (viewGroup == null) {
+                continue;
+            }
+
+            Runnable refresh = new Runnable() {
+                @Override
+                public void run() {
+                    addToActionBar(viewGroup, showOnSurface);
+                    if (keepOrderStable) {
+                        keepActionBarButtonOrderStable(viewGroup);
+                    }
+                }
+            };
+
+            if (Looper.myLooper() == Looper.getMainLooper()) {
+                refresh.run();
+            } else if (!viewGroup.post(refresh)) {
+                refresh.run();
+            }
+        }
+    }
+
+    private static void addToActionBar(ViewGroup viewGroup, boolean showOnSurface) {
+        try {
+            if (viewGroup == null) {
+                return;
+            }
+
+            View existingView = UI.findDirectChildWithTag(viewGroup, ACTION_BAR_VIEW_TAG);
+            if (!shouldShow(showOnSurface)) {
+                removeExisting(existingView);
+                return;
+            }
+
+            if (iconResId() == 0) {
+                removeExisting(existingView);
+                return;
+            }
+
+            if (existingView instanceof ImageView) {
+                ImageView imageView = (ImageView) existingView;
+                registerButton(imageView);
+                updateIcon(imageView);
+                return;
+            }
+
+            ImageView imageView = UI.addImageViewToViewGroup(viewGroup, currentIcon(), null);
+            if (imageView == null) {
+                return;
+            }
+
+            prepareActionBarButton(imageView);
+        } catch (Exception e) {
+            Logger.printException(() -> "add ghost mode quick toggle failure", e);
+        }
+    }
+
+    public static void keepActionBarButtonOrderStable(final ViewGroup viewGroup) {
+        if (viewGroup == null) {
+            return;
+        }
+
+        if (hasMeasuredDirectChild(viewGroup)) {
+            stabilizeActionBarOrder(viewGroup);
+        }
+
+        postActionBarOrderUpdate(viewGroup);
+    }
+
+    private static void postActionBarOrderUpdate(final ViewGroup viewGroup) {
+        synchronized (PENDING_ACTION_BAR_ORDER_UPDATES) {
+            if (PENDING_ACTION_BAR_ORDER_UPDATES.contains(viewGroup)) {
+                return;
+            }
+            PENDING_ACTION_BAR_ORDER_UPDATES.add(viewGroup);
+        }
+
+        boolean posted = viewGroup.post(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    stabilizeActionBarOrder(viewGroup);
+                } finally {
+                    synchronized (PENDING_ACTION_BAR_ORDER_UPDATES) {
+                        PENDING_ACTION_BAR_ORDER_UPDATES.remove(viewGroup);
+                    }
+                }
+            }
+        });
+        if (!posted) {
+            synchronized (PENDING_ACTION_BAR_ORDER_UPDATES) {
+                PENDING_ACTION_BAR_ORDER_UPDATES.remove(viewGroup);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Object addDirectInboxActionModel(Object actionBarModel) {
+        try {
+            if (actionBarModel == null || !shouldShow(Pref.showGhostModeQuickToggleDirectInbox())) {
+                return actionBarModel;
+            }
+
+            Class<?> modelClass = actionBarModel.getClass();
+            ClassLoader classLoader = modelClass.getClassLoader();
+            Class<?> leadingClass = Class.forName(DIRECT_INBOX_LEADING_CLASS_NAME, false, classLoader);
+            Class<?> titleClass = Class.forName(DIRECT_INBOX_TITLE_CLASS_NAME, false, classLoader);
+            Class<?> actionClass = Class.forName(DIRECT_INBOX_ACTION_CLASS_NAME, false, classLoader);
+            Class<?> placementClass = Class.forName(DIRECT_INBOX_PLACEMENT_CLASS_NAME, false, classLoader);
+            Object endPlacement = Enum.valueOf((Class<Enum>) placementClass.asSubclass(Enum.class), "END");
+            Field leadingField = declaredUniqueFieldByType(modelClass, leadingClass);
+            Field titleField = declaredUniqueFieldByType(modelClass, titleClass);
+            Field actionsField = declaredActionListField(modelClass, actionBarModel, actionClass);
+
+            Object leading = leadingField.get(actionBarModel);
+            Object title = titleField.get(actionBarModel);
+            Object actionsObject = actionsField.get(actionBarModel);
+            if (!(actionsObject instanceof List)) {
+                return actionBarModel;
+            }
+
+            List<?> actions = (List<?>) actionsObject;
+            if (containsDirectInboxAction(actions)) {
+                return actionBarModel;
+            }
+
+            ArrayList<Object> newActions = new ArrayList<>(actions);
+            Object pikoAction = createDirectInboxAction(
+                    classLoader,
+                    actionClass,
+                    placementClass,
+                    endPlacement
+            );
+            if (pikoAction == null) {
+                return actionBarModel;
+            }
+
+            int insertIndex = findDirectInboxInsertIndex(
+                    newActions,
+                    actionClass,
+                    placementClass,
+                    endPlacement
+            );
+            newActions.add(insertIndex, pikoAction);
+            synchronized (DIRECT_INBOX_ACTIONS) {
+                DIRECT_INBOX_ACTIONS.add(pikoAction);
+            }
+
+            Constructor<?> constructor = modelClass.getDeclaredConstructor(
+                    leadingClass,
+                    titleClass,
+                    List.class
+            );
+            constructor.setAccessible(true);
+            return constructor.newInstance(leading, title, newActions);
+        } catch (Exception e) {
+            Logger.printException(() -> "add direct inbox ghost mode action failure", e);
+            return actionBarModel;
+        }
+    }
+
+    private static Object createDirectInboxAction(
+            final ClassLoader classLoader,
+            Class<?> actionClass,
+            Class<?> placementClass,
+            Object placement
+    ) {
+        try {
+            int iconResId = iconResId();
+            if (iconResId == 0) {
+                return null;
+            }
+
+            Class<?> function0Class = Class.forName("kotlin.jvm.functions.Function0", false, classLoader);
+            Class<?> function1Class = Class.forName("kotlin.jvm.functions.Function1", false, classLoader);
+
+            Object clickAction = Proxy.newProxyInstance(
+                    classLoader,
+                    new Class<?>[]{function1Class},
+                    new InvocationHandler() {
+                        @Override
+                        public Object invoke(Object proxy, Method method, Object[] args) {
+                            if (isObjectMethod(method)) {
+                                return handleObjectMethod(proxy, method, args);
+                            }
+
+                            if (isInvokeCall(method, args, 1)) {
+                                toggle();
+                                return kotlinUnit(classLoader);
+                            }
+
+                            return null;
+                        }
+                    }
+            );
+            Object bindAction = Proxy.newProxyInstance(
+                    classLoader,
+                    new Class<?>[]{function1Class},
+                    new InvocationHandler() {
+                        @Override
+                        public Object invoke(Object proxy, Method method, Object[] args) {
+                            if (isObjectMethod(method)) {
+                                return handleObjectMethod(proxy, method, args);
+                            }
+
+                            if (isInvokeCall(method, args, 1)) {
+                                bindDirectInboxButton(args[0]);
+                                return kotlinUnit(classLoader);
+                            }
+
+                            return null;
+                        }
+                    }
+            );
+
+            Constructor<?> constructor = actionClass.getDeclaredConstructor(
+                    placementClass,
+                    Integer.class,
+                    function0Class,
+                    function1Class,
+                    function1Class,
+                    int.class
+            );
+            constructor.setAccessible(true);
+            return constructor.newInstance(
+                    placement,
+                    titleResId(),
+                    null,
+                    clickAction,
+                    bindAction,
+                    iconResId
+            );
+        } catch (Exception e) {
+            Logger.printException(() -> "create direct inbox ghost mode action failure", e);
+            return null;
+        }
+    }
+
+    private static void bindDirectInboxButton(Object view) {
+        if (!(view instanceof ImageView)) {
+            return;
+        }
+
+        ImageView imageView = (ImageView) view;
+        registerButton(imageView);
+        updateIcon(imageView);
+        imageView.setContentDescription(str("piko_ghost_modes_quick_toggle"));
+        allowTranslatedButtonOverflow(imageView);
+        applyDirectInboxTranslation(imageView);
+    }
+
+    private static void applyDirectInboxTranslation(ImageView imageView) {
+        int offset = dp(imageView.getContext(), DIRECT_INBOX_MODEL_OFFSET_DP);
+        imageView.setTranslationX(imageView.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL ? offset : -offset);
+    }
+
+    // The inbox action slot clips translated icons unless the nearby parent chain allows overflow.
+    private static void allowTranslatedButtonOverflow(View view) {
+        ViewParent parent = view.getParent();
+        for (int depth = 0; parent instanceof ViewGroup && depth < 3; depth++) {
+            ViewGroup viewGroup = (ViewGroup) parent;
+            viewGroup.setClipChildren(false);
+            viewGroup.setClipToPadding(false);
+            parent = viewGroup.getParent();
+        }
+    }
+
+    private static void prepareActionBarButton(final ImageView imageView) {
+        imageView.setTag(ACTION_BAR_VIEW_TAG);
+        imageView.setContentDescription(str("piko_ghost_modes_quick_toggle"));
+        registerButton(imageView);
+        updateIcon(imageView);
+        imageView.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                toggle();
+            }
+        });
+    }
+
+    private static void toggle() {
+        try {
+            boolean enabled = !Pref.getTurnOnAllGhostModes();
+            Pref.setTurnOnAllGhostModes(enabled);
+            updateAllIcons(enabled);
+
+            String toastStr = enabled ? str("piko_ghost_modes_on") : str("piko_ghost_modes_default");
+            Utils.showToastShort(toastStr);
+        } catch (Exception ex) {
+            Logger.printException(() -> "ghost icon click failed: ", ex);
+        }
+    }
+
+    private static boolean shouldShow() {
+        return Pref.enableGhostModeQuickToggle() && SettingsStatus.ghostSection();
+    }
+
+    private static boolean shouldShow(boolean showOnSurface) {
+        return showOnSurface && shouldShow();
+    }
+
+    private static String currentIcon() {
+        return currentIcon(Pref.getTurnOnAllGhostModes());
+    }
+
+    private static String currentIcon(boolean enabled) {
+        return enabled ? HIDE_ICON_NAME : SHOW_ICON_NAME;
+    }
+
+    private static void updateIcon(ImageView imageView) {
+        updateIcon(imageView, Pref.getTurnOnAllGhostModes());
+    }
+
+    private static void updateIcon(ImageView imageView, boolean enabled) {
+        UI.setThemedIcon(imageView, currentIcon(enabled));
+        imageView.setSelected(enabled);
+        imageView.setActivated(enabled);
+        imageView.refreshDrawableState();
+        imageView.invalidate();
+    }
+
+    private static void updateAllIcons(boolean enabled) {
+        synchronized (BUTTONS) {
+            for (int i = BUTTONS.size() - 1; i >= 0; i--) {
+                ImageView button = BUTTONS.get(i).get();
+                if (button == null || button.getParent() == null) {
+                    BUTTONS.remove(i);
+                    continue;
+                }
+
+                updateIcon(button, enabled);
+            }
+        }
+    }
+
+    private static void registerButton(ImageView imageView) {
+        synchronized (BUTTONS) {
+            for (int i = BUTTONS.size() - 1; i >= 0; i--) {
+                ImageView button = BUTTONS.get(i).get();
+                if (button == null || button.getParent() == null) {
+                    BUTTONS.remove(i);
+                    continue;
+                }
+
+                if (button == imageView) {
+                    return;
+                }
+            }
+
+            BUTTONS.add(new WeakReference<>(imageView));
+        }
+    }
+
+    private static boolean containsDirectInboxAction(List<?> actions) {
+        synchronized (DIRECT_INBOX_ACTIONS) {
+            for (Object action : actions) {
+                if (DIRECT_INBOX_ACTIONS.contains(action)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private static int findDirectInboxInsertIndex(
+            List<?> actions,
+            Class<?> actionClass,
+            Class<?> placementClass,
+            Object endPlacement
+    ) {
+        try {
+            Field placementField = declaredUniqueFieldByType(actionClass, placementClass);
+            for (int i = actions.size() - 1; i >= 0; i--) {
+                Object action = actions.get(i);
+                if (actionClass.isInstance(action) && endPlacement.equals(placementField.get(action))) {
+                    return i;
+                }
+            }
+        } catch (Exception e) {
+            Logger.printException(() -> "find direct inbox action insert index failure", e);
+        }
+
+        return Math.max(0, actions.size() - 1);
+    }
+
+    private static void stabilizeActionBarOrder(ViewGroup viewGroup) {
+        View ghostButton = UI.findDirectChildWithTag(viewGroup, ACTION_BAR_VIEW_TAG);
+        View settingsButton = UI.findDirectChildWithTag(viewGroup, UI.PIKO_SETTINGS_GEAR_TAG);
+        if (ghostButton == null && settingsButton == null) {
+            return;
+        }
+
+        View anchor = findTrailingNativeButton(viewGroup, ghostButton, settingsButton);
+        removeDirectChild(viewGroup, ghostButton);
+        removeDirectChild(viewGroup, settingsButton);
+
+        int insertIndex = anchor != null && anchor.getParent() == viewGroup
+                ? viewGroup.indexOfChild(anchor)
+                : viewGroup.getChildCount();
+
+        insertIndex = addDirectChild(viewGroup, ghostButton, insertIndex);
+        addDirectChild(viewGroup, settingsButton, insertIndex);
+
+        viewGroup.requestLayout();
+        viewGroup.invalidate();
+    }
+
+    private static View findTrailingNativeButton(ViewGroup viewGroup, View ghostButton, View settingsButton) {
+        View rightmostButton = findRightmostCompactNativeButton(viewGroup, ghostButton, settingsButton);
+        if (rightmostButton != null) {
+            return rightmostButton;
+        }
+
+        for (int i = viewGroup.getChildCount() - 1; i >= 0; i--) {
+            View child = viewGroup.getChildAt(i);
+            if (child != ghostButton && child != settingsButton) {
+                return child;
+            }
+        }
+
+        return null;
+    }
+
+    private static View findRightmostCompactNativeButton(ViewGroup viewGroup, View ghostButton, View settingsButton) {
+        int maxSize = dp(viewGroup.getContext(), MAX_NATIVE_ANCHOR_SIZE_DP);
+        View bestView = null;
+        float bestRight = Float.NEGATIVE_INFINITY;
+
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            if (!isCompactNativeChild(child, ghostButton, settingsButton, maxSize)) {
+                continue;
+            }
+
+            float right = child.getX() + child.getWidth();
+            if (right > bestRight) {
+                bestRight = right;
+                bestView = child;
+            }
+        }
+
+        return bestView;
+    }
+
+    private static boolean isCompactNativeChild(View child, View ghostButton, View settingsButton, int maxSize) {
+        if (child == null || child == ghostButton || child == settingsButton) {
+            return false;
+        }
+
+        if (child.getVisibility() != View.VISIBLE) {
+            return false;
+        }
+
+        int width = child.getWidth();
+        int height = child.getHeight();
+        return width > 0 && height > 0 && width <= maxSize && height <= maxSize;
+    }
+
+    private static boolean hasMeasuredDirectChild(ViewGroup viewGroup) {
+        for (int i = 0; i < viewGroup.getChildCount(); i++) {
+            View child = viewGroup.getChildAt(i);
+            if (child.getWidth() > 0 && child.getHeight() > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void removeDirectChild(ViewGroup viewGroup, View child) {
+        if (child != null && child.getParent() == viewGroup) {
+            viewGroup.removeView(child);
+        }
+    }
+
+    private static int addDirectChild(ViewGroup viewGroup, View child, int requestedIndex) {
+        if (child == null) {
+            return requestedIndex;
+        }
+
+        int insertIndex = Math.max(0, Math.min(requestedIndex, viewGroup.getChildCount()));
+        viewGroup.addView(child, insertIndex);
+        return insertIndex + 1;
+    }
+
+    private static void removeExisting(View view) {
+        if (view == null) {
+            return;
+        }
+
+        ViewParent parent = view.getParent();
+        if (parent instanceof ViewGroup) {
+            ViewGroup viewGroup = (ViewGroup) parent;
+            viewGroup.removeView(view);
+        }
+    }
+
+    private static Field declaredUniqueFieldByType(Class<?> cls, Class<?> fieldType) throws NoSuchFieldException {
+        Field match = null;
+        for (Field field : cls.getDeclaredFields()) {
+            if (fieldType.isAssignableFrom(field.getType())) {
+                if (match != null) {
+                    throw new NoSuchFieldException("Multiple " + fieldType.getName() + " fields in " + cls.getName());
+                }
+                match = field;
+            }
+        }
+
+        if (match == null) {
+            throw new NoSuchFieldException(fieldType.getName());
+        }
+
+        match.setAccessible(true);
+        return match;
+    }
+
+    private static Field declaredActionListField(
+            Class<?> cls,
+            Object instance,
+            Class<?> actionClass
+    ) throws NoSuchFieldException, IllegalAccessException {
+        Field onlyListField = null;
+        Field onlyEmptyListField = null;
+        int listFieldCount = 0;
+        int emptyListFieldCount = 0;
+
+        for (Field field : cls.getDeclaredFields()) {
+            if (!List.class.isAssignableFrom(field.getType())) {
+                continue;
+            }
+
+            listFieldCount++;
+            field.setAccessible(true);
+            Object value = field.get(instance);
+            if (value instanceof List) {
+                List<?> list = (List<?>) value;
+                if (isNonEmptyActionList(list, directInboxActionListItemClass(actionClass))) {
+                    return field;
+                }
+
+                if (list.isEmpty()) {
+                    emptyListFieldCount++;
+                    onlyEmptyListField = field;
+                }
+            }
+
+            onlyListField = field;
+        }
+
+        if (emptyListFieldCount == 1 && onlyEmptyListField != null) {
+            return onlyEmptyListField;
+        }
+
+        if (listFieldCount == 1 && onlyListField != null) {
+            return onlyListField;
+        }
+
+        throw new NoSuchFieldException("action list in " + cls.getName());
+    }
+
+    private static Class<?> directInboxActionListItemClass(Class<?> actionClass) {
+        for (Class<?> iface : actionClass.getInterfaces()) {
+            String name = iface.getName();
+            if (!name.startsWith("java.") && !name.startsWith("kotlin.")) {
+                return iface;
+            }
+        }
+
+        return actionClass;
+    }
+
+    private static boolean isNonEmptyActionList(List<?> list, Class<?> listItemClass) {
+        if (list.isEmpty()) {
+            return false;
+        }
+
+        boolean hasAction = false;
+        for (Object item : list) {
+            if (item == null) {
+                continue;
+            }
+
+            if (!listItemClass.isInstance(item)) {
+                return false;
+            }
+
+            hasAction = true;
+        }
+
+        return hasAction;
+    }
+
+    private static int iconResId() {
+        return ResourceUtils.getIdentifier(ResourceType.DRAWABLE, currentIcon());
+    }
+
+    private static Integer titleResId() {
+        int resId = ResourceUtils.getIdentifier(ResourceType.STRING, "piko_ghost_modes_quick_toggle");
+        return resId == 0 ? null : resId;
+    }
+
+    private static int dp(Context context, int value) {
+        return (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP,
+                value,
+                context.getResources().getDisplayMetrics()
+        );
+    }
+
+    private static boolean isObjectMethod(Method method) {
+        return method.getDeclaringClass() == Object.class;
+    }
+
+    private static boolean isInvokeCall(Method method, Object[] args, int argumentCount) {
+        return "invoke".equals(method.getName()) && args != null && args.length == argumentCount;
+    }
+
+    private static Object handleObjectMethod(Object proxy, Method method, Object[] args) {
+        String name = method.getName();
+        if ("toString".equals(name)) {
+            return "PikoGhostModeQuickToggleProxy";
+        }
+
+        if ("hashCode".equals(name)) {
+            return System.identityHashCode(proxy);
+        }
+
+        if ("equals".equals(name)) {
+            return args != null && args.length > 0 && proxy == args[0];
+        }
+
+        return null;
+    }
+
+    private static Object kotlinUnit(ClassLoader classLoader) {
+        try {
+            Class<?> unitClass = Class.forName("kotlin.Unit", false, classLoader);
+            Field instanceField = unitClass.getField("INSTANCE");
+            return instanceField.get(null);
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/MainFeedActionBar.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/MainFeedActionBar.java
@@ -21,9 +21,11 @@ public class MainFeedActionBar {
 
     public static void addActionBarButton(ViewGroup viewGroup) {
         try {
+            GhostModeQuickToggle.addToHomeActionBar(viewGroup);
             if(PIKO_SETTINGS_ON_ACTION_BAR) {
                 UI.pikoSettingsGear(viewGroup);
             }
+            GhostModeQuickToggle.keepActionBarButtonOrderStable(viewGroup);
 
         } catch (Exception e) {
             Logger.printException(() -> "addActionBarButton failure", e);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -26,10 +26,7 @@ public class Settings {
     public static final BooleanSetting REMOVE_BUILD_EXPIRE_POPUP = new BooleanSetting("remove_build_expire_popup", true);
     public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
     public static final BooleanSetting TURN_ON_ALL_GHOST_MODES = new BooleanSetting("turn_on_all_ghost_modes", false);
-    public static final BooleanSetting GHOST_MODES_QUICK_TOGGLE = new BooleanSetting("ghost_mode_quick_toggle", true);
-    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_HOME = new BooleanSetting("ghost_mode_quick_toggle_home", true);
-    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX = new BooleanSetting("ghost_mode_quick_toggle_direct_inbox", true);
-    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD = new BooleanSetting("ghost_mode_quick_toggle_direct_thread", true);
+    public static final StringSetting GHOST_MODE_QUICK_TOGGLE_LOCATIONS = new StringSetting("ghost_mode_quick_toggle_locations", "all");
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
     public static final BooleanSetting DISABLE_SCREENSHOT_DETECTION = new BooleanSetting("disable_screenshot_detection", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -27,6 +27,9 @@ public class Settings {
     public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
     public static final BooleanSetting TURN_ON_ALL_GHOST_MODES = new BooleanSetting("turn_on_all_ghost_modes", false);
     public static final BooleanSetting GHOST_MODES_QUICK_TOGGLE = new BooleanSetting("ghost_mode_quick_toggle", true);
+    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_HOME = new BooleanSetting("ghost_mode_quick_toggle_home", true);
+    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX = new BooleanSetting("ghost_mode_quick_toggle_direct_inbox", true);
+    public static final BooleanSetting GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD = new BooleanSetting("ghost_mode_quick_toggle_direct_thread", true);
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
     public static final BooleanSetting DISABLE_SCREENSHOT_DETECTION = new BooleanSetting("disable_screenshot_detection", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -79,6 +79,10 @@ public class SettingsStatus {
     public static void viewDmAnonymously() {
         viewDmAnonymously = true;
     }
+    public static boolean directInboxGhostModeQuickToggle = false;
+    public static void directInboxGhostModeQuickToggle() {
+        directInboxGhostModeQuickToggle = true;
+    }
     public static boolean ghostSection() {
         return (viewStoriesAnonymously || viewLiveAnonymously || disableScreenshotDetection || disableTypingStatus || viewDmAnonymously);
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -9,26 +9,13 @@ package app.morphe.extension.instagram.settings.preference;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
-import android.animation.ValueAnimator;
 import android.content.Context;
-import android.os.Handler;
-import android.os.Looper;
 import android.preference.PreferenceScreen;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
-import android.view.View;
-import android.view.ViewGroup;
-import android.view.accessibility.AccessibilityEvent;
-import android.view.animation.DecelerateInterpolator;
-import android.widget.AbsListView;
-import android.widget.LinearLayout;
 import java.util.TreeMap;
 import java.util.Map;
 
-import app.morphe.extension.crimera.SharedPref;
-import app.morphe.extension.crimera.settings.BooleanSetting;
 import app.morphe.extension.instagram.patches.actionbar.GhostModeQuickToggle;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.settings.Settings;
@@ -41,7 +28,6 @@ public class ScreenBuilder {
     private final Context context;
     private final PreferenceScreen screen;
     private final Helper helper;
-    private int ghostQuickToggleLocationsVisibilityRequest;
 
     public ScreenBuilder(Context context, PreferenceScreen screen, Helper helper) {
         this.context = context;
@@ -74,56 +60,6 @@ public class ScreenBuilder {
     private Preference withOrder(Preference preference, int order) {
         preference.setOrder(order);
         return preference;
-    }
-
-    private void setGhostQuickToggleLocationsVisible(
-            final GhostQuickToggleLocationsPref preference,
-            boolean visible,
-            boolean animate
-    ) {
-        final int request = ++ghostQuickToggleLocationsVisibilityRequest;
-        if (visible) {
-            addGhostQuickToggleLocationsPreference(preference, animate, request);
-        } else {
-            hideGhostQuickToggleLocationsPreference(preference, animate);
-        }
-    }
-
-    private void addGhostQuickToggleLocationsPreference(
-            final GhostQuickToggleLocationsPref preference,
-            boolean animate,
-            final int request
-    ) {
-        if (screen.findPreference(preference.getKey()) == null) {
-            preference.setExpanded(false, false);
-            addPreference(preference);
-        }
-
-        if (animate) {
-            new Handler(Looper.getMainLooper()).post(new Runnable() {
-                @Override
-                public void run() {
-                    if (request != ghostQuickToggleLocationsVisibilityRequest || !Pref.enableGhostModeQuickToggle()) {
-                        return;
-                    }
-                    preference.setExpanded(true, true);
-                }
-            });
-        } else {
-            preference.setExpanded(true, false);
-        }
-    }
-
-    private void hideGhostQuickToggleLocationsPreference(
-            final GhostQuickToggleLocationsPref preference,
-            boolean animate
-    ) {
-        if (screen.findPreference(preference.getKey()) == null) {
-            preference.setExpanded(false, false);
-            return;
-        }
-
-        preference.setExpanded(false, animate);
     }
 
     public void buildAdsSection() {
@@ -259,34 +195,20 @@ public class ScreenBuilder {
                 ), order++)
         );
 
-        final int quickToggleOrder = order++;
-        final GhostQuickToggleLocationsPref quickToggleLocationsPreference = new GhostQuickToggleLocationsPref(context);
-        quickToggleLocationsPreference.setOrder(order++);
-
-        Preference quickTogglePreference = withOrder(helper.switchPreference(
-                str("piko_ghost_modes_quick_toggle"),
-                str("piko_ghost_modes_quick_toggle_desc"),
-                Settings.GHOST_MODES_QUICK_TOGGLE
-        ), quickToggleOrder);
-        quickTogglePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+        Preference quickToggleLocationsPreference = withOrder(helper.listPreference(
+                str("piko_ghost_modes_quick_toggle_locations"),
+                str("piko_ghost_modes_quick_toggle_locations_desc"),
+                Settings.GHOST_MODE_QUICK_TOGGLE_LOCATIONS
+        ), order++);
+        quickToggleLocationsPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 helper.setValue(preference, newValue);
-                setGhostQuickToggleLocationsVisible(
-                        quickToggleLocationsPreference,
-                        Boolean.TRUE.equals(newValue),
-                        true
-                );
                 GhostModeQuickToggle.refreshActionBarButtons();
                 return true;
             }
         });
-        addPreference(quickTogglePreference);
-        setGhostQuickToggleLocationsVisible(
-                quickToggleLocationsPreference,
-                Pref.enableGhostModeQuickToggle(),
-                false
-        );
+        addPreference(quickToggleLocationsPreference);
 
         if (SettingsStatus.viewStoriesAnonymously) {
             addPreference(
@@ -932,340 +854,6 @@ public class ScreenBuilder {
                 )
         );
 
-    }
-
-    private static class GhostQuickToggleLocationsPref extends Preference {
-        private static final String KEY = "piko_ghost_mode_quick_toggle_locations";
-        private static final long EXPAND_ANIMATION_DURATION_MS = 260L;
-        private static final int LOCATION_ROW_MIN_HEIGHT_DP = 78;
-        private static final int COLLAPSE_TRANSLATION_DP = 10;
-
-        private ExpandableLinearLayout rootView;
-        private LinearLayout contentView;
-        private ValueAnimator animator;
-        private boolean expanded = true;
-        private boolean animateExpansionWhenBound;
-        private float expansionProgress = 1f;
-
-        GhostQuickToggleLocationsPref(Context context) {
-            super(context);
-            setKey(KEY);
-            setSelectable(false);
-        }
-
-        @Override
-        protected View onCreateView(ViewGroup parent) {
-            Context context = getContext();
-            ExpandableLinearLayout root = new ExpandableLinearLayout(context);
-            root.setOrientation(LinearLayout.VERTICAL);
-            root.setClipChildren(true);
-            root.setClipToPadding(true);
-            root.setBackgroundColor(InstagramPreferenceStyle.backgroundColor(context));
-            root.setLayoutParams(new AbsListView.LayoutParams(
-                    AbsListView.LayoutParams.MATCH_PARENT,
-                    expanded ? AbsListView.LayoutParams.WRAP_CONTENT : 0
-            ));
-
-            LinearLayout content = new LinearLayout(context);
-            content.setOrientation(LinearLayout.VERTICAL);
-            root.addView(content, new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-            ));
-
-            content.addView(createLocationRow(
-                    str("piko_ghost_modes_quick_toggle_home"),
-                    str("piko_ghost_modes_quick_toggle_home_desc"),
-                    Settings.GHOST_MODE_QUICK_TOGGLE_HOME
-            ));
-            if (showDirectInboxLocationRow()) {
-                content.addView(createLocationRow(
-                        str("piko_ghost_modes_quick_toggle_direct_inbox"),
-                        str("piko_ghost_modes_quick_toggle_direct_inbox_desc"),
-                        Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX
-                ));
-            }
-            if (showDirectThreadLocationRow()) {
-                content.addView(createLocationRow(
-                        str("piko_ghost_modes_quick_toggle_direct_thread"),
-                        str("piko_ghost_modes_quick_toggle_direct_thread_desc"),
-                        Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD
-                ));
-            }
-
-            rootView = root;
-            contentView = content;
-            setExpansionProgress(expansionProgress);
-            return root;
-        }
-
-        @Override
-        protected void onBindView(View view) {
-            if (!(view instanceof ExpandableLinearLayout)) {
-                return;
-            }
-
-            rootView = (ExpandableLinearLayout) view;
-            if (rootView.getChildCount() > 0) {
-                View child = rootView.getChildAt(0);
-                if (child instanceof LinearLayout) {
-                    contentView = (LinearLayout) child;
-                }
-            }
-            setExpansionProgress(expansionProgress);
-            animateExpansionWhenBound();
-        }
-
-        void setExpanded(boolean expanded, boolean animate) {
-            if (this.expanded == expanded && animator == null) {
-                return;
-            }
-
-            this.expanded = expanded;
-            float target = expanded ? 1f : 0f;
-            if (rootView == null) {
-                if (animate && expanded) {
-                    expansionProgress = 0f;
-                    animateExpansionWhenBound = true;
-                } else {
-                    expansionProgress = target;
-                    animateExpansionWhenBound = false;
-                }
-                notifyChanged();
-                return;
-            }
-
-            if (animator != null) {
-                animator.cancel();
-            }
-
-            if (!animate) {
-                animateExpansionWhenBound = false;
-                setExpansionProgress(target);
-                return;
-            }
-
-            animateExpansionTo(target);
-        }
-
-        private void animateExpansionWhenBound() {
-            if (!animateExpansionWhenBound || rootView == null) {
-                return;
-            }
-
-            animateExpansionWhenBound = false;
-            rootView.post(new Runnable() {
-                @Override
-                public void run() {
-                    if (rootView == null) {
-                        return;
-                    }
-                    if (animator != null) {
-                        animator.cancel();
-                    }
-                    animateExpansionTo(expanded ? 1f : 0f);
-                }
-            });
-        }
-
-        private void animateExpansionTo(float target) {
-            final ValueAnimator currentAnimator = ValueAnimator.ofFloat(expansionProgress, target);
-            animator = currentAnimator;
-            currentAnimator.setDuration(EXPAND_ANIMATION_DURATION_MS);
-            currentAnimator.setInterpolator(new DecelerateInterpolator());
-            currentAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
-                @Override
-                public void onAnimationUpdate(ValueAnimator animation) {
-                    setExpansionProgress((Float) animation.getAnimatedValue());
-                }
-            });
-            currentAnimator.addListener(new AnimatorListenerAdapter() {
-                private boolean cancelled;
-
-                @Override
-                public void onAnimationCancel(Animator animation) {
-                    cancelled = true;
-                }
-
-                @Override
-                public void onAnimationEnd(Animator animation) {
-                    if (animator == animation) {
-                        animator = null;
-                    }
-                    if (cancelled) {
-                        return;
-                    }
-                    setExpansionProgress(expanded ? 1f : 0f);
-                }
-            });
-            currentAnimator.start();
-        }
-
-        private View createLocationRow(String title, String summary, final BooleanSetting setting) {
-            Context context = getContext();
-            final View row = InstagramPreferenceStyle.createPreferenceView(
-                    context,
-                    InstagramPreferenceStyle.TRAILING_SWITCH
-            );
-            Preference rowPreference = new Preference(context);
-            rowPreference.setTitle(title);
-            rowPreference.setSummary(summary);
-            InstagramPreferenceStyle.bindText(rowPreference, row);
-            row.setFocusable(true);
-            final InstagramPreferenceStyle.SwitchView switchView = InstagramPreferenceStyle.findSwitch(row);
-            updateLocationRow(row, switchView, setting, false);
-            row.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View view) {
-                    if (!InstagramPreferenceStyle.consumeSwitchClickAllowed(view)) {
-                        return;
-                    }
-
-                    boolean checked = !SharedPref.getBooleanPref(setting);
-                    SharedPref.setBooleanPref(setting.key, checked);
-                    updateLocationRow(view, switchView, setting, true);
-                    GhostModeQuickToggle.refreshActionBarButtons();
-                    view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_CLICKED);
-                }
-            });
-
-            return row;
-        }
-
-        private void updateLocationRow(
-                View row,
-                InstagramPreferenceStyle.SwitchView switchView,
-                BooleanSetting setting,
-                boolean animate
-        ) {
-            boolean checked = SharedPref.getBooleanPref(setting);
-            if (switchView != null) {
-                switchView.setChecked(checked, animate);
-            }
-            InstagramPreferenceStyle.bindSwitchAccessibility(row, checked);
-            row.setSelected(checked);
-            row.setActivated(checked);
-        }
-
-        private boolean showDirectInboxLocationRow() {
-            return SettingsStatus.directInboxGhostModeQuickToggle && showDirectThreadLocationRow();
-        }
-
-        private boolean showDirectThreadLocationRow() {
-            return SettingsStatus.viewStoriesAnonymously
-                    || SettingsStatus.viewLiveAnonymously
-                    || SettingsStatus.disableTypingStatus
-                    || SettingsStatus.viewDmAnonymously;
-        }
-
-        private void setExpansionProgress(float progress) {
-            expansionProgress = Math.max(0f, Math.min(1f, progress));
-            if (rootView == null) {
-                return;
-            }
-
-            int targetHeight = measuredExpandedHeight();
-            ViewGroup.LayoutParams layoutParams = rootView.getLayoutParams();
-            if (layoutParams == null) {
-                layoutParams = new AbsListView.LayoutParams(
-                        AbsListView.LayoutParams.MATCH_PARENT,
-                        AbsListView.LayoutParams.WRAP_CONTENT
-                );
-            }
-
-            if (expansionProgress >= 1f) {
-                rootView.setForcedHeight(-1);
-                layoutParams.height = AbsListView.LayoutParams.WRAP_CONTENT;
-            } else {
-                int animatedHeight = Math.round(targetHeight * expansionProgress);
-                rootView.setForcedHeight(animatedHeight);
-                layoutParams.height = animatedHeight;
-            }
-            rootView.setLayoutParams(layoutParams);
-            rootView.setVisibility(View.VISIBLE);
-            rootView.setEnabled(expansionProgress > 0f);
-            rootView.setAlpha(expansionProgress);
-            rootView.setClickable(expansionProgress > 0f);
-
-            if (contentView != null) {
-                contentView.setVisibility(expansionProgress > 0f ? View.VISIBLE : View.INVISIBLE);
-                contentView.setTranslationY(
-                        -InstagramPreferenceStyle.dp(rootView.getContext(), COLLAPSE_TRANSLATION_DP)
-                                * (1f - expansionProgress)
-                );
-            }
-        }
-
-        private int measuredExpandedHeight() {
-            if (contentView == null) {
-                return fallbackExpandedHeight();
-            }
-
-            int width = rootView != null ? rootView.getWidth() : 0;
-            View parent = rootView != null && rootView.getParent() instanceof View
-                    ? (View) rootView.getParent()
-                    : null;
-            if (width <= 0 && parent != null) {
-                width = parent.getWidth();
-            }
-            if (width <= 0) {
-                width = getContext().getResources().getDisplayMetrics().widthPixels;
-            }
-
-            int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
-            int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
-            contentView.measure(widthSpec, heightSpec);
-            return Math.max(
-                    contentView.getMeasuredHeight(),
-                    fallbackExpandedHeight()
-            );
-        }
-
-        private int fallbackExpandedHeight() {
-            int rowCount = contentView != null
-                    ? Math.max(1, contentView.getChildCount())
-                    : locationRowCount();
-            return InstagramPreferenceStyle.dp(getContext(), LOCATION_ROW_MIN_HEIGHT_DP) * rowCount;
-        }
-
-        private int locationRowCount() {
-            int rowCount = 1;
-            if (showDirectInboxLocationRow()) {
-                rowCount++;
-            }
-            if (showDirectThreadLocationRow()) {
-                rowCount++;
-            }
-            return rowCount;
-        }
-
-        private static class ExpandableLinearLayout extends LinearLayout {
-            private int forcedHeight = -1;
-
-            ExpandableLinearLayout(Context context) {
-                super(context);
-            }
-
-            void setForcedHeight(int height) {
-                if (forcedHeight == height) {
-                    return;
-                }
-                forcedHeight = height;
-                requestLayout();
-            }
-
-            @Override
-            protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
-                if (forcedHeight >= 0) {
-                    super.onMeasure(
-                            widthMeasureSpec,
-                            View.MeasureSpec.makeMeasureSpec(forcedHeight, View.MeasureSpec.EXACTLY)
-                    );
-                    return;
-                }
-                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-            }
-        }
     }
 
     //end

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -9,13 +9,27 @@ package app.morphe.extension.instagram.settings.preference;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.animation.ValueAnimator;
 import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
 import android.preference.PreferenceScreen;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityEvent;
+import android.view.animation.DecelerateInterpolator;
+import android.widget.AbsListView;
+import android.widget.LinearLayout;
 import java.util.TreeMap;
 import java.util.Map;
 
+import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.crimera.settings.BooleanSetting;
+import app.morphe.extension.instagram.patches.actionbar.GhostModeQuickToggle;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.widgets.*;
@@ -27,6 +41,7 @@ public class ScreenBuilder {
     private final Context context;
     private final PreferenceScreen screen;
     private final Helper helper;
+    private int ghostQuickToggleLocationsVisibilityRequest;
 
     public ScreenBuilder(Context context, PreferenceScreen screen, Helper helper) {
         this.context = context;
@@ -54,6 +69,61 @@ public class ScreenBuilder {
         preferenceCategory.setTitle(title);
         screen.addPreference(preferenceCategory);
         return preferenceCategory;
+    }
+
+    private Preference withOrder(Preference preference, int order) {
+        preference.setOrder(order);
+        return preference;
+    }
+
+    private void setGhostQuickToggleLocationsVisible(
+            final GhostQuickToggleLocationsPref preference,
+            boolean visible,
+            boolean animate
+    ) {
+        final int request = ++ghostQuickToggleLocationsVisibilityRequest;
+        if (visible) {
+            addGhostQuickToggleLocationsPreference(preference, animate, request);
+        } else {
+            hideGhostQuickToggleLocationsPreference(preference, animate);
+        }
+    }
+
+    private void addGhostQuickToggleLocationsPreference(
+            final GhostQuickToggleLocationsPref preference,
+            boolean animate,
+            final int request
+    ) {
+        if (screen.findPreference(preference.getKey()) == null) {
+            preference.setExpanded(false, false);
+            addPreference(preference);
+        }
+
+        if (animate) {
+            new Handler(Looper.getMainLooper()).post(new Runnable() {
+                @Override
+                public void run() {
+                    if (request != ghostQuickToggleLocationsVisibilityRequest || !Pref.enableGhostModeQuickToggle()) {
+                        return;
+                    }
+                    preference.setExpanded(true, true);
+                }
+            });
+        } else {
+            preference.setExpanded(true, false);
+        }
+    }
+
+    private void hideGhostQuickToggleLocationsPreference(
+            final GhostQuickToggleLocationsPref preference,
+            boolean animate
+    ) {
+        if (screen.findPreference(preference.getKey()) == null) {
+            preference.setExpanded(false, false);
+            return;
+        }
+
+        preference.setExpanded(false, animate);
     }
 
     public void buildAdsSection() {
@@ -179,66 +249,88 @@ public class ScreenBuilder {
         if (!(SettingsStatus.ghostSection())) return;
 
         // PreferenceCategory category= addCategory(str("piko_category_ghost"));
+        int order = 0;
 
         addPreference(
-                helper.switchPreference(
+                withOrder(helper.switchPreference(
                         str("piko_turn_on_all_ghost_modes"),
                         "",
                         Settings.TURN_ON_ALL_GHOST_MODES
-                )
+                ), order++)
         );
 
-        addPreference(
-                helper.switchPreference(
-                        str("piko_ghost_modes_quick_toggle"),
-                        str("piko_ghost_modes_quick_toggle_desc"),
-                        Settings.GHOST_MODES_QUICK_TOGGLE
-                )
+        final int quickToggleOrder = order++;
+        final GhostQuickToggleLocationsPref quickToggleLocationsPreference = new GhostQuickToggleLocationsPref(context);
+        quickToggleLocationsPreference.setOrder(order++);
+
+        Preference quickTogglePreference = withOrder(helper.switchPreference(
+                str("piko_ghost_modes_quick_toggle"),
+                str("piko_ghost_modes_quick_toggle_desc"),
+                Settings.GHOST_MODES_QUICK_TOGGLE
+        ), quickToggleOrder);
+        quickTogglePreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                helper.setValue(preference, newValue);
+                setGhostQuickToggleLocationsVisible(
+                        quickToggleLocationsPreference,
+                        Boolean.TRUE.equals(newValue),
+                        true
+                );
+                GhostModeQuickToggle.refreshActionBarButtons();
+                return true;
+            }
+        });
+        addPreference(quickTogglePreference);
+        setGhostQuickToggleLocationsVisible(
+                quickToggleLocationsPreference,
+                Pref.enableGhostModeQuickToggle(),
+                false
         );
 
         if (SettingsStatus.viewStoriesAnonymously) {
             addPreference(
-                    helper.switchPreference(
+                    withOrder(helper.switchPreference(
                             str("piko_view_stories_anonymously"),
                             "",
                             Settings.VIEW_STORIES_ANONYMOUSLY
-                    )
+                    ), order++)
             );
         }
         if (SettingsStatus.viewLiveAnonymously) {
             addPreference(
-                    helper.switchPreference(
+                    withOrder(helper.switchPreference(
                             str("piko_view_live_anonymously"),
                             "",
                             Settings.VIEW_LIVE_ANONYMOUSLY
-                    )
+                    ), order++)
             );
         }
         if (SettingsStatus.disableTypingStatus) {
             addPreference(
-                    helper.switchPreference(
+                    withOrder(helper.switchPreference(
                             str("piko_disable_typing_status"),
                             "",
                             Settings.DISABLE_TYPING_STATUS
-                    )
+                    ), order++)
             );
         }
         if (SettingsStatus.disableScreenshotDetection) {
             addPreference(
-                    helper.switchPreference(
+                    withOrder(helper.switchPreference(
                             str("piko_disable_screenshot_detection"),
                             "",
                             Settings.DISABLE_SCREENSHOT_DETECTION
-                    )
+                    ), order++)
             );
         }
         if (SettingsStatus.viewDmAnonymously) {
             addPreference(
-                    helper.switchPreference(
+                    withOrder(helper.switchPreference(
                             str("piko_view_dm_anonymously"),
                             "",
                             Settings.VIEW_DM_ANONYMOUSLY
-                    )
+                    ), order++)
             );
         }
 
@@ -840,6 +932,340 @@ public class ScreenBuilder {
                 )
         );
 
+    }
+
+    private static class GhostQuickToggleLocationsPref extends Preference {
+        private static final String KEY = "piko_ghost_mode_quick_toggle_locations";
+        private static final long EXPAND_ANIMATION_DURATION_MS = 260L;
+        private static final int LOCATION_ROW_MIN_HEIGHT_DP = 78;
+        private static final int COLLAPSE_TRANSLATION_DP = 10;
+
+        private ExpandableLinearLayout rootView;
+        private LinearLayout contentView;
+        private ValueAnimator animator;
+        private boolean expanded = true;
+        private boolean animateExpansionWhenBound;
+        private float expansionProgress = 1f;
+
+        GhostQuickToggleLocationsPref(Context context) {
+            super(context);
+            setKey(KEY);
+            setSelectable(false);
+        }
+
+        @Override
+        protected View onCreateView(ViewGroup parent) {
+            Context context = getContext();
+            ExpandableLinearLayout root = new ExpandableLinearLayout(context);
+            root.setOrientation(LinearLayout.VERTICAL);
+            root.setClipChildren(true);
+            root.setClipToPadding(true);
+            root.setBackgroundColor(InstagramPreferenceStyle.backgroundColor(context));
+            root.setLayoutParams(new AbsListView.LayoutParams(
+                    AbsListView.LayoutParams.MATCH_PARENT,
+                    expanded ? AbsListView.LayoutParams.WRAP_CONTENT : 0
+            ));
+
+            LinearLayout content = new LinearLayout(context);
+            content.setOrientation(LinearLayout.VERTICAL);
+            root.addView(content, new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+            ));
+
+            content.addView(createLocationRow(
+                    str("piko_ghost_modes_quick_toggle_home"),
+                    str("piko_ghost_modes_quick_toggle_home_desc"),
+                    Settings.GHOST_MODE_QUICK_TOGGLE_HOME
+            ));
+            if (showDirectInboxLocationRow()) {
+                content.addView(createLocationRow(
+                        str("piko_ghost_modes_quick_toggle_direct_inbox"),
+                        str("piko_ghost_modes_quick_toggle_direct_inbox_desc"),
+                        Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX
+                ));
+            }
+            if (showDirectThreadLocationRow()) {
+                content.addView(createLocationRow(
+                        str("piko_ghost_modes_quick_toggle_direct_thread"),
+                        str("piko_ghost_modes_quick_toggle_direct_thread_desc"),
+                        Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD
+                ));
+            }
+
+            rootView = root;
+            contentView = content;
+            setExpansionProgress(expansionProgress);
+            return root;
+        }
+
+        @Override
+        protected void onBindView(View view) {
+            if (!(view instanceof ExpandableLinearLayout)) {
+                return;
+            }
+
+            rootView = (ExpandableLinearLayout) view;
+            if (rootView.getChildCount() > 0) {
+                View child = rootView.getChildAt(0);
+                if (child instanceof LinearLayout) {
+                    contentView = (LinearLayout) child;
+                }
+            }
+            setExpansionProgress(expansionProgress);
+            animateExpansionWhenBound();
+        }
+
+        void setExpanded(boolean expanded, boolean animate) {
+            if (this.expanded == expanded && animator == null) {
+                return;
+            }
+
+            this.expanded = expanded;
+            float target = expanded ? 1f : 0f;
+            if (rootView == null) {
+                if (animate && expanded) {
+                    expansionProgress = 0f;
+                    animateExpansionWhenBound = true;
+                } else {
+                    expansionProgress = target;
+                    animateExpansionWhenBound = false;
+                }
+                notifyChanged();
+                return;
+            }
+
+            if (animator != null) {
+                animator.cancel();
+            }
+
+            if (!animate) {
+                animateExpansionWhenBound = false;
+                setExpansionProgress(target);
+                return;
+            }
+
+            animateExpansionTo(target);
+        }
+
+        private void animateExpansionWhenBound() {
+            if (!animateExpansionWhenBound || rootView == null) {
+                return;
+            }
+
+            animateExpansionWhenBound = false;
+            rootView.post(new Runnable() {
+                @Override
+                public void run() {
+                    if (rootView == null) {
+                        return;
+                    }
+                    if (animator != null) {
+                        animator.cancel();
+                    }
+                    animateExpansionTo(expanded ? 1f : 0f);
+                }
+            });
+        }
+
+        private void animateExpansionTo(float target) {
+            final ValueAnimator currentAnimator = ValueAnimator.ofFloat(expansionProgress, target);
+            animator = currentAnimator;
+            currentAnimator.setDuration(EXPAND_ANIMATION_DURATION_MS);
+            currentAnimator.setInterpolator(new DecelerateInterpolator());
+            currentAnimator.addUpdateListener(new ValueAnimator.AnimatorUpdateListener() {
+                @Override
+                public void onAnimationUpdate(ValueAnimator animation) {
+                    setExpansionProgress((Float) animation.getAnimatedValue());
+                }
+            });
+            currentAnimator.addListener(new AnimatorListenerAdapter() {
+                private boolean cancelled;
+
+                @Override
+                public void onAnimationCancel(Animator animation) {
+                    cancelled = true;
+                }
+
+                @Override
+                public void onAnimationEnd(Animator animation) {
+                    if (animator == animation) {
+                        animator = null;
+                    }
+                    if (cancelled) {
+                        return;
+                    }
+                    setExpansionProgress(expanded ? 1f : 0f);
+                }
+            });
+            currentAnimator.start();
+        }
+
+        private View createLocationRow(String title, String summary, final BooleanSetting setting) {
+            Context context = getContext();
+            final View row = InstagramPreferenceStyle.createPreferenceView(
+                    context,
+                    InstagramPreferenceStyle.TRAILING_SWITCH
+            );
+            Preference rowPreference = new Preference(context);
+            rowPreference.setTitle(title);
+            rowPreference.setSummary(summary);
+            InstagramPreferenceStyle.bindText(rowPreference, row);
+            row.setFocusable(true);
+            final InstagramPreferenceStyle.SwitchView switchView = InstagramPreferenceStyle.findSwitch(row);
+            updateLocationRow(row, switchView, setting, false);
+            row.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    if (!InstagramPreferenceStyle.consumeSwitchClickAllowed(view)) {
+                        return;
+                    }
+
+                    boolean checked = !SharedPref.getBooleanPref(setting);
+                    SharedPref.setBooleanPref(setting.key, checked);
+                    updateLocationRow(view, switchView, setting, true);
+                    GhostModeQuickToggle.refreshActionBarButtons();
+                    view.sendAccessibilityEvent(AccessibilityEvent.TYPE_VIEW_CLICKED);
+                }
+            });
+
+            return row;
+        }
+
+        private void updateLocationRow(
+                View row,
+                InstagramPreferenceStyle.SwitchView switchView,
+                BooleanSetting setting,
+                boolean animate
+        ) {
+            boolean checked = SharedPref.getBooleanPref(setting);
+            if (switchView != null) {
+                switchView.setChecked(checked, animate);
+            }
+            InstagramPreferenceStyle.bindSwitchAccessibility(row, checked);
+            row.setSelected(checked);
+            row.setActivated(checked);
+        }
+
+        private boolean showDirectInboxLocationRow() {
+            return SettingsStatus.directInboxGhostModeQuickToggle && showDirectThreadLocationRow();
+        }
+
+        private boolean showDirectThreadLocationRow() {
+            return SettingsStatus.viewStoriesAnonymously
+                    || SettingsStatus.viewLiveAnonymously
+                    || SettingsStatus.disableTypingStatus
+                    || SettingsStatus.viewDmAnonymously;
+        }
+
+        private void setExpansionProgress(float progress) {
+            expansionProgress = Math.max(0f, Math.min(1f, progress));
+            if (rootView == null) {
+                return;
+            }
+
+            int targetHeight = measuredExpandedHeight();
+            ViewGroup.LayoutParams layoutParams = rootView.getLayoutParams();
+            if (layoutParams == null) {
+                layoutParams = new AbsListView.LayoutParams(
+                        AbsListView.LayoutParams.MATCH_PARENT,
+                        AbsListView.LayoutParams.WRAP_CONTENT
+                );
+            }
+
+            if (expansionProgress >= 1f) {
+                rootView.setForcedHeight(-1);
+                layoutParams.height = AbsListView.LayoutParams.WRAP_CONTENT;
+            } else {
+                int animatedHeight = Math.round(targetHeight * expansionProgress);
+                rootView.setForcedHeight(animatedHeight);
+                layoutParams.height = animatedHeight;
+            }
+            rootView.setLayoutParams(layoutParams);
+            rootView.setVisibility(View.VISIBLE);
+            rootView.setEnabled(expansionProgress > 0f);
+            rootView.setAlpha(expansionProgress);
+            rootView.setClickable(expansionProgress > 0f);
+
+            if (contentView != null) {
+                contentView.setVisibility(expansionProgress > 0f ? View.VISIBLE : View.INVISIBLE);
+                contentView.setTranslationY(
+                        -InstagramPreferenceStyle.dp(rootView.getContext(), COLLAPSE_TRANSLATION_DP)
+                                * (1f - expansionProgress)
+                );
+            }
+        }
+
+        private int measuredExpandedHeight() {
+            if (contentView == null) {
+                return fallbackExpandedHeight();
+            }
+
+            int width = rootView != null ? rootView.getWidth() : 0;
+            View parent = rootView != null && rootView.getParent() instanceof View
+                    ? (View) rootView.getParent()
+                    : null;
+            if (width <= 0 && parent != null) {
+                width = parent.getWidth();
+            }
+            if (width <= 0) {
+                width = getContext().getResources().getDisplayMetrics().widthPixels;
+            }
+
+            int widthSpec = View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY);
+            int heightSpec = View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED);
+            contentView.measure(widthSpec, heightSpec);
+            return Math.max(
+                    contentView.getMeasuredHeight(),
+                    fallbackExpandedHeight()
+            );
+        }
+
+        private int fallbackExpandedHeight() {
+            int rowCount = contentView != null
+                    ? Math.max(1, contentView.getChildCount())
+                    : locationRowCount();
+            return InstagramPreferenceStyle.dp(getContext(), LOCATION_ROW_MIN_HEIGHT_DP) * rowCount;
+        }
+
+        private int locationRowCount() {
+            int rowCount = 1;
+            if (showDirectInboxLocationRow()) {
+                rowCount++;
+            }
+            if (showDirectThreadLocationRow()) {
+                rowCount++;
+            }
+            return rowCount;
+        }
+
+        private static class ExpandableLinearLayout extends LinearLayout {
+            private int forcedHeight = -1;
+
+            ExpandableLinearLayout(Context context) {
+                super(context);
+            }
+
+            void setForcedHeight(int height) {
+                if (forcedHeight == height) {
+                    return;
+                }
+                forcedHeight = height;
+                requestLayout();
+            }
+
+            @Override
+            protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                if (forcedHeight >= 0) {
+                    super.onMeasure(
+                            widthMeasureSpec,
+                            View.MeasureSpec.makeMeasureSpec(forcedHeight, View.MeasureSpec.EXACTLY)
+                    );
+                    return;
+                }
+                super.onMeasure(widthMeasureSpec, heightMeasureSpec);
+            }
+        }
     }
 
     //end

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ListPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ListPref.java
@@ -12,8 +12,6 @@ import android.preference.ListPreference;
 import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
-import app.morphe.extension.instagram.settings.Settings;
-import app.morphe.extension.shared.ResourceUtils;
 import android.preference.Preference;
 import app.morphe.extension.instagram.settings.preference.Helper;
 
@@ -53,18 +51,13 @@ public class ListPref extends ListPreference {
         super.onSetInitialValue(restoreValue, defaultValue);
         String key = getKey();
 
-        CharSequence[] entries = new CharSequence[]{};
-        CharSequence[] entriesValues = new CharSequence[]{};
-        if (key == Settings.CUSTOMISE_STORY_TIMESTAMP.key) {
-            entries = ResourceUtils.getStringArray("piko_array_customise_story_timestamp");
-            entriesValues = ResourceUtils.getStringArray("piko_array_customise_story_timestamp_val");
-        } else if (key == Settings.CHANGE_LIKE_ANIMATION.key) {
-            entries = ResourceUtils.getStringArray("piko_array_change_like_animation");
-            entriesValues = ResourceUtils.getStringArray("piko_array_change_like_animation_val");
-        }
+        setEntries(getStringArray("piko_array_" + key));
+        setEntryValues(getStringArray("piko_array_" + key + "_val"));
+    }
 
-        setEntries(entries);
-        setEntryValues(entriesValues);
+    private CharSequence[] getStringArray(String name) {
+        int id = getContext().getResources().getIdentifier(name, "array", getContext().getPackageName());
+        return id == 0 ? new CharSequence[]{} : getContext().getResources().getTextArray(id);
     }
 
     @Override

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -13,6 +13,15 @@ import app.morphe.extension.crimera.SharedPref;
 
 @SuppressWarnings("unused")
 public class Pref {
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_NONE = "none";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_ALL = "all";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME = "home";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_MESSAGES = "messages";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_CHATS = "chats";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_MESSAGES = "home_messages";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_CHATS = "home_chats";
+    private static final String GHOST_MODE_QUICK_TOGGLE_LOCATION_MESSAGES_CHATS = "messages_chats";
+
     public static boolean pikoSettingsOnActionBar() {
         return SharedPref.getBooleanPref(Settings.PIKO_SETTINGS_ON_ACTION_BAR);
     }
@@ -57,19 +66,35 @@ public class Pref {
     }
 
     public static boolean enableGhostModeQuickToggle() {
-        return SharedPref.getBooleanPref(Settings.GHOST_MODES_QUICK_TOGGLE);
+        return !GHOST_MODE_QUICK_TOGGLE_LOCATION_NONE.equals(ghostModeQuickToggleLocations());
     }
 
     public static boolean showGhostModeQuickToggleHome() {
-        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_HOME);
+        String locations = ghostModeQuickToggleLocations();
+        return GHOST_MODE_QUICK_TOGGLE_LOCATION_ALL.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_MESSAGES.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_CHATS.equals(locations);
     }
 
     public static boolean showGhostModeQuickToggleDirectInbox() {
-        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX);
+        String locations = ghostModeQuickToggleLocations();
+        return GHOST_MODE_QUICK_TOGGLE_LOCATION_ALL.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_MESSAGES.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_MESSAGES.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_MESSAGES_CHATS.equals(locations);
     }
 
     public static boolean showGhostModeQuickToggleDirectThread() {
-        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD);
+        String locations = ghostModeQuickToggleLocations();
+        return GHOST_MODE_QUICK_TOGGLE_LOCATION_ALL.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_CHATS.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_HOME_CHATS.equals(locations)
+                || GHOST_MODE_QUICK_TOGGLE_LOCATION_MESSAGES_CHATS.equals(locations);
+    }
+
+    private static String ghostModeQuickToggleLocations() {
+        return SharedPref.getStringPref(Settings.GHOST_MODE_QUICK_TOGGLE_LOCATIONS);
     }
 
     public static boolean enableMoreOptionsOnProfileQuickToggle() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -60,6 +60,18 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.GHOST_MODES_QUICK_TOGGLE);
     }
 
+    public static boolean showGhostModeQuickToggleHome() {
+        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_HOME);
+    }
+
+    public static boolean showGhostModeQuickToggleDirectInbox() {
+        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_INBOX);
+    }
+
+    public static boolean showGhostModeQuickToggleDirectThread() {
+        return SharedPref.getBooleanPref(Settings.GHOST_MODE_QUICK_TOGGLE_DIRECT_THREAD);
+    }
+
     public static boolean enableMoreOptionsOnProfileQuickToggle() {
         return SharedPref.getBooleanPref(Settings.MORE_PROFILE_OPTIONS_ACTION_BAR_TOGGLE) && Pref.isMoreOptionsOnProfilePatched();
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/dmActionBarButton/DMActionBarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/dmActionBarButton/DMActionBarButtonPatch.kt
@@ -9,10 +9,14 @@ package app.crimera.patches.instagram.misc.actionBar.dmActionBarButton
 import app.crimera.patches.instagram.utils.Constants.ACTIONBAR_DESCRIPTOR
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.enableSettings
+import app.crimera.utils.classNameToExtension
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
@@ -20,8 +24,25 @@ import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21c
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import java.util.logging.Logger
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val GHOST_MODE_QUICK_TOGGLE_DESCRIPTOR = "$ACTIONBAR_DESCRIPTOR/GhostModeQuickToggle;"
+private const val DIRECT_INBOX_MODEL_LEADING_CLASS_NAME = "directInboxLeadingClassName"
+private const val DIRECT_INBOX_MODEL_TITLE_CLASS_NAME = "directInboxTitleClassName"
+private const val DIRECT_INBOX_MODEL_ACTION_CLASS_NAME = "directInboxActionClassName"
+private const val DIRECT_INBOX_MODEL_PLACEMENT_CLASS_NAME = "directInboxPlacementClassName"
+private const val DIRECT_INBOX_MODEL_LEADING_FIELD_NAME = "directInboxModelLeadingFieldName"
+private const val DIRECT_INBOX_MODEL_TITLE_FIELD_NAME = "directInboxModelTitleFieldName"
+private const val DIRECT_INBOX_MODEL_ACTIONS_FIELD_NAME = "directInboxModelActionsFieldName"
+private const val DIRECT_INBOX_ACTION_PLACEMENT_FIELD_NAME = "directInboxActionPlacementFieldName"
+private const val ENUM_DESCRIPTOR = "Ljava/lang/Enum;"
+private const val INTEGER_DESCRIPTOR = "Ljava/lang/Integer;"
+private const val FUNCTION0_DESCRIPTOR = "Lkotlin/jvm/functions/Function0;"
+private const val FUNCTION1_DESCRIPTOR = "Lkotlin/jvm/functions/Function1;"
+private const val LIST_DESCRIPTOR = "Ljava/util/List;"
 
 object DMActionBarBuilderFingerprint : Fingerprint(
     returnType = "V",
@@ -31,13 +52,27 @@ object DMActionBarBuilderFingerprint : Fingerprint(
 
 private object DirectInboxActionBarModelFingerprint : Fingerprint(
     custom = { methodDef, classDef ->
-        classDef.type == "LX/5GB;" &&
-            methodDef.name == "A00" &&
-            methodDef.parameters.size == 2 &&
-            methodDef.parameters[0].type == "LX/5Fu;" &&
-            methodDef.parameters[1].type == "LX/5GB;" &&
-            methodDef.returnType == "LX/5Sq;"
+        methodDef.parameters.size == 2 &&
+            methodDef.parameters[1].type == classDef.type &&
+            methodDef.returnType.startsWith("L") &&
+            methodDef.implementation?.instructions?.any { instruction ->
+                val reference = (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                reference?.definingClass == methodDef.returnType &&
+                    reference.name == "<init>" &&
+                    reference.parameterTypes.size == 3 &&
+                    reference.parameterTypes[2] == LIST_DESCRIPTOR
+            } == true
     },
+)
+
+private object AddDirectInboxActionModelExtensionFingerprint : Fingerprint(
+    definingClass = GHOST_MODE_QUICK_TOGGLE_DESCRIPTOR,
+    name = "addDirectInboxActionModel",
+)
+
+private object FindDirectInboxInsertIndexExtensionFingerprint : Fingerprint(
+    definingClass = GHOST_MODE_QUICK_TOGGLE_DESCRIPTOR,
+    name = "findDirectInboxInsertIndex",
 )
 
 val dmActionBarButtonPatch =
@@ -68,17 +103,70 @@ val dmActionBarButtonPatch =
                     }
             }
 
-            val directInboxActionBarModelMethod = runCatching {
-                DirectInboxActionBarModelFingerprint.method
-            }.getOrElse {
-                Logger.getLogger(this::class.java.name).warning(
-                    "Skipping ghost mode quick toggle on direct inbox because its action bar hook was not found.\n",
-                )
-                null
-            }
-
-            directInboxActionBarModelMethod?.apply {
+            DirectInboxActionBarModelFingerprint.method.apply {
                 val actionBarModelType = returnType
+                val actionBarModelClass = mutableClassDefBy(actionBarModelType)
+                val actionBarModelConstructor = instructions
+                    .mapNotNull { (it as? ReferenceInstruction)?.reference as? MethodReference }
+                    .first {
+                        it.definingClass == actionBarModelType &&
+                            it.name == "<init>" &&
+                            it.parameterTypes.size == 3 &&
+                            it.parameterTypes[2] == LIST_DESCRIPTOR
+                    }
+                val leadingType = actionBarModelConstructor.parameterTypes[0].toString()
+                val titleType = actionBarModelConstructor.parameterTypes[1].toString()
+                val actionType = instructions
+                    .mapNotNull { (it as? ReferenceInstruction)?.reference as? MethodReference }
+                    .filter {
+                        it.definingClass == definingClass &&
+                            it.name != "<init>" &&
+                            it.returnType.toString().startsWith("L")
+                    }
+                    .map { it.returnType.toString() }
+                    .distinct()
+                    .first { isDirectInboxActionClass(it) }
+                val placementType = mutableClassDefBy(actionType).fields
+                    .map { it.type }
+                    .single { isEnumClass(it) }
+                val modelLeadingFieldName = actionBarModelClass.fields.single { it.type == leadingType }.name
+                val modelTitleFieldName = actionBarModelClass.fields.single { it.type == titleType }.name
+                val modelActionsFieldName = actionBarModelClass.fields.single { it.type == LIST_DESCRIPTOR }.name
+                val actionPlacementFieldName = mutableClassDefBy(actionType).fields.single { it.type == placementType }.name
+
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_LEADING_CLASS_NAME,
+                    classNameToExtension(leadingType),
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_TITLE_CLASS_NAME,
+                    classNameToExtension(titleType),
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_ACTION_CLASS_NAME,
+                    classNameToExtension(actionType),
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_PLACEMENT_CLASS_NAME,
+                    classNameToExtension(placementType),
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_LEADING_FIELD_NAME,
+                    modelLeadingFieldName,
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_TITLE_FIELD_NAME,
+                    modelTitleFieldName,
+                )
+                AddDirectInboxActionModelExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_MODEL_ACTIONS_FIELD_NAME,
+                    modelActionsFieldName,
+                )
+                FindDirectInboxInsertIndexExtensionFingerprint.replaceString(
+                    DIRECT_INBOX_ACTION_PLACEMENT_FIELD_NAME,
+                    actionPlacementFieldName,
+                )
+
                 val returnObjectInstructions = implementation!!.instructions
                     .withIndex()
                     .filter { it.value.opcode == Opcode.RETURN_OBJECT }
@@ -104,3 +192,44 @@ val dmActionBarButtonPatch =
             }
         }
     }
+
+context(patchContext: BytecodePatchContext)
+private fun isDirectInboxActionClass(type: String): Boolean = runCatching {
+    patchContext.mutableClassDefBy(type).methods.any { method ->
+        method.name == "<init>" &&
+            method.parameters.size == 6 &&
+            isEnumClass(method.parameters[0].type) &&
+            method.parameters[1].type == INTEGER_DESCRIPTOR &&
+            method.parameters[2].type == FUNCTION0_DESCRIPTOR &&
+            method.parameters[3].type == FUNCTION1_DESCRIPTOR &&
+            method.parameters[4].type == FUNCTION1_DESCRIPTOR &&
+            method.parameters[5].type == "I"
+    }
+}.getOrDefault(false)
+
+context(patchContext: BytecodePatchContext)
+private fun isEnumClass(type: String): Boolean = runCatching {
+    patchContext.mutableClassDefBy(type).superclass == ENUM_DESCRIPTOR
+}.getOrDefault(false)
+
+context(patchContext: BytecodePatchContext)
+private fun Fingerprint.replaceString(
+    placeholder: String,
+    value: String,
+) {
+    var replaced = false
+    method.instructions
+        .withIndex()
+        .filter { it.value.opcode == Opcode.CONST_STRING }
+        .forEach { (index, instruction) ->
+            val constStringInstruction = instruction as BuilderInstruction21c
+            if (constStringInstruction.reference.toString() == placeholder) {
+                method.replaceInstruction(index, "const-string v${constStringInstruction.registerA}, \"$value\"")
+                replaced = true
+            }
+        }
+
+    check(replaced) {
+        "Could not replace direct inbox action bar placeholder: $placeholder"
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/dmActionBarButton/DMActionBarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/dmActionBarButton/DMActionBarButtonPatch.kt
@@ -8,8 +8,10 @@ package app.crimera.patches.instagram.misc.actionBar.dmActionBarButton
 
 import app.crimera.patches.instagram.utils.Constants.ACTIONBAR_DESCRIPTOR
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.ResourceType
@@ -18,11 +20,24 @@ import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import java.util.logging.Logger
 
 object DMActionBarBuilderFingerprint : Fingerprint(
     returnType = "V",
     filters =
         listOf(resourceLiteral(ResourceType.LAYOUT, "layout_direct_thread_header")),
+)
+
+private object DirectInboxActionBarModelFingerprint : Fingerprint(
+    custom = { methodDef, classDef ->
+        classDef.type == "LX/5GB;" &&
+            methodDef.name == "A00" &&
+            methodDef.parameters.size == 2 &&
+            methodDef.parameters[0].type == "LX/5Fu;" &&
+            methodDef.parameters[1].type == "LX/5GB;" &&
+            methodDef.returnType == "LX/5Sq;"
+    },
 )
 
 val dmActionBarButtonPatch =
@@ -51,6 +66,41 @@ val dmActionBarButtonPatch =
                             """.trimIndent(),
                         )
                     }
+            }
+
+            val directInboxActionBarModelMethod = runCatching {
+                DirectInboxActionBarModelFingerprint.method
+            }.getOrElse {
+                Logger.getLogger(this::class.java.name).warning(
+                    "Skipping ghost mode quick toggle on direct inbox because its action bar hook was not found.\n",
+                )
+                null
+            }
+
+            directInboxActionBarModelMethod?.apply {
+                val actionBarModelType = returnType
+                val returnObjectInstructions = implementation!!.instructions
+                    .withIndex()
+                    .filter { it.value.opcode == Opcode.RETURN_OBJECT }
+
+                check(returnObjectInstructions.isNotEmpty()) {
+                    "Could not find return-object instructions in direct inbox action bar model method"
+                }
+
+                returnObjectInstructions
+                    .asReversed()
+                    .forEach { (index, instruction) ->
+                        val returnRegister = (instruction as OneRegisterInstruction).registerA
+                        addInstructions(
+                            index,
+                            """
+                            invoke-static {v$returnRegister}, $ACTIONBAR_DESCRIPTOR/GhostModeQuickToggle;->addDirectInboxActionModel(Ljava/lang/Object;)Ljava/lang/Object;
+                            move-result-object v$returnRegister
+                            check-cast v$returnRegister, $actionBarModelType
+                            """.trimIndent(),
+                        )
+                    }
+                enableSettings("directInboxGhostModeQuickToggle")
             }
         }
     }

--- a/patches/src/main/resources/addresources/values/instagram/arrays.xml
+++ b/patches/src/main/resources/addresources/values/instagram/arrays.xml
@@ -15,6 +15,28 @@
         <item>timeleft</item>
     </string-array>
 
+    <string-array name="piko_array_ghost_mode_quick_toggle_locations">
+        <item>@string/piko_array_none</item>
+        <item>@string/piko_array_all_locations</item>
+        <item>@string/piko_array_home_and_messages</item>
+        <item>@string/piko_array_home_and_chats</item>
+        <item>@string/piko_array_messages_and_chats</item>
+        <item>@string/piko_array_home</item>
+        <item>@string/piko_array_messages</item>
+        <item>@string/piko_array_chats</item>
+    </string-array>
+
+    <string-array name="piko_array_ghost_mode_quick_toggle_locations_val">
+        <item>none</item>
+        <item>all</item>
+        <item>home_messages</item>
+        <item>home_chats</item>
+        <item>messages_chats</item>
+        <item>home</item>
+        <item>messages</item>
+        <item>chats</item>
+    </string-array>
+
     <string-array name="piko_array_change_like_animation">
         <item>@string/piko_array_default</item>
         <item>Anyway like activation</item>

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -42,7 +42,13 @@
     <string name="piko_ghost_modes_on">Ghost mode: ON</string>
     <string name="piko_ghost_modes_default">Ghost mode: DEFAULT</string>
     <string name="piko_ghost_modes_quick_toggle">Enable quick toggle for ghost modes</string>
-    <string name="piko_ghost_modes_quick_toggle_desc">Adds a quick toggle in chat action bar to control ghost modes</string>
+    <string name="piko_ghost_modes_quick_toggle_desc">Shows ghost mode quick toggle buttons in selected locations</string>
+    <string name="piko_ghost_modes_quick_toggle_home">Show quick toggle on home tab</string>
+    <string name="piko_ghost_modes_quick_toggle_home_desc">Adds the ghost mode quick toggle to the home tab action bar</string>
+    <string name="piko_ghost_modes_quick_toggle_direct_inbox">Show quick toggle in messages</string>
+    <string name="piko_ghost_modes_quick_toggle_direct_inbox_desc">Adds the ghost mode quick toggle to the messages action bar</string>
+    <string name="piko_ghost_modes_quick_toggle_direct_thread">Show quick toggle in chats</string>
+    <string name="piko_ghost_modes_quick_toggle_direct_thread_desc">Adds the ghost mode quick toggle to chat action bars</string>
 
     <!-- Distraction-Free Section -->
     <string name="piko_category_distraction_free">Distraction free</string>

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -41,14 +41,18 @@
     <string name="piko_turn_on_all_ghost_modes">Turn on all ghost modes</string>
     <string name="piko_ghost_modes_on">Ghost mode: ON</string>
     <string name="piko_ghost_modes_default">Ghost mode: DEFAULT</string>
-    <string name="piko_ghost_modes_quick_toggle">Enable quick toggle for ghost modes</string>
-    <string name="piko_ghost_modes_quick_toggle_desc">Shows ghost mode quick toggle buttons in selected locations</string>
-    <string name="piko_ghost_modes_quick_toggle_home">Show quick toggle on home tab</string>
-    <string name="piko_ghost_modes_quick_toggle_home_desc">Adds the ghost mode quick toggle to the home tab action bar</string>
-    <string name="piko_ghost_modes_quick_toggle_direct_inbox">Show quick toggle in messages</string>
-    <string name="piko_ghost_modes_quick_toggle_direct_inbox_desc">Adds the ghost mode quick toggle to the messages action bar</string>
-    <string name="piko_ghost_modes_quick_toggle_direct_thread">Show quick toggle in chats</string>
-    <string name="piko_ghost_modes_quick_toggle_direct_thread_desc">Adds the ghost mode quick toggle to chat action bars</string>
+    <string name="piko_ghost_modes_quick_toggle">Ghost mode quick toggle</string>
+    <string name="piko_ghost_modes_quick_toggle_desc">Shows ghost mode quick toggle buttons</string>
+    <string name="piko_ghost_modes_quick_toggle_locations">Ghost mode quick toggle</string>
+    <string name="piko_ghost_modes_quick_toggle_locations_desc">Choose where to show the ghost mode quick toggle</string>
+    <string name="piko_array_none">None</string>
+    <string name="piko_array_all_locations">All locations</string>
+    <string name="piko_array_home_and_messages">Home and messages</string>
+    <string name="piko_array_home_and_chats">Home and chats</string>
+    <string name="piko_array_messages_and_chats">Messages and chats</string>
+    <string name="piko_array_home">Home</string>
+    <string name="piko_array_messages">Messages</string>
+    <string name="piko_array_chats">Chats</string>
 
     <!-- Distraction-Free Section -->
     <string name="piko_category_distraction_free">Distraction free</string>


### PR DESCRIPTION
Makes the ghost mode quick toggle locations customizable. the existing quick toggle setting still works as the main on/off switch, and when it is enabled users can choose where to show the icon

- Home
- Messages
- Chats

<img width="1080" height="207" alt="Screenshot_20260628_051630_Piko Instagram" src="https://github.com/user-attachments/assets/a88638b0-4fc3-4e34-ad95-da412857496f" />

<img width="1080" height="225" alt="Screenshot_20260628_051738_Piko Instagram" src="https://github.com/user-attachments/assets/de084ce7-2c71-4d8a-b2dc-ff0fe49377f8" />

https://github.com/user-attachments/assets/b25e4c95-9cc6-486b-8d00-aa8a9daa594d

## Testing
- `.\gradlew.bat :patches:build`
- `.\gradlew.bat :patches:checkStringResources`
- Tested on Instagram v435.0.0.37.76 with Piko v3.7.0
- Tested on Samsung Galaxy S26

Closes #1400 and #1430 