### PR TITLE
chore: Add resource mapping dependency, update gradle plugin and patches-library dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-morphe-patcher = "1.5.2"
-morphe-patches-library = "1.4.1"
+morphe-patcher = "1.6.0"
+morphe-patches-library = "1.5.0"
 #noinspection GradleDependency
 smali = "d92701d947"
 gson = "2.14.0"

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/HideNotesTrayPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/HideNotesTrayPatch.kt
@@ -13,11 +13,11 @@ import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.util.findFreeRegister
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
@@ -34,7 +34,7 @@ val hideNotesTrayPatch =
         name = "Hide notes tray",
         description = "Hides notes tray in DM section",
     ) {
-        dependsOn(settingsPatch)
+        dependsOn(settingsPatch, resourceMappingPatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/roundOffNumbers/RoundOffNumbersPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/roundOffNumbers/RoundOffNumbersPatch.kt
@@ -17,6 +17,7 @@ import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import com.android.tools.smali.dexlib2.Opcode
 
 private object RoundOffNumbersFingerprint : Fingerprint(
@@ -39,7 +40,7 @@ val roundOffNumbersPatch =
         description = "Enable or disable rounding off numbers",
     ) {
         compatibleWith(COMPATIBILITY_X)
-        dependsOn(settingsPatch)
+        dependsOn(settingsPatch, resourceMappingPatch)
 
         execute {
             RoundOffNumbersFingerprint.method.apply {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,7 +22,7 @@ pluginManagement {
 }
 
 plugins {
-    id("app.morphe.patches") version "1.3.2"
+    id("app.morphe.patches") version "1.3.3"
 }
 
 settings {


### PR DESCRIPTION
Fixes 'resource mapping not initialized' error with certain combinations of "pick and choose" patching.