### PR TITLE
chore: crediting the PR author in release notes

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -29,6 +29,9 @@
                     { "type": "perf", "section": "🔧 Improvements",  "hidden": false },
                     { "type": "build", "hidden": true }
                 ]
+            },
+            "writerOpts": {
+                "commitPartial": "* {{#if scope}}**{{scope}}:** {{/if}}{{#if subject}}{{subject}}{{else}}{{header}}{{/if}}{{#if hash}} ([{{shortHash}}]({{commitUrlFormat}})){{/if}}{{#if references}}, closes{{#each references}} [{{#if this.owner}}{{this.owner}}/{{/if}}{{this.repository}}#{{this.issue}}]({{issueUrlFormat}}){{/each}}{{/if}}{{#if authorName}} ({{authorName}}){{else}}{{#if author.name}} ({{author.name}}){{/if}}{{/if}}\n"
             }
             }
         ],
@@ -45,9 +48,7 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "./gradlew generatePatchesList \
-          && jq '.version=\"${nextRelease.version}\"' patches-list.json > patches-list.json.tmp && mv patches-list.json.tmp patches-list.json \
-          && python3 .github/scripts/generate_patches_readme.py $GITHUB_REPOSITORY $GITHUB_REF_NAME patches-list.json README.md"
+        "prepareCmd": "./gradlew generatePatchesList && jq '.version=\"${nextRelease.version}\"' patches-list.json > patches-list.json.tmp && mv patches-list.json.tmp patches-list.json && python3 .github/scripts/generate_patches_readme.py $GITHUB_REPOSITORY $GITHUB_REF_NAME patches-list.json README.md"
       }
     ],
     [


### PR DESCRIPTION
### Why
Release notes are a nice, zero-maintenance way to recognize the people whose work ships in each version. Crediting the change author has become something of a community norm for OSS projects — it mirrors GitHub's own auto-generated release notes (`* <change> by @author in #PR`) and what tools like release-drafter do out of the box. Since piko already generates its changelog with `semantic-release`, this just opts that setup into the same convention. Sharing it as a PR in case it's useful — very happy to adjust or drop it if it doesn't fit the project's style.

### What changed
- **🛠 Release notes now include the commit author.** Added a `writerOpts.commitPartial` override to `@semantic-release/release-notes-generator` so each entry ends with the author, e.g.
  `* fix(Instagram): … ([abc1234](commit-url)) (Jane Doe)`
- **📦 Minor:** collapsed the multi-line `prepareCmd` (which used `\` shell line-continuations) onto a single line so `.releaserc` is valid strict JSON — some editors were flagging the `\`+newline as an invalid escape. Behaviour is identical (the sub-commands were already `&&`-chained).

### How it works / safety
- It overrides **only** the per-commit template, so the existing `conventionalcommits` preset — section grouping (✨/🐛/🔧/🚀), issue links, and commit URLs — is untouched.
- The author is rendered inside `{{#if}}` guards and falls back across field names (`authorName` → `author.name`). If neither resolves on a given `semantic-release` version, notes render exactly as before, just without the name — so there's no way for this to break the changelog.
- It reads the commit **author** (never the committer). On squash/rebase merges GitHub preserves the PR author as the commit author, so this credits the contributor, not whoever merged. Bot/`chore` commits are already excluded by the preset's `types`, so they won't clutter the notes.

### Notes
- This uses the git author's display name. The GitHub `@handle` specifically isn't available to `release-notes-generator` without an extra GitHub-API enrichment step — happy to look into that as a follow-up if `@`-mentions are preferred.
- Worth a quick `npx semantic-release --dry-run --no-ci` to eyeball the formatting before merging.
