### PR TITLE
feat(instagram): save deleted messages

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -45,6 +45,7 @@ public class UI {
     public static final String DRAWABLE_SHEILD_ICON = "fb_ic_badge_admin_filled_32";
     public static final String DRAWABLE_SNAPCHAT_ICON = "fb_ic_app_snapchat_filled_16";
     public static final String DRAWABLE_STACK_ICON = "fb_ic_changed_beliefs_outline_24";
+    public static final String DRAWABLE_HISTORY_ICON = "instagram_history_outline_24";
     public static final String DRAWABLE_CODE_ICON = "fb_ic_code_outline_24";
     public static final String DRAWABLE_FRAME_CROSSED_ICON = "fb_ic_frames_cross_outline_16";
     public static final String DRAWABLE_LINK_ICON = "fb_ic_link_outline_24";

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
@@ -1,0 +1,404 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.db;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PikoMessageDb extends SQLiteOpenHelper {
+
+    private static final String DB_NAME = "piko_dm_vault.db";
+    private static final int DB_VERSION = 2;
+    private static final String TABLE = "saved_messages";
+    // sender_id → username directory. MQTT-delivered items carry only a numeric sender_id;
+    // the REST path occasionally carries a full UserInfo. Every time we resolve a username we
+    // persist it here so later MQTT-only items (and notifications) can show the real handle.
+    private static final String DIR_TABLE = "user_directory";
+
+    private static volatile PikoMessageDb instance;
+
+    public static PikoMessageDb getInstance(Context context) {
+        if (instance == null) {
+            synchronized (PikoMessageDb.class) {
+                if (instance == null) {
+                    instance = new PikoMessageDb(context.getApplicationContext());
+                }
+            }
+        }
+        return instance;
+    }
+
+    private PikoMessageDb(Context context) {
+        super(context, DB_NAME, null, DB_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(
+            "CREATE TABLE " + TABLE + " (" +
+            "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+            "message_id TEXT UNIQUE NOT NULL," +
+            "thread_id TEXT NOT NULL," +
+            "sender_id TEXT," +
+            "sender_username TEXT," +
+            "content TEXT," +
+            "message_type TEXT," +
+            "timestamp INTEGER NOT NULL," +
+            "is_deleted INTEGER DEFAULT 0" +
+            ")"
+        );
+        db.execSQL("CREATE INDEX idx_thread_id ON " + TABLE + "(thread_id)");
+        db.execSQL("CREATE INDEX idx_is_deleted ON " + TABLE + "(is_deleted)");
+        createDirTable(db);
+    }
+
+    private void createDirTable(SQLiteDatabase db) {
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS " + DIR_TABLE + " (" +
+            "sender_id TEXT PRIMARY KEY," +
+            "username TEXT NOT NULL" +
+            ")"
+        );
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // Additive upgrade: keep captured messages, just add the new directory table.
+        if (oldVersion < 2) createDirTable(db);
+    }
+
+    /**
+     * Insert a captured message. If the row already exists (same message_id), the insert is
+     * ignored — EXCEPT that any newly-arriving non-empty content / username / sender_id is
+     * written into the existing row when its corresponding column is still empty.
+     *
+     * This matters because the feature captures the same message from multiple hooks at
+     * different times: an early hook may store an empty-content placeholder, and the later
+     * authoritative source (e.g. Hook 4 reading Instagram's own "messages" table at delete
+     * time, or a username resolved after the fact) must be able to fill those blanks in.
+     * A plain CONFLICT_IGNORE would silently drop that better data, leaving the UI showing
+     * "[text]" / "Unknown".
+     */
+    public void insertOrIgnore(String messageId, String threadId, String senderId,
+                               String senderUsername, String content, String type, long timestamp) {
+        if (messageId == null || threadId == null) return;
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues cv = new ContentValues();
+        cv.put("message_id", messageId);
+        cv.put("thread_id", threadId);
+        cv.put("sender_id", senderId);
+        cv.put("sender_username", senderUsername != null ? senderUsername : "");
+        cv.put("content", content != null ? content : "");
+        cv.put("message_type", type != null ? type : "unknown");
+        cv.put("timestamp", timestamp);
+        long rowId = db.insertWithOnConflict(TABLE, null, cv, SQLiteDatabase.CONFLICT_IGNORE);
+
+        // rowId == -1 → conflict, row already existed. Backfill any empty columns with the
+        // newly-supplied non-empty values.
+        if (rowId == -1) {
+            // A media url resolved on a later pass must be able to REPLACE an earlier caption /
+            // placeholder — fillIfEmpty alone would keep the caption, leaving the row non-http and
+            // the media untappable ("media not available"). Any http(s) value upgrades the content.
+            if (content != null && content.startsWith("http")) {
+                upgradeContentToUrl(db, messageId, content);
+            } else {
+                fillIfEmpty(db, messageId, "content", content);
+            }
+            fillIfEmpty(db, messageId, "sender_username", senderUsername);
+            fillIfEmpty(db, messageId, "sender_id", senderId);
+        }
+    }
+
+    /** Overwrite stored content with a media url when the stored value isn't already an http link.
+     *  A media DM is often captured first (MQTT real-time) before its CDN url is resolved, so the
+     *  row lands with a caption or empty placeholder; a later pass (REST thread-history) that finds
+     *  the url must be able to replace that so the item stays tappable / downloadable. */
+    private void upgradeContentToUrl(SQLiteDatabase db, String messageId, String url) {
+        ContentValues cv = new ContentValues();
+        cv.put("content", url);
+        db.update(TABLE, cv,
+            "message_id = ? AND (content IS NULL OR content = '' OR content NOT LIKE 'http%')",
+            new String[]{messageId});
+    }
+
+    /** Update a single column on the existing row only when the new value is non-empty AND
+     *  the stored value is currently null/empty. Preserves is_deleted, timestamp, etc. */
+    private void fillIfEmpty(SQLiteDatabase db, String messageId, String column, String value) {
+        if (value == null || value.isEmpty()) return;
+        ContentValues cv = new ContentValues();
+        cv.put(column, value);
+        db.update(TABLE, cv,
+            "message_id = ? AND (" + column + " IS NULL OR " + column + " = '')",
+            new String[]{messageId});
+    }
+
+    /** Persist a sender_id → username mapping (no-op for empty input). Latest non-empty wins. */
+    public void putUsername(String senderId, String username) {
+        if (senderId == null || senderId.isEmpty() || username == null || username.isEmpty()) return;
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues cv = new ContentValues();
+        cv.put("sender_id", senderId);
+        cv.put("username", username);
+        db.insertWithOnConflict(DIR_TABLE, null, cv, SQLiteDatabase.CONFLICT_REPLACE);
+        // Backfill any stored messages from this sender that still lack a username.
+        ContentValues mv = new ContentValues();
+        mv.put("sender_username", username);
+        db.update(TABLE, mv,
+            "sender_id = ? AND (sender_username IS NULL OR sender_username = '')",
+            new String[]{senderId});
+    }
+
+    /**
+     * Record a chat title as a username — but ONLY for a 1:1 chat, where the title names exactly
+     * one person. In a group the title names no single sender, so blindly applying it to every row
+     * (the old behaviour) made all members' messages show the same name. We therefore resolve the
+     * thread's sole sender and route through the directory (which backfills that sender's rows
+     * everywhere); a group thread (no sole sender) is left untouched.
+     */
+    public void setThreadUsername(String threadId, String username) {
+        if (threadId == null || threadId.isEmpty() || username == null || username.isEmpty()) return;
+        String sole = getSoleSenderId(threadId);
+        if (sole == null) return; // group (or empty) thread → never attribute the title to anyone
+        putUsername(sole, username);
+    }
+
+    /** Look up a previously-resolved username for a sender_id, or null. */
+    public String getUsername(String senderId) {
+        if (senderId == null || senderId.isEmpty()) return null;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(DIR_TABLE, new String[]{"username"},
+                "sender_id = ?", new String[]{senderId}, null, null, null);
+        String result = null;
+        if (c.moveToFirst()) result = c.getString(0);
+        c.close();
+        return (result != null && !result.isEmpty()) ? result : null;
+    }
+
+    /** True if a row for messageId already exists and is NOT yet marked deleted. Used to
+     *  distinguish a live unsend (we saw the message alive first) from a historical unsent
+     *  item that arrives already-hidden during a sync (never seen alive → don't notify). */
+    public boolean isStoredAlive(String messageId) {
+        if (messageId == null) return false;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, new String[]{"is_deleted"}, "message_id = ?",
+                new String[]{messageId}, null, null, null);
+        boolean alive = false;
+        if (c.moveToFirst()) alive = c.getInt(0) == 0;
+        c.close();
+        return alive;
+    }
+
+    /** Permanently remove one saved message from the vault. */
+    public void deleteSaved(String messageId) {
+        if (messageId == null) return;
+        getWritableDatabase().delete(TABLE, "message_id = ?", new String[]{messageId});
+    }
+
+    /** Remove all saved messages (optionally just one thread). Pass null threadId to clear all. */
+    public int clearSaved(String threadId) {
+        if (threadId != null && !threadId.isEmpty()) {
+            return getWritableDatabase().delete(TABLE, "thread_id = ?", new String[]{threadId});
+        }
+        return getWritableDatabase().delete(TABLE, null, null);
+    }
+
+    public void markDeleted(String messageId) {
+        if (messageId == null) return;
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues cv = new ContentValues();
+        cv.put("is_deleted", 1);
+        db.update(TABLE, cv, "message_id = ?", new String[]{messageId});
+    }
+
+    /** Returns sender_username if non-empty, else sender_id (numeric), else null. */
+    public String getSenderDisplay(String messageId) {
+        if (messageId == null) return null;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, new String[]{"sender_username", "sender_id"},
+                "message_id = ?", new String[]{messageId}, null, null, null);
+        String result = null;
+        String uid = null;
+        if (c.moveToFirst()) {
+            String uname = c.getString(0);
+            uid          = c.getString(1);
+            if (uname != null && !uname.isEmpty()) result = uname;
+        }
+        c.close();
+        // Row had no username — consult the directory before falling back to the numeric id.
+        if (result == null && uid != null && !uid.isEmpty()) {
+            String dir = getUsername(uid);
+            result = (dir != null) ? dir : uid;
+        }
+        return result;
+    }
+
+    /** thread_id stored for a message, or null. */
+    public String getThreadIdOf(String messageId) {
+        if (messageId == null) return null;
+        Cursor c = getReadableDatabase().query(TABLE, new String[]{"thread_id"},
+                "message_id = ?", new String[]{messageId}, null, null, null);
+        String r = c.moveToFirst() ? c.getString(0) : null;
+        c.close();
+        return (r != null && !r.isEmpty()) ? r : null;
+    }
+
+    /** message_type stored for a message (e.g. image/video/voice_media), or null. */
+    public String getMessageType(String messageId) {
+        if (messageId == null) return null;
+        Cursor c = getReadableDatabase().query(TABLE, new String[]{"message_type"},
+                "message_id = ?", new String[]{messageId}, null, null, null);
+        String r = c.moveToFirst() ? c.getString(0) : null;
+        c.close();
+        return (r != null && !r.isEmpty() && !"unknown".equals(r)) ? r : null;
+    }
+
+    /** sender_id stored for a message, or null. */
+    public String getSenderId(String messageId) {
+        if (messageId == null) return null;
+        Cursor c = getReadableDatabase().query(TABLE, new String[]{"sender_id"},
+                "message_id = ?", new String[]{messageId}, null, null, null);
+        String r = c.moveToFirst() ? c.getString(0) : null;
+        c.close();
+        return (r != null && !r.isEmpty()) ? r : null;
+    }
+
+    /**
+     * The single distinct sender_id in a thread, or null if the thread has zero or more than one
+     * distinct sender. Used to recognise a 1:1 chat, where the action-bar title reliably names
+     * that one sender. Own outgoing messages are never stored, so they never count here — meaning
+     * a 1:1 thread has exactly one stored sender (the other participant), while a group has 2+ as
+     * soon as a second person sends. This is what keeps the username-learning safe in groups.
+     */
+    public String getSoleSenderId(String threadId) {
+        if (threadId == null || threadId.isEmpty()) return null;
+        SQLiteDatabase db = getReadableDatabase();
+        // distinct = true, limit 2: we only need to know whether there is exactly one.
+        Cursor c = db.query(true, TABLE, new String[]{"sender_id"},
+                "thread_id = ? AND sender_id IS NOT NULL AND sender_id != ''",
+                new String[]{threadId}, null, null, null, "2");
+        String sole = null;
+        int n = 0;
+        while (c.moveToNext()) { sole = c.getString(0); n++; }
+        c.close();
+        return n == 1 ? sole : null;
+    }
+
+    /**
+     * Any non-empty sender_username recorded for a thread, or null. Group-safe: returns a value
+     * ONLY for a 1:1 thread (a sole sender). In a group, an arbitrary member's name would otherwise
+     * be returned and applied to a different sender by the resolution chain — the exact bug where
+     * everyone's messages showed as the same person. Callers using this as a name fallback get null
+     * for groups and fall through to the per-sender directory / numeric id instead.
+     */
+    public String getThreadUsername(String threadId) {
+        if (threadId == null || threadId.isEmpty()) return null;
+        if (getSoleSenderId(threadId) == null) return null; // group thread → no single name
+        Cursor c = getReadableDatabase().query(TABLE, new String[]{"sender_username"},
+                "thread_id = ? AND sender_username IS NOT NULL AND sender_username != ''",
+                new String[]{threadId}, null, null, null, "1");
+        String r = c.moveToFirst() ? c.getString(0) : null;
+        c.close();
+        return (r != null && !r.isEmpty()) ? r : null;
+    }
+
+    public String getStoredContent(String messageId) {
+        if (messageId == null) return null;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, new String[]{"content"}, "message_id = ?",
+                new String[]{messageId}, null, null, null);
+        String result = null;
+        if (c.moveToFirst()) result = c.getString(0);
+        c.close();
+        return (result != null && !result.isEmpty()) ? result : null;
+    }
+
+    // Returns [messageId, threadId, senderUsername, content, messageType, timestamp, senderId]
+    public List<String[]> getDeletedMessages() {
+        List<String[]> result = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, null, "is_deleted = 1", null, null, null, "timestamp DESC");
+        while (c.moveToNext()) {
+            result.add(rowToStringArray(c));
+        }
+        c.close();
+        return result;
+    }
+
+    public List<String[]> getDeletedMessagesForThread(String threadId) {
+        List<String[]> result = new ArrayList<>();
+        // Never scope to the empty-thread bucket: rows stored with thread_id = "" are orphans
+        // (thread id was unknown at capture) and must not surface as a specific chat's history.
+        if (threadId == null || threadId.isEmpty()) return result;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, null, "is_deleted = 1 AND thread_id = ?",
+            new String[]{threadId}, null, null, "timestamp DESC");
+        while (c.moveToNext()) {
+            result.add(rowToStringArray(c));
+        }
+        c.close();
+        return result;
+    }
+
+    // Returns [messageId, threadId, senderUsername, content, messageType, timestamp, isDeleted]
+    public List<String[]> getAllMessages() {
+        List<String[]> result = new ArrayList<>();
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, null, null, null, null, null, "timestamp DESC");
+        while (c.moveToNext()) {
+            result.add(rowToStringArrayFull(c));
+        }
+        c.close();
+        return result;
+    }
+
+    private String[] rowToStringArray(Cursor c) {
+        String senderId = c.getString(c.getColumnIndexOrThrow("sender_id"));
+        return new String[]{
+            c.getString(c.getColumnIndexOrThrow("message_id")),
+            c.getString(c.getColumnIndexOrThrow("thread_id")),
+            resolveUsername(c.getString(c.getColumnIndexOrThrow("sender_username")), senderId),
+            c.getString(c.getColumnIndexOrThrow("content")),
+            c.getString(c.getColumnIndexOrThrow("message_type")),
+            String.valueOf(c.getLong(c.getColumnIndexOrThrow("timestamp"))),
+            senderId
+        };
+    }
+
+    /**
+     * The display username for a row: the stored sender_username if present, otherwise the
+     * sender_id → username directory (populated from thread loads / 1:1 chats). Returns the
+     * stored value (possibly empty) when the directory has no entry, so the caller's existing
+     * numeric-id fallback still applies for a sender we have never seen named.
+     */
+    private String resolveUsername(String storedUsername, String senderId) {
+        if (storedUsername != null && !storedUsername.isEmpty()) return storedUsername;
+        if (senderId != null && !senderId.isEmpty()) {
+            String dir = getUsername(senderId);
+            if (dir != null && !dir.isEmpty()) return dir;
+        }
+        return storedUsername;
+    }
+
+    private String[] rowToStringArrayFull(Cursor c) {
+        return new String[]{
+            c.getString(c.getColumnIndexOrThrow("message_id")),
+            c.getString(c.getColumnIndexOrThrow("thread_id")),
+            resolveUsername(c.getString(c.getColumnIndexOrThrow("sender_username")),
+                    c.getString(c.getColumnIndexOrThrow("sender_id"))),
+            c.getString(c.getColumnIndexOrThrow("content")),
+            c.getString(c.getColumnIndexOrThrow("message_type")),
+            String.valueOf(c.getLong(c.getColumnIndexOrThrow("timestamp"))),
+            String.valueOf(c.getInt(c.getColumnIndexOrThrow("is_deleted")))
+        };
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+
+package app.morphe.extension.instagram.entity;
+
+/**
+ * Wrapper around a single Instagram DM (DirectItem).
+ *
+ * <p>All placeholder names below (e.g. {@code "fieldName"}) are rewritten at patch time by
+ * {@code directItemEntity}, so at runtime this class only does plain reflection on names
+ * already correct for the installed app version. See {@code MediaData} for the reference pattern.
+ *
+ * <p>Reads go through the base class because the MQTT subclass shadows several base fields with
+ * same-named fields of a different type. Reading off the (patched) base class avoids that mix-up.
+ */
+public class DirectItem extends Entity {
+    private final Object obj;
+
+    public DirectItem(Object obj) {
+        super(obj);
+        this.obj = obj;
+    }
+
+    /** Binary name of the DirectItem base class (patched, e.g. {@code X.9ZA}). */
+    private String getBaseClassName() {
+        return "className";
+    }
+
+    /** Loads the base class via the app classloader. */
+    private Class<?> baseClass() throws Exception {
+        return Class.forName(this.getBaseClassName());
+    }
+
+    /** Reads a base-class field, bypassing MQTT subclass field shadowing. */
+    private Object readBaseField(String fieldName) throws Exception {
+        return super.getField(this.baseClass(), this.obj, fieldName);
+    }
+
+    public String getItemId() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v instanceof String ? (String) v : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String getUserId() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v instanceof String ? (String) v : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public String getText() {
+        // REST stores text on the base class; MQTT leaves it null and uses a subclass payload field.
+        try {
+            Object v = this.readBaseField("baseTextField");
+            if (v instanceof CharSequence) return v.toString();
+        } catch (Exception ignored) {
+        }
+        try {
+            Object v = super.getField(this.obj, "subTextField");
+            if (v instanceof CharSequence) return v.toString();
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    /** Raw server timestamp string (microseconds). */
+    private String getTimestampRaw() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v instanceof String ? (String) v : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Timestamp in milliseconds, or {@code now} when unavailable. */
+    public long getTimestampMs() {
+        String raw = this.getTimestampRaw();
+        if (raw != null && !raw.isEmpty()) {
+            try {
+                return Long.parseLong(raw) / 1000L; // microseconds -> milliseconds
+            } catch (NumberFormatException ignored) {
+            }
+        }
+        return System.currentTimeMillis();
+    }
+
+    /** True when the sender has unsent (hidden) this message. */
+    public boolean isHideInThread() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v instanceof Boolean && (Boolean) v;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** True when sent by the logged-in user. */
+    public boolean isSentByViewer() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v instanceof Boolean && (Boolean) v;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /** Clears/sets the hide_in_thread flag (anti-revoke). */
+    public void setHideInThread(boolean hidden) {
+        try {
+            java.lang.reflect.Field f = this.baseClass().getDeclaredField("fieldName");
+            f.setAccessible(true);
+            f.set(this.obj, hidden);
+        } catch (Exception ignored) {
+        }
+    }
+
+    /** Restores the text on both the base and MQTT subclass fields (anti-revoke). */
+    public void setText(String text) {
+        try {
+            java.lang.reflect.Field f = this.baseClass().getDeclaredField("baseTextField");
+            f.setAccessible(true);
+            f.set(this.obj, text);
+        } catch (Exception ignored) {
+        }
+        try {
+            java.lang.reflect.Field f = this.obj.getClass().getDeclaredField("subTextField");
+            f.setAccessible(true);
+            f.set(this.obj, text);
+        } catch (Exception ignored) {
+        }
+    }
+
+    /** item_type as a stable token (enum {@code toString()}), or null. */
+    public String getItemType() {
+        try {
+            Object v = this.readBaseField("fieldName");
+            return v != null ? v.toString() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** The DirectThreadKey object, or null. */
+    private Object getThreadKey() throws Exception {
+        return this.readBaseField("fieldName");
+    }
+
+    /** The numeric thread id this message belongs to, or null. */
+    public String getThreadId() {
+        try {
+            Object key = this.getThreadKey();
+            if (key == null) return null;
+            Object v = super.getField(key, "fieldName");
+            return v instanceof String ? (String) v : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    // Media URL resolution. Every supported shape carries an unobfuscated Media object (the stable
+    // anchor); field names below are placeholders rewritten at patch time by directItemEntity.
+    //   * DIRECT  — a Media field (media, media_share, raven_media).
+    //   * WRAPPED — a reshare/voice wrapper holding a Media (clip, reel_share, voice_media).
+    // Not resolved (no stable type anchor): animated_media, story_share, xma, link -> "[type]" label.
+
+    /** Binary name of the concrete item class (e.g. X/6fW) that declares the media fields. */
+    private String mediaClassName() { return "mediaClassName"; }
+
+    private Class<?> mediaClass() throws Exception { return Class.forName(this.mediaClassName()); }
+
+    // Field-name providers — one placeholder each, rewritten at patch time via changeFirstString.
+    private String fieldMedia()        { return "fieldName"; } // media        -> Media
+    private String fieldMediaShare()   { return "fieldName"; } // media_share  -> Media
+    private String fieldRavenMedia()   { return "fieldName"; } // raven_media  -> Media
+    private String fieldClip()         { return "fieldName"; } // clip         -> wrapper
+    private String fieldClipMedia()    { return "fieldName"; } //   wrapper.Media (by type)
+    private String fieldReel()         { return "fieldName"; } // reel_share   -> wrapper
+    private String fieldReelMedia()    { return "fieldName"; } //   wrapper.Media (by type)
+    private String fieldVoice()        { return "fieldName"; } // voice_media  -> wrapper
+    private String fieldVoiceMedia()   { return "fieldName"; } //   wrapper.Media (by type)
+
+    /** Link from a Media field declared directly on the item class. */
+    private String directMediaUrl(String fieldName) {
+        try {
+            Object media = super.getField(this.mediaClass(), this.obj, fieldName);
+            if (media == null) return null;
+            return new MediaData(media).getMediaLink();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Link from a Media nested one level inside an obfuscated reshare/voice wrapper. */
+    private String wrappedMediaUrl(String wrapperField, String innerMediaField) {
+        try {
+            Object wrapper = super.getField(this.mediaClass(), this.obj, wrapperField);
+            if (wrapper == null) return null;
+            Object media = super.getField(wrapper.getClass(), wrapper, innerMediaField);
+            if (media == null) return null;
+            return new MediaData(media).getMediaLink();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** Audio URL for a voice note (Media.getMessageAudioUrl; no image/video candidate). */
+    private String wrappedAudioUrl(String wrapperField, String innerMediaField) {
+        try {
+            Object wrapper = super.getField(this.mediaClass(), this.obj, wrapperField);
+            if (wrapper == null) return null;
+            Object media = super.getField(wrapper.getClass(), wrapper, innerMediaField);
+            if (media == null) return null;
+            return new MediaData(media).getMessageAudioUrl();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /** First usable media URL (image/video/audio) across all supported DM shapes. */
+    public String getMediaUrl() {
+        String[] urls = {
+            directMediaUrl(this.fieldMedia()),
+            directMediaUrl(this.fieldMediaShare()),
+            directMediaUrl(this.fieldRavenMedia()),
+            wrappedMediaUrl(this.fieldClip(),  this.fieldClipMedia()),
+            wrappedMediaUrl(this.fieldReel(),  this.fieldReelMedia()),
+            wrappedAudioUrl(this.fieldVoice(), this.fieldVoiceMedia()),
+        };
+        for (String u : urls) if (u != null && u.startsWith("http")) return u;
+        return null;
+    }
+
+    /**
+     * Permalink for an xma reshare (shared post/reel), e.g. https://www.instagram.com/reel/<code>/.
+     *
+     * Runtime scan, not patch-time resolution: an xma reshare has no Media object, so the only
+     * patch-time anchor would be opcode/iput sequencing that needs re-RE every version. Instead we
+     * scan for the permalink by its value — an instagram.com/p|reel link is a product-level invariant
+     * that barely changes, so the value is a more stable anchor than any obfuscated field name.
+     * Bounded: walk the item's List fields, first element only, no recursion; scoped to xma by caller.
+     */
+    public String xmaReshareLink() {
+        try {
+            Class<?> c = this.mediaClass();
+            for (java.lang.reflect.Field f : c.getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
+                f.setAccessible(true);
+                Object v = f.get(this.obj);
+                if (!(v instanceof java.util.List)) continue;
+                java.util.List<?> list = (java.util.List<?>) v;
+                if (list.isEmpty()) continue;
+                Object element = list.get(0);
+                if (element == null) continue;
+                String link = firstInstagramPermalink(element);
+                if (link != null) return link;
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+
+    /** First String field on {@code o} whose value is an instagram.com post/reel permalink, query stripped. */
+    private String firstInstagramPermalink(Object o) {
+        try {
+            for (java.lang.reflect.Field g : o.getClass().getDeclaredFields()) {
+                if (java.lang.reflect.Modifier.isStatic(g.getModifiers())) continue;
+                if (g.getType() != String.class) continue;
+                g.setAccessible(true);
+                Object gv = g.get(o);
+                if (!(gv instanceof String)) continue;
+                String s = (String) gv;
+                if (s.startsWith("https://www.instagram.com/")
+                        && (s.contains("/p/") || s.contains("/reel/") || s.contains("/reels/") || s.contains("/tv/"))) {
+                    int q = s.indexOf('?');
+                    return q > 0 ? s.substring(0, q) : s;
+                }
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
@@ -189,6 +189,8 @@ public class DirectItem extends Entity {
     private String fieldReelMedia()    { return "fieldName"; } //   wrapper.Media (by type)
     private String fieldVoice()        { return "fieldName"; } // voice_media  -> wrapper
     private String fieldVoiceMedia()   { return "fieldName"; } //   wrapper.Media (by type)
+    private String fieldVisual()       { return "fieldName"; } // visual_media -> wrapper
+    private String fieldVisualMedia()  { return "fieldName"; } //   wrapper.Media (by type)
 
     /** Link from a Media field declared directly on the item class. */
     private String directMediaUrl(String fieldName) {
@@ -233,6 +235,7 @@ public class DirectItem extends Entity {
             directMediaUrl(this.fieldMedia()),
             directMediaUrl(this.fieldMediaShare()),
             directMediaUrl(this.fieldRavenMedia()),
+            wrappedMediaUrl(this.fieldVisual(), this.fieldVisualMedia()),
             wrappedMediaUrl(this.fieldClip(),  this.fieldClipMedia()),
             wrappedMediaUrl(this.fieldReel(),  this.fieldReelMedia()),
             wrappedAudioUrl(this.fieldVoice(), this.fieldVoiceMedia()),

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/DirectItem.java
@@ -241,45 +241,22 @@ public class DirectItem extends Entity {
         return null;
     }
 
-    /**
-     * Permalink for an xma reshare (shared post/reel), e.g. https://www.instagram.com/reel/<code>/.
-     *
-     * Runtime scan, not patch-time resolution: an xma reshare has no Media object, so the only
-     * patch-time anchor would be opcode/iput sequencing that needs re-RE every version. Instead we
-     * scan for the permalink by its value — an instagram.com/p|reel link is a product-level invariant
-     * that barely changes, so the value is a more stable anchor than any obfuscated field name.
-     * Bounded: walk the item's List fields, first element only, no recursion; scoped to xma by caller.
-     */
+    // xma reshare: the item holds a List of xma elements, each with a permalink String
+    // (JSON "target_url").
+    private String fieldXma()     { return "fieldName"; } // xma List on item
+    private String fieldXmaLink() { return "fieldName"; } // permalink on each element
+
+    /** Permalink for a shared post/reel, e.g. https://www.instagram.com/reel/<code>/. */
     public String xmaReshareLink() {
         try {
-            Class<?> c = this.mediaClass();
-            for (java.lang.reflect.Field f : c.getDeclaredFields()) {
-                if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
-                f.setAccessible(true);
-                Object v = f.get(this.obj);
-                if (!(v instanceof java.util.List)) continue;
-                java.util.List<?> list = (java.util.List<?>) v;
-                if (list.isEmpty()) continue;
-                Object element = list.get(0);
+            Object list = super.getField(this.mediaClass(), this.obj, this.fieldXma());
+            if (!(list instanceof java.util.List)) return null;
+            for (Object element : (java.util.List<?>) list) {
                 if (element == null) continue;
-                String link = firstInstagramPermalink(element);
-                if (link != null) return link;
-            }
-        } catch (Exception ignored) {
-        }
-        return null;
-    }
-
-    /** First String field on {@code o} whose value is an instagram.com post/reel permalink, query stripped. */
-    private String firstInstagramPermalink(Object o) {
-        try {
-            for (java.lang.reflect.Field g : o.getClass().getDeclaredFields()) {
-                if (java.lang.reflect.Modifier.isStatic(g.getModifiers())) continue;
-                if (g.getType() != String.class) continue;
-                g.setAccessible(true);
-                Object gv = g.get(o);
-                if (!(gv instanceof String)) continue;
-                String s = (String) gv;
+                Object v = super.getField(element.getClass(), element, this.fieldXmaLink());
+                if (!(v instanceof String)) continue;
+                String s = (String) v;
+                // only actual post/reel links; other xma types (e.g. xma_link) point elsewhere
                 if (s.startsWith("https://www.instagram.com/")
                         && (s.contains("/p/") || s.contains("/reel/") || s.contains("/reels/") || s.contains("/tv/"))) {
                     int q = s.indexOf('?');

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -41,7 +41,14 @@ public class MediaData extends Entity {
     }
 
     private Object getExtendedData() throws Exception {
-        return super.getField("fieldName");
+        try {
+            Object extendedData = super.getField("fieldName");
+            if (extendedData != null) return extendedData;
+        } catch (Exception ignored) {
+            // v441 folded the mutable media dict into Media itself, so there is no wrapper field to
+            // hop through and the getters sit directly on the media object.
+        }
+        return this.obj;
     }
 
     public String getShortcode() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -10,6 +10,7 @@ package app.morphe.extension.instagram.patches.actionbar;
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
 import android.app.Activity;
+import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -138,7 +139,7 @@ public class ActionBarPatch {
             }
 
             if(SettingsStatus.saveDeletedMessages) {
-                android.content.Context context = viewGroup.getContext();
+                Context context = viewGroup.getContext();
                 UI.addImageViewToViewGroup(viewGroup, UI.DRAWABLE_HISTORY_ICON,
                         () -> SavedMessagesHook.openDeletedMessages(context));
             }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -139,7 +139,7 @@ public class ActionBarPatch {
             }
 
             if(SettingsStatus.saveDeletedMessages) {
-                Context context = viewGroup.getContext();
+                android.content.Context context = viewGroup.getContext();
                 UI.addImageViewToViewGroup(viewGroup, UI.DRAWABLE_HISTORY_ICON,
                         () -> SavedMessagesHook.openDeletedMessages(context));
             }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -22,6 +22,7 @@ import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.entity.ProfileInfo;
 import app.morphe.extension.instagram.patches.userprofile.ProfileMoreOption;
+import app.morphe.extension.instagram.patches.dm.SavedMessagesHook;
 import app.morphe.extension.instagram.entity.UserData;
 import app.morphe.extension.instagram.constants.Constants;
 
@@ -135,6 +136,12 @@ public class ActionBarPatch {
 
             if(pref.contains(Constants.AB_GHOST_MODE_ICON)) {
                 ghostModeToggle(viewGroup);
+            }
+
+            if(SettingsStatus.saveDeletedMessages) {
+                Context context = viewGroup.getContext();
+                UI.addImageViewToViewGroup(viewGroup, UI.DRAWABLE_HISTORY_ICON,
+                        () -> SavedMessagesHook.openDeletedMessages(context));
             }
 
         } catch (Exception e) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
@@ -42,9 +42,9 @@ public class DeletedMessagesActivity extends Activity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        // Instagram is a portrait-only app; lock this screen to portrait so it doesn't follow the
-        // device auto-rotate (which looks broken since the layout is built for portrait).
-        setRequestedOrientation(android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        // Follow the user's own auto-rotate preference (portrait when they've locked rotation,
+        // landscape when they allow it) instead of forcing portrait — keeps tablets/landscape usable.
+        setRequestedOrientation(android.content.pm.ActivityInfo.SCREEN_ORIENTATION_USER);
 
         // When launched from compose-bar button, filter to that thread only.
         // When launched from Piko settings, show all deleted messages.

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
@@ -185,6 +185,24 @@ public class DeletedMessagesActivity extends Activity {
         return ".jpg";
     }
 
+    /**
+     * True when a CDN url has passed the expiry it carries in its own "oe" parameter (hex epoch).
+     * Shared-post permalinks have no such parameter and never expire.
+     */
+    private static boolean isExpiredMediaUrl(String url) {
+        try {
+            int i = url.indexOf("oe=");
+            // Must start a parameter, so "?oe=" or "&oe=" — not a suffix of another name.
+            if (i < 1 || (url.charAt(i - 1) != '?' && url.charAt(i - 1) != '&')) return false;
+            int end = i + 3;
+            while (end < url.length() && Character.digit(url.charAt(end), 16) >= 0) end++;
+            if (end == i + 3) return false;
+            return Long.parseLong(url.substring(i + 3, end), 16) * 1000L < System.currentTimeMillis();
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     /** Offers open/download/copy for a captured media url, via a plain framework AlertDialog. */
     private void showMediaOptions(String messageId, String url, String type) {
         try {
@@ -333,7 +351,8 @@ public class DeletedMessagesActivity extends Activity {
             senderView.setText(who);
             boolean isMediaUrl = content != null && content.startsWith("http");
             if (isMediaUrl) {
-                contentView.setText(mediaLabel(type) + "  ·  " + str("piko_tap_to_view"));
+                contentView.setText(mediaLabel(type) + "  ·  "
+                        + str(isExpiredMediaUrl(content) ? "piko_media_expired" : "piko_tap_to_view"));
             } else {
                 contentView.setText(content != null && !content.isEmpty() ? content
                         : (type != null ? "[" + type + "]" : str("piko_media_deleted_generic")));

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.dm;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.text.format.DateFormat;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseAdapter;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import java.util.Date;
+import java.util.List;
+
+import app.morphe.extension.instagram.constants.UI;
+import app.morphe.extension.instagram.constants.Constants;
+import app.morphe.extension.instagram.db.PikoMessageDb;
+import app.morphe.extension.instagram.patches.download.DownloadUtils;
+import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.shared.Utils;
+import app.morphe.extension.shared.ui.Dim;
+
+public class DeletedMessagesActivity extends Activity {
+
+    private List<String[]> messages;
+    private String threadTitle;
+    private MessageAdapter adapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        // Instagram is a portrait-only app; lock this screen to portrait so it doesn't follow the
+        // device auto-rotate (which looks broken since the layout is built for portrait).
+        setRequestedOrientation(android.content.pm.ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+
+        // When launched from compose-bar button, filter to that thread only.
+        // When launched from Piko settings, show all deleted messages.
+        String threadId = getIntent().getStringExtra("thread_id");
+        // An empty thread id can never scope a real chat — treat it like "no scope" (show all)
+        // instead of matching the orphaned thread_id = "" bucket, which would leak unrelated
+        // chats into a per-person screen.
+        if (threadId != null && threadId.isEmpty()) threadId = null;
+        threadTitle = getIntent().getStringExtra("thread_title");
+        messages = threadId != null
+            ? PikoMessageDb.getInstance(this).getDeletedMessagesForThread(threadId)
+            : PikoMessageDb.getInstance(this).getDeletedMessages();
+
+        String titleText = threadId != null ? str("piko_deleted_in_chat") : str("piko_all_deleted_messages");
+
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+
+        // Toolbar
+        LinearLayout toolbar = new LinearLayout(this);
+        toolbar.setOrientation(LinearLayout.HORIZONTAL);
+        toolbar.setPadding(Dim.dp8, Dim.dp8, Dim.dp8, Dim.dp8);
+
+        ImageView back = new ImageView(this);
+        LinearLayout.LayoutParams backParams = new LinearLayout.LayoutParams(Dim.dp48, Dim.dp48);
+        backParams.gravity = Gravity.CENTER_VERTICAL;
+        back.setLayoutParams(backParams);
+        UI.setThemedIcon(back, "material_ic_keyboard_arrow_left_black_24dp");
+        back.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
+        back.setOnClickListener(v -> finish());
+
+        TextView title = new TextView(this);
+        title.setText(titleText);
+        title.setTextSize(TypedValue.COMPLEX_UNIT_PX, PikoUtils.spToPixels(20));
+        title.setTextColor(UI.getThemedColour("igds_color_primary_icon"));
+        LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT,
+            LinearLayout.LayoutParams.WRAP_CONTENT
+        );
+        titleParams.gravity = Gravity.CENTER_VERTICAL;
+        titleParams.leftMargin = Dim.dp8 / 2;
+        title.setLayoutParams(titleParams);
+
+        toolbar.addView(back);
+        toolbar.addView(title);
+
+        // "Clear" action — wipes this chat's saved messages (or all, from settings entry).
+        final String clearThreadId = threadId;
+        TextView clear = new TextView(this);
+        clear.setText(str("piko_clear"));
+        clear.setTextSize(TypedValue.COMPLEX_UNIT_PX, PikoUtils.spToPixels(16));
+        clear.setTextColor(UI.getThemedColour("igds_color_primary_icon"));
+        clear.setPadding(Dim.dp8, Dim.dp8, Dim.dp8, Dim.dp8);
+        LinearLayout.LayoutParams clearParams = new LinearLayout.LayoutParams(
+            LinearLayout.LayoutParams.WRAP_CONTENT, LinearLayout.LayoutParams.WRAP_CONTENT, 0);
+        clearParams.gravity = Gravity.CENTER_VERTICAL;
+        clear.setLayoutParams(clearParams);
+        // push Clear to the right
+        LinearLayout.LayoutParams titleP = (LinearLayout.LayoutParams) title.getLayoutParams();
+        titleP.weight = 1; title.setLayoutParams(titleP);
+        clear.setOnClickListener(v -> new android.app.AlertDialog.Builder(this)
+            .setMessage(clearThreadId != null ? str("piko_clear_chat_confirm") : str("piko_clear_all_confirm"))
+            .setPositiveButton(str("piko_clear"), (d, w) -> {
+                PikoMessageDb.getInstance(this).clearSaved(clearThreadId);
+                messages.clear();
+                recreate();
+            })
+            .setNegativeButton(str("piko_cancel"), null)
+            .show());
+        toolbar.addView(clear);
+        root.addView(toolbar);
+
+        if (messages.isEmpty()) {
+            TextView empty = new TextView(this);
+            empty.setText(str("piko_no_deleted_messages"));
+            empty.setGravity(Gravity.CENTER);
+            empty.setPadding(Dim.dp8 * 2, Dim.dp8 * 4, Dim.dp8 * 2, Dim.dp8 * 4);
+            empty.setTextColor(UI.getThemedColour("igds_color_primary_icon"));
+            root.addView(empty, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                1
+            ));
+        } else {
+            ListView listView = new ListView(this);
+            adapter = new MessageAdapter();
+            listView.setAdapter(adapter);
+            listView.setDividerHeight(1);
+            listView.setOnItemClickListener((parent, view, pos, idLong) -> {
+                String[] m = messages.get(pos);
+                String messageId = m[0];
+                String c = m[3];
+                String t = m[4];
+                if (c != null && c.startsWith("http")) {
+                    showMediaOptions(messageId, c, t);
+                } else if (t != null && !"text".equals(t)) {
+                    android.widget.Toast.makeText(this, str("piko_media_not_available"),
+                            android.widget.Toast.LENGTH_SHORT).show();
+                }
+            });
+            listView.setOnItemLongClickListener((parent, view, pos, idLong) -> {
+                String[] m = messages.get(pos);
+                new android.app.AlertDialog.Builder(this)
+                    .setMessage(str("piko_delete_saved_confirm"))
+                    .setPositiveButton(str("piko_delete"), (d, w) -> {
+                        PikoMessageDb.getInstance(this).deleteSaved(m[0]); // m[0] = message_id
+                        messages.remove(pos);
+                        adapter.notifyDataSetChanged();
+                    })
+                    .setNegativeButton(str("piko_cancel"), null)
+                    .show();
+                return true;
+            });
+            root.addView(listView, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                1
+            ));
+        }
+
+        root.setOnApplyWindowInsetsListener((v, insets) -> {
+            v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+            return insets;
+        });
+
+        setContentView(root);
+    }
+
+    /** Extension guess from the captured CDN url, falling back to the stored message type. */
+    private static String guessExtension(String url, String type) {
+        java.util.regex.Matcher m = java.util.regex.Pattern
+                .compile("(?i)\\.(jpg|jpeg|webp|heic|png|mp4|mov|m4a|aac|mp3|ogg|gif)(?:\\?.*)?$")
+                .matcher(url);
+        if (m.find()) return "." + m.group(1).toLowerCase();
+        if ("voice_media".equals(type) || "audio".equals(type)) return ".m4a";
+        if ("video".equals(type)) return ".mp4";
+        if ("animated_media".equals(type)) return ".gif";
+        return ".jpg";
+    }
+
+    /** Offers open/download/copy for a captured media url, via a plain framework AlertDialog. */
+    private void showMediaOptions(String messageId, String url, String type) {
+        try {
+            final boolean isAudio = "voice_media".equals(type) || "audio".equals(type)
+                    || url.matches("(?i).*\\.(m4a|aac|mp3|ogg)(\\?.*)?$");
+            final boolean isVideo = "video".equals(type) || "clip".equals(type) || "xma_clip".equals(type);
+            // A shared post/reel is stored as an instagram.com permalink and opens inside the IG app,
+            // so label its action "Open in Instagram" rather than "open externally".
+            final boolean isShare = url.contains("instagram.com/reel/")
+                    || url.contains("instagram.com/p/") || url.contains("instagram.com/tv/");
+
+            final CharSequence[] options = new CharSequence[] {
+                str("piko_download_current_media"),
+                isShare ? str("piko_open_share_in_instagram")
+                        : isAudio ? str("piko_open_voice_with_player")
+                        : isVideo ? str("piko_open_video_externally")
+                        : str("piko_open_image_externally"),
+                str("piko_copy_media_link"),
+            };
+
+            new android.app.AlertDialog.Builder(this)
+                .setTitle(str("piko_download_options"))
+                .setItems(options, (d, which) -> {
+                    try {
+                        if (which == 0) {
+                            String fileName = "piko_" + messageId + guessExtension(url, type);
+                            DownloadUtils.downloadMediaUrl(this, url, Constants.DEFAULT_DM_FOLDER, fileName);
+                        } else if (which == 2) {
+                            Utils.setClipboard(url);
+                            Utils.showToastShort(str("piko_copied_media_link"));
+                        } else {
+                            android.net.Uri uri = android.net.Uri.parse(url);
+                            // Reels/posts are stored as instagram.com permalinks — open them inside
+                            // the Instagram app itself (setPackage) so they render natively; only fall
+                            // back to a browser chooser if IG can't handle the link.
+                            boolean igLink = url.contains("instagram.com/reel/")
+                                    || url.contains("instagram.com/p/")
+                                    || url.contains("instagram.com/tv/");
+                            boolean opened = false;
+                            if (igLink) {
+                                try {
+                                    startActivity(new android.content.Intent(
+                                            android.content.Intent.ACTION_VIEW, uri)
+                                            .setPackage("com.instagram.android"));
+                                    opened = true;
+                                } catch (android.content.ActivityNotFoundException ignored) {}
+                            }
+                            if (!opened) {
+                                android.content.Intent i = new android.content.Intent(
+                                        android.content.Intent.ACTION_VIEW, uri);
+                                if (isAudio) i.setDataAndType(uri, "audio/*");
+                                startActivity(android.content.Intent.createChooser(i, null));
+                            }
+                        }
+                    } catch (Exception e) {
+                        android.util.Log.e("piko", "showMediaOptions action: " + e);
+                    }
+                })
+                .show();
+        } catch (Exception e) {
+            android.util.Log.e("piko", "showMediaOptions: " + e);
+        }
+    }
+
+    private static String mediaLabel(String type) {
+        if (type == null) return "[" + str("piko_media_unknown") + "]";
+        String label;
+        switch (type) {
+            case "media":
+            case "image":          label = str("piko_media_photo"); break;
+            case "video":          label = str("piko_media_video"); break;
+            case "voice_media":
+            case "audio":          label = str("piko_media_voice"); break;
+            case "animated_media": label = str("piko_media_gif"); break;
+            case "reel_share":     label = str("piko_media_reel"); break;
+            case "story_share":    label = str("piko_media_story"); break;
+            case "media_share":    label = str("piko_media_post"); break;
+            case "clip":
+            case "xma_clip":       label = str("piko_media_reel"); break;
+            default:               return "[" + type + "]";
+        }
+        return "[" + label + "]";
+    }
+
+    private class MessageAdapter extends BaseAdapter {
+
+        @Override public int getCount() { return messages.size(); }
+        @Override public Object getItem(int pos) { return messages.get(pos); }
+        @Override public long getItemId(int pos) { return pos; }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            LinearLayout row;
+            TextView senderView, contentView, metaView;
+
+            if (convertView == null) {
+                row = new LinearLayout(DeletedMessagesActivity.this);
+                row.setOrientation(LinearLayout.VERTICAL);
+                int pad = Dim.dp8;
+                row.setPadding(pad * 2, pad, pad * 2, pad);
+
+                senderView = new TextView(DeletedMessagesActivity.this);
+                senderView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 13);
+                senderView.setTextColor(UI.getThemedColour("igds_color_primary_icon"));
+                senderView.setTag("s");
+
+                contentView = new TextView(DeletedMessagesActivity.this);
+                contentView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 16);
+                contentView.setTag("c");
+
+                metaView = new TextView(DeletedMessagesActivity.this);
+                metaView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 11);
+                metaView.setTag("m");
+
+                row.addView(senderView);
+                row.addView(contentView);
+                row.addView(metaView);
+            } else {
+                row = (LinearLayout) convertView;
+                senderView = row.findViewWithTag("s");
+                contentView = row.findViewWithTag("c");
+                metaView    = row.findViewWithTag("m");
+            }
+
+            // [messageId, threadId, senderUsername, content, messageType, timestamp, senderId]
+            String[] msg = messages.get(position);
+            String sender    = msg[2];
+            String content   = msg[3];
+            String type      = msg[4];
+            String senderId  = msg.length > 6 ? msg[6] : null;
+            long   timestamp = 0;
+            try { timestamp = Long.parseLong(msg[5]); } catch (Exception ignored) {}
+
+            // Attribute each row by its own sender, never by the screen-level chat title (that would
+            // show every sender as the same person). Order: username -> numeric sender id -> title.
+            final String who;
+            if (sender != null && !sender.isEmpty()) {
+                who = "@" + sender;
+            } else if (senderId != null && !senderId.isEmpty()) {
+                who = "@" + senderId;
+            } else if (threadTitle != null && !threadTitle.isEmpty()) {
+                who = threadTitle; // chat title from action bar (participant's name)
+            } else {
+                who = str("piko_unknown");
+            }
+            senderView.setText(who);
+            boolean isMediaUrl = content != null && content.startsWith("http");
+            if (isMediaUrl) {
+                contentView.setText(mediaLabel(type) + "  ·  " + str("piko_tap_to_view"));
+            } else {
+                contentView.setText(content != null && !content.isEmpty() ? content
+                        : (type != null ? "[" + type + "]" : str("piko_media_deleted_generic")));
+            }
+            metaView.setText(DateFormat.format("MMM dd, yyyy  HH:mm", new Date(timestamp)));
+
+            return row;
+        }
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
@@ -1,0 +1,477 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.dm;
+
+import android.content.Context;
+import android.content.Intent;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import java.lang.reflect.Field;
+
+import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.instagram.db.PikoMessageDb;
+import app.morphe.extension.instagram.entity.DirectItem;
+import app.morphe.extension.instagram.entity.UserData;
+import app.morphe.extension.instagram.utils.Pref;
+
+/** Runtime hooks for "Save deleted messages". Fields resolved at patch time via DirectItem entity. */
+@SuppressWarnings("unused")
+public class SavedMessagesHook {
+
+    private static void piko(String msg) {
+        android.util.Log.e("piko", msg);
+    }
+
+    private static volatile String sCurrentThreadId;
+    private static volatile String sCurrentThreadTitle;
+
+    public static void noteThreadTitle(String title) {
+        if (title == null || title.trim().isEmpty()) return;
+        sCurrentThreadTitle = title.trim();
+        // Persist for the current thread so the all-chats screen and notifications show a name too.
+        try {
+            if (sCurrentThreadId != null && !sCurrentThreadId.isEmpty()) {
+                PikoMessageDb.getInstance(PikoUtils.getContext())
+                        .setThreadUsername(sCurrentThreadId, sCurrentThreadTitle);
+            }
+        } catch (Exception ignored) {}
+    }
+
+    public static void noteOpenThreadId(String threadId) {
+        if (threadId != null && !threadId.isEmpty()) sCurrentThreadId = threadId;
+    }
+
+    /** Hook 6: harvest participant id→username from the thread deserializer's user list. */
+    public static void noteThreadUsers(final java.util.List<?> users) {
+        if (users == null || users.isEmpty()) return;
+        if (!Pref.saveDeletedMessages()) return;
+        final java.util.ArrayList<Object> copy;
+        try { copy = new java.util.ArrayList<Object>(users); } catch (Throwable t) { return; }
+        getWorker().post(new Runnable() { @Override public void run() {
+            try {
+                PikoMessageDb db = PikoMessageDb.getInstance(PikoUtils.getContext());
+                for (Object u : copy) {
+                    if (u == null) continue;
+                    try {
+                        UserData ud = new UserData(u);
+                        String id = ud.getUserId();
+                        if (id == null || !id.matches("\\d{6,14}")) continue;
+                        String name = ud.getUsername();
+                        if (name == null || name.isEmpty()) name = ud.getFullName();
+                        if (name != null && !name.isEmpty()) db.putUsername(id, name);
+                    } catch (Throwable ignored) {}
+                }
+            } catch (Throwable ignored) {}
+        }});
+    }
+
+    /** Most-recent DM action-bar controller, held weakly. Thread id is read lazily via BFS. */
+    private static java.lang.ref.WeakReference<Object> sOpenThreadController;
+
+    /** Hook 5: records the action-bar controller so its thread id can be read on button click. */
+    public static void noteOpenThreadController(final Object controller) {
+        if (controller == null) return;
+        sOpenThreadController = new java.lang.ref.WeakReference<>(controller);
+    }
+
+    private static String resolveOpenThreadId() {
+        if (sCurrentThreadId != null && !sCurrentThreadId.isEmpty()) return sCurrentThreadId;
+        java.lang.ref.WeakReference<Object> ref = sOpenThreadController;
+        Object controller = (ref != null) ? ref.get() : null;
+        if (controller == null) return null;
+        return deepFindThreadId(controller);
+    }
+
+    /** Opens the deleted-messages screen for the current thread (or all if unknown). */
+    public static void openDeletedMessages(Context ctx) {
+        try {
+            if (ctx == null) ctx = PikoUtils.getContext();
+            if (ctx == null) return;
+            String openThreadId = resolveOpenThreadId();
+            Intent intent = new Intent(ctx, DeletedMessagesActivity.class);
+            if (openThreadId != null && !openThreadId.isEmpty()) {
+                intent.putExtra("thread_id", openThreadId);
+            }
+            if (sCurrentThreadTitle != null && !sCurrentThreadTitle.isEmpty()) {
+                intent.putExtra("thread_title", sCurrentThreadTitle);
+            }
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            ctx.startActivity(intent);
+        } catch (Exception e) {
+            piko("SavedMessagesHook.openDeletedMessages: " + e);
+        }
+    }
+
+    // Our own user id, learned from messages whose is_sent_by_viewer flag is set (and persisted),
+    // so even a freshly-sent message is recognised as own by comparing sender ids — no session reflection.
+    private static volatile String sMyUserId;
+
+    private static String myUserId() {
+        if (sMyUserId == null) {
+            try {
+                Context ctx = PikoUtils.getContext();
+                if (ctx != null) {
+                    String v = ctx.getSharedPreferences("piko_dm", Context.MODE_PRIVATE)
+                            .getString("my_user_id", null);
+                    if (v != null && !v.isEmpty()) sMyUserId = v;
+                }
+            } catch (Exception ignored) {}
+        }
+        return sMyUserId;
+    }
+
+    private static void rememberMyUserId(String id) {
+        if (id == null || id.isEmpty() || id.equals(sMyUserId)) return;
+        sMyUserId = id;
+        try {
+            Context ctx = PikoUtils.getContext();
+            if (ctx != null) {
+                ctx.getSharedPreferences("piko_dm", Context.MODE_PRIVATE)
+                        .edit().putString("my_user_id", id).apply();
+            }
+        } catch (Exception ignored) {}
+    }
+
+    /** True when senderId is the logged-in user (an own outgoing message). */
+    private static boolean isOwnSender(String senderId) {
+        String me = myUserId();
+        return senderId != null && me != null && senderId.equals(me);
+    }
+
+    /**
+     * The open chat's title, but only when it is the currently-open thread AND a 1:1 chat
+     * (so the title names exactly one sender). In a group the title is the group name, which
+     * would misattribute every sender — return null there so callers fall back to the directory.
+     */
+    private static String openChatTitleFor(PikoMessageDb db, String threadId) {
+        if (threadId == null || sCurrentThreadTitle == null) return null;
+        if (!threadId.equals(sCurrentThreadId)) return null;
+        return db.getSoleSenderId(threadId) != null ? sCurrentThreadTitle : null;
+    }
+
+    // Hook 1 (REST): fires from LX/0gL;.parseFromJson (thread-history loads).
+    // Hook 2 (MQTT): fires from LX/0gF;.A0P (real-time MSys delivery).
+    // Both pass the item as Object; reflection extracts the fields via DirectItem.
+
+    // Background thread so the MQTT delivery thread is never blocked.
+    private static android.os.HandlerThread sWorkerThread;
+    private static android.os.Handler sWorker;
+
+    private static synchronized android.os.Handler getWorker() {
+        if (sWorker == null) {
+            sWorkerThread = new android.os.HandlerThread("piko-dm-hook");
+            sWorkerThread.start();
+            sWorker = new android.os.Handler(sWorkerThread.getLooper());
+        }
+        return sWorker;
+    }
+
+    // Dedup set of item_ids already queued (bounded to 2000 via eldest-entry eviction).
+    private static final java.util.Map<String, Boolean> SEEN_ITEM_IDS =
+        java.util.Collections.synchronizedMap(new java.util.LinkedHashMap<String, Boolean>() {
+            @Override protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> e) {
+                return size() > 2000;
+            }
+        });
+
+    // Notification dedup: a live unsend can surface via Hook 2 (re-delivery) and Hook 4 (DB hide).
+    // Notify at most once per message_id (bounded, eldest-evicted).
+    private static final java.util.Map<String, Boolean> NOTIFIED_IDS =
+        java.util.Collections.synchronizedMap(new java.util.LinkedHashMap<String, Boolean>() {
+            @Override protected boolean removeEldestEntry(java.util.Map.Entry<String, Boolean> e) {
+                return size() > 1000;
+            }
+        });
+
+    /** True the first time this message_id is offered for notification; false on repeats. */
+    private static boolean claimNotification(String messageId) {
+        if (messageId == null) return true; // can't dedup → allow
+        return NOTIFIED_IDS.put(messageId, Boolean.TRUE) == null;
+    }
+
+    /** Hook 1 (REST): the parsed DirectItem carries its own thread_key, so no hint is needed. */
+    public static void onMessageReceived(final Object item) {
+        onMessageReceived(item, null);
+    }
+
+    /**
+     * Hook 2 (MQTT/MSys): the item's thread_key is null here, so the patch passes the thread id
+     * read from the MSys delta (A0P's p2) as {@code threadIdHint}.
+     */
+    public static void onMessageReceived(final Object item, final String threadIdHint) {
+        // Runs on the MQTT thread — return instantly; all work is posted to sWorker.
+        if (item == null) return;
+        if (!Pref.saveDeletedMessages()) return;
+        // Class guard: only X.* (obfuscated IG classes) are DirectItem candidates.
+        if (!item.getClass().getName().startsWith("X.")) return;
+
+        getWorker().post(new Runnable() { @Override public void run() {
+            processReceivedItem(item, threadIdHint);
+        }});
+    }
+
+    private static void processReceivedItem(Object item, String threadIdHint) {
+        try {
+            DirectItem di = new DirectItem(item);
+            String senderId = di.getUserId();
+            if (di.isSentByViewer()) {
+                rememberMyUserId(senderId);
+                return;
+            }
+            if (isOwnSender(senderId)) return;
+            String messageId  = di.getItemId();
+            boolean deleted = di.isHideInThread();
+            // dedup key includes deletion state — alive vs unsent are different events
+            if (messageId != null
+                    && SEEN_ITEM_IDS.put(messageId + (deleted ? ":1" : ":0"), Boolean.TRUE) != null) return;
+            String threadId   = di.getThreadId();
+            PikoMessageDb db = PikoMessageDb.getInstance(PikoUtils.getContext());
+            // sender name: id→handle directory first, then thread title, then open-chat title
+            String senderUser = db.getUsername(senderId);
+            if (senderUser == null) senderUser = db.getThreadUsername(threadId);
+            if (senderUser == null) senderUser = openChatTitleFor(db, threadId);
+            String content    = di.getText();
+            String type       = di.getItemType();
+            if (type != null) type = type.trim().toLowerCase();
+            long   timestamp  = di.getTimestampMs();
+
+            if ("action_log".equals(type) || "expired_placeholder".equals(type)
+                    || "placeholder".equals(type)) return;
+
+            // For non-text items, capture the CDN/permalink so media stays recoverable. A caption
+            // must not block this: media-with-caption would otherwise store the caption (not a URL)
+            // and become non-tappable — the root of the "media not available" reports.
+            if (type != null && !type.equals("text")
+                    && (content == null || content.isEmpty() || !content.startsWith("http"))) {
+                // Media URL is resolved via the DirectItem entity (patch-time resolved field names).
+                // Unsupported shapes (animated_media/story_share/xma/link) return null → "[type]" label.
+                String url = di.getMediaUrl();
+                // xma reshares carry no CDN media — recover the permalink instead.
+                if (url == null && type != null && type.startsWith("xma")) url = di.xmaReshareLink();
+                if (url != null && url.startsWith("http")) content = url;
+            }
+
+            if (messageId == null) {
+                // MQTT subclass (X.0gF) may not resolve item_id — derive a synthetic key from
+                // sender + timestamp so a later unsend maps back to the same row.
+                if (senderId != null) {
+                    messageId = "syn:" + senderId + ":" + timestamp;
+                } else {
+                    return;
+                }
+            }
+
+            // MQTT path: thread_id comes from the MSys delta passed as threadIdHint.
+            if ((threadId == null || threadId.isEmpty())
+                    && threadIdHint != null && !threadIdHint.isEmpty()) {
+                threadId = threadIdHint;
+            }
+            if (threadId == null) threadId = "";
+
+            if (deleted) {
+                // Only notify when we previously captured this message alive.
+                boolean liveDeletion = db.isStoredAlive(messageId);
+                db.insertOrIgnore(messageId, threadId, senderId, senderUser, content, type, timestamp);
+                db.markDeleted(messageId);
+                if (liveDeletion && claimNotification(messageId)) {
+                    String notifySender = (senderUser != null) ? senderUser
+                            : db.getThreadUsername(threadId);
+                    if (notifySender == null) notifySender = openChatTitleFor(db, threadId);
+                    if (notifySender == null) notifySender = db.getSenderDisplay(messageId);
+                    String notifyBody   = (content != null && !content.isEmpty())
+                            ? content : db.getStoredContent(messageId);
+                    notifyDeletion(notifySender, notifyBody, type);
+                }
+
+                String storedContent = (content != null && !content.isEmpty())
+                        ? content : db.getStoredContent(messageId);
+                antiRevokeItem(di, storedContent);
+            } else {
+                db.insertOrIgnore(messageId, threadId, senderId, senderUser, content, type, timestamp);
+            }
+
+            // Backfill the 1:1 sender name into the directory (sole-sender guard prevents group misattribution).
+            if (sCurrentThreadTitle != null && threadId.equals(sCurrentThreadId)
+                    && senderId != null && senderId.equals(db.getSoleSenderId(threadId))) {
+                db.putUsername(senderId, sCurrentThreadTitle);
+            }
+        } catch (Exception e) {
+            piko("SavedMessagesHook.processReceivedItem: " + e);
+        }
+    }
+
+    private static void antiRevokeItem(DirectItem di, String restoredContent) {
+        di.setHideInThread(false);
+        if (restoredContent != null && !restoredContent.isEmpty()) {
+            di.setText(restoredContent);
+        }
+    }
+
+    private static void notifyDeletion(String sender, String content, String type) {
+        try {
+            Context ctx = PikoUtils.getContext();
+            if (ctx == null) return;
+
+            android.app.NotificationManager nm =
+                (android.app.NotificationManager) ctx.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (nm == null) return;
+
+            String channelId = "piko_deleted_messages";
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
+                android.app.NotificationChannel ch = new android.app.NotificationChannel(
+                    channelId, str("piko_deleted_messages_channel"), android.app.NotificationManager.IMPORTANCE_DEFAULT);
+                ch.setDescription(str("piko_deleted_messages_channel_desc"));
+                nm.createNotificationChannel(ch);
+            }
+
+            String who = (sender != null && !sender.isEmpty()) ? sender : str("piko_someone");
+            String body = (content != null && !content.isEmpty())
+                    ? content
+                    : (type != null && !type.isEmpty()) ? "[" + type + "]" : str("piko_media_deleted_generic");
+
+            Intent intent = new Intent(ctx, DeletedMessagesActivity.class);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            int piFlags = android.app.PendingIntent.FLAG_UPDATE_CURRENT
+                | (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M
+                    ? android.app.PendingIntent.FLAG_IMMUTABLE : 0);
+            android.app.PendingIntent pi = android.app.PendingIntent.getActivity(ctx, 0, intent, piFlags);
+
+            int iconRes = ctx.getApplicationInfo().icon;
+            android.app.Notification.Builder b =
+                android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O
+                    ? new android.app.Notification.Builder(ctx, channelId)
+                    : new android.app.Notification.Builder(ctx);
+            android.app.Notification n = b
+                .setSmallIcon(iconRes != 0 ? iconRes : android.R.drawable.ic_dialog_info)
+                .setContentTitle(String.format(str("piko_deleted_a_message"), who))
+                .setContentText(body)
+                .setAutoCancel(true)
+                .setContentIntent(pi)
+                .build();
+
+            nm.notify((int) (System.currentTimeMillis() & 0x7fffffff), n);
+        } catch (Exception e) {
+            piko("SavedMessagesHook.notifyDeletion: " + e);
+        }
+    }
+
+    public static void onMessageHiddenFromDb(Object dao, String serverId, String clientId) {
+        try {
+            if (!Pref.saveDeletedMessages()) return;
+
+            String itemId = (serverId != null && !serverId.isEmpty()) ? serverId : clientId;
+            if (itemId == null) return;
+
+            PikoMessageDb vault = PikoMessageDb.getInstance(PikoUtils.getContext());
+            boolean wasReceived = vault.isStoredAlive(itemId);
+            String messageType = vault.getMessageType(itemId);
+            boolean own = isOwnSender(vault.getSenderId(itemId));
+
+            vault.insertOrIgnore(itemId, "", null, null, null, messageType, System.currentTimeMillis());
+            vault.markDeleted(itemId);
+
+            if (wasReceived && !own && claimNotification(itemId)) {
+                String stored = vault.getStoredContent(itemId);
+                boolean isMedia = stored == null || stored.isEmpty()
+                        || stored.startsWith("http") || stored.startsWith("[");
+                String notifBody = isMedia ? describeMediaType(messageType) : stored;
+                String storedThreadId = vault.getThreadIdOf(itemId);
+                String name = vault.getThreadUsername(storedThreadId);
+                if (name == null) name = openChatTitleFor(vault, storedThreadId);
+                if (name == null) name = vault.getSenderDisplay(itemId);
+                notifyDeletion(name, notifBody, messageType);
+            }
+        } catch (Exception e) {
+            piko("SavedMessagesHook.onMessageHiddenFromDb: " + e);
+        }
+    }
+
+    private static String describeMediaType(String type) {
+        if (type == null) return str("piko_media_deleted_generic");
+        String label;
+        switch (type) {
+            case "media":
+            case "image":           label = str("piko_media_photo"); break;
+            case "raven_media":     label = str("piko_media_disappearing_photo"); break;
+            case "video":           label = str("piko_media_video"); break;
+            case "voice_media":
+            case "audio":           label = str("piko_media_voice"); break;
+            case "animated_media":  label = str("piko_media_gif"); break;
+            case "reel_share":      label = str("piko_media_reel"); break;
+            case "story_share":     label = str("piko_media_story"); break;
+            case "media_share":     label = str("piko_media_post"); break;
+            case "like":            label = str("piko_media_like"); break;
+            case "link":            label = str("piko_media_link"); break;
+            case "action_log":      label = str("piko_media_activity"); break;
+            default:                label = type; break;
+        }
+        return String.format(str("piko_media_deleted"), label);
+    }
+
+
+    /** BFS over the controller graph to find a DirectThreadKey and read the thread id string. */
+    private static String deepFindThreadId(Object root) {
+        try {
+            java.util.IdentityHashMap<Object, Boolean> seen = new java.util.IdentityHashMap<>();
+            java.util.ArrayDeque<Object> q = new java.util.ArrayDeque<>();
+            q.add(root); seen.put(root, Boolean.TRUE);
+            int budget = 6000;
+            String digitCandidate = null;
+            while (!q.isEmpty() && budget-- > 0) {
+                Object o = q.poll();
+                Class<?> k = o.getClass();
+                if (k.isArray() && !k.getComponentType().isPrimitive()) {
+                    for (Object el : (Object[]) o) if (el != null && seen.put(el, Boolean.TRUE) == null) q.add(el);
+                    continue;
+                }
+                String kn = k.getName();
+                if (!(kn.startsWith("X.") || kn.startsWith("com.instagram"))) continue;
+                if (kn.equals("com.instagram.model.direct.DirectThreadKey")) {
+                    for (Class<?> cc = k; cc != null && cc != Object.class; cc = cc.getSuperclass()) {
+                        for (Field f : cc.getDeclaredFields()) {
+                            if (f.getType() != String.class) continue;
+                            try {
+                                f.setAccessible(true);
+                                Object fv = f.get(o);
+                                if (fv instanceof String) {
+                                    String s = (String) fv;
+                                    if (s.length() >= 15 && s.matches("\\d+")) return s;
+                                }
+                            } catch (Throwable ignored) {}
+                        }
+                    }
+                    continue;
+                }
+                for (Class<?> cc = k; cc != null && cc != Object.class; cc = cc.getSuperclass()) {
+                    for (Field f : cc.getDeclaredFields()) {
+                        if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
+                        if (f.getType().isPrimitive()) continue;
+                        Object v;
+                        try { f.setAccessible(true); v = f.get(o); } catch (Throwable t) { continue; }
+                        if (v == null || seen.put(v, Boolean.TRUE) != null) continue;
+                        if (v instanceof String) {
+                            String s = (String) v;
+                            if (s.length() >= 38 && s.matches("\\d+")
+                                    && (digitCandidate == null || s.length() > digitCandidate.length())) {
+                                digitCandidate = s;
+                            }
+                            continue;
+                        }
+                        if (v instanceof CharSequence || v instanceof Number || v instanceof Boolean) continue;
+                        q.add(v);
+                    }
+                }
+            }
+            return digitCandidate;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
@@ -89,16 +89,25 @@ public class SavedMessagesHook {
 
     /** Opens the deleted-messages screen for the current thread (or all if unknown). */
     public static void openDeletedMessages(Context ctx) {
+        openDeletedMessages(ctx, true);
+    }
+
+    /**
+     * Opens the deleted-messages screen.
+     * @param scopeToCurrentThread when false (Piko Settings entry point), always shows all
+     * chats, ignoring any stale current-thread state left over from the last opened DM.
+     */
+    public static void openDeletedMessages(Context ctx, boolean scopeToCurrentThread) {
         try {
             if (ctx == null) ctx = PikoUtils.getContext();
             if (ctx == null) return;
-            String openThreadId = resolveOpenThreadId();
+            String openThreadId = scopeToCurrentThread ? resolveOpenThreadId() : null;
             Intent intent = new Intent(ctx, DeletedMessagesActivity.class);
             if (openThreadId != null && !openThreadId.isEmpty()) {
                 intent.putExtra("thread_id", openThreadId);
-            }
-            if (sCurrentThreadTitle != null && !sCurrentThreadTitle.isEmpty()) {
-                intent.putExtra("thread_title", sCurrentThreadTitle);
+                if (sCurrentThreadTitle != null && !sCurrentThreadTitle.isEmpty()) {
+                    intent.putExtra("thread_title", sCurrentThreadTitle);
+                }
             }
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             ctx.startActivity(intent);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
@@ -11,7 +11,6 @@ import android.content.Intent;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
-import java.lang.reflect.Field;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.db.PikoMessageDb;
@@ -70,21 +69,8 @@ public class SavedMessagesHook {
         }});
     }
 
-    /** Most-recent DM action-bar controller, held weakly. Thread id is read lazily via BFS. */
-    private static java.lang.ref.WeakReference<Object> sOpenThreadController;
-
-    /** Hook 5: records the action-bar controller so its thread id can be read on button click. */
-    public static void noteOpenThreadController(final Object controller) {
-        if (controller == null) return;
-        sOpenThreadController = new java.lang.ref.WeakReference<>(controller);
-    }
-
     private static String resolveOpenThreadId() {
-        if (sCurrentThreadId != null && !sCurrentThreadId.isEmpty()) return sCurrentThreadId;
-        java.lang.ref.WeakReference<Object> ref = sOpenThreadController;
-        Object controller = (ref != null) ? ref.get() : null;
-        if (controller == null) return null;
-        return deepFindThreadId(controller);
+        return (sCurrentThreadId != null && !sCurrentThreadId.isEmpty()) ? sCurrentThreadId : null;
     }
 
     /** Opens the deleted-messages screen for the current thread (or all if unknown). */
@@ -421,66 +407,5 @@ public class SavedMessagesHook {
         }
         return String.format(str("piko_media_deleted"), label);
     }
-
-
-    /** BFS over the controller graph to find a DirectThreadKey and read the thread id string. */
-    private static String deepFindThreadId(Object root) {
-        try {
-            java.util.IdentityHashMap<Object, Boolean> seen = new java.util.IdentityHashMap<>();
-            java.util.ArrayDeque<Object> q = new java.util.ArrayDeque<>();
-            q.add(root); seen.put(root, Boolean.TRUE);
-            int budget = 6000;
-            String digitCandidate = null;
-            while (!q.isEmpty() && budget-- > 0) {
-                Object o = q.poll();
-                Class<?> k = o.getClass();
-                if (k.isArray() && !k.getComponentType().isPrimitive()) {
-                    for (Object el : (Object[]) o) if (el != null && seen.put(el, Boolean.TRUE) == null) q.add(el);
-                    continue;
-                }
-                String kn = k.getName();
-                if (!(kn.startsWith("X.") || kn.startsWith("com.instagram"))) continue;
-                if (kn.equals("com.instagram.model.direct.DirectThreadKey")) {
-                    for (Class<?> cc = k; cc != null && cc != Object.class; cc = cc.getSuperclass()) {
-                        for (Field f : cc.getDeclaredFields()) {
-                            if (f.getType() != String.class) continue;
-                            try {
-                                f.setAccessible(true);
-                                Object fv = f.get(o);
-                                if (fv instanceof String) {
-                                    String s = (String) fv;
-                                    if (s.length() >= 15 && s.matches("\\d+")) return s;
-                                }
-                            } catch (Throwable ignored) {}
-                        }
-                    }
-                    continue;
-                }
-                for (Class<?> cc = k; cc != null && cc != Object.class; cc = cc.getSuperclass()) {
-                    for (Field f : cc.getDeclaredFields()) {
-                        if (java.lang.reflect.Modifier.isStatic(f.getModifiers())) continue;
-                        if (f.getType().isPrimitive()) continue;
-                        Object v;
-                        try { f.setAccessible(true); v = f.get(o); } catch (Throwable t) { continue; }
-                        if (v == null || seen.put(v, Boolean.TRUE) != null) continue;
-                        if (v instanceof String) {
-                            String s = (String) v;
-                            if (s.length() >= 38 && s.matches("\\d+")
-                                    && (digitCandidate == null || s.length() > digitCandidate.length())) {
-                                digitCandidate = s;
-                            }
-                            continue;
-                        }
-                        if (v instanceof CharSequence || v instanceof Number || v instanceof Boolean) continue;
-                        q.add(v);
-                    }
-                }
-            }
-            return digitCandidate;
-        } catch (Throwable t) {
-            return null;
-        }
-    }
-
 
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -36,6 +36,7 @@ public class Settings {
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
     public static final BooleanSetting DISABLE_SCREENSHOT_DETECTION = new BooleanSetting("disable_screenshot_detection", true);
     public static final BooleanSetting VIEW_DM_ANONYMOUSLY = new BooleanSetting("view_dm_anonymously", false);
+    public static final BooleanSetting SAVE_DELETED_MESSAGES = new BooleanSetting("save_deleted_messages", true);
     public static final BooleanSetting DISABLE_STORIES = new BooleanSetting("disable_stories", false);
     public static final BooleanSetting DISABLE_HIGHLIGHTS = new BooleanSetting("disable_highlights", false);
     public static final BooleanSetting HIDE_STORIES_TRAY = new BooleanSetting("hide_stories_tray", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -81,6 +81,10 @@ public class SettingsStatus {
     public static void viewDmAnonymously() {
         viewDmAnonymously = true;
     }
+    public static boolean saveDeletedMessages = false;
+    public static void saveDeletedMessages() {
+        saveDeletedMessages = true;
+    }
     public static boolean ghostSection() {
         return (viewStoriesAnonymously || viewLiveAnonymously || disableScreenshotDetection || disableTypingStatus || viewDmAnonymously);
     }
@@ -199,7 +203,7 @@ public class SettingsStatus {
     public static void unlimitedReplaysOnEphemeralMedia() {unlimitedReplaysOnEphemeralMedia = true;}
     public static boolean markChatAsRead = false;
     public static void markChatAsRead() { markChatAsRead = true; }
-    public static boolean dmSection(){ return markChatAsRead || unlimitedReplaysOnEphemeralMedia || disableTypingStatus || viewDmAnonymously ;}
+    public static boolean dmSection(){ return markChatAsRead || unlimitedReplaysOnEphemeralMedia || disableTypingStatus || viewDmAnonymously || saveDeletedMessages ;}
 
     //Download section.
     public static boolean downloadMedia = false;
@@ -263,6 +267,7 @@ public class SettingsStatus {
         FLAGS.put(str("piko_disable_swipe_to_create"), SettingsStatus.disableSwipeToCreate);
 
         FLAGS.put(str("piko_view_dm_anonymously"),SettingsStatus.viewDmAnonymously);
+        FLAGS.put(str("piko_save_deleted_messages"),SettingsStatus.saveDeletedMessages);
         FLAGS.put(str("piko_view_live_anonymously"),SettingsStatus.disableScreenshotDetection);
         FLAGS.put(str("piko_disable_typing_status"),SettingsStatus.disableTypingStatus);
         FLAGS.put(str("piko_more_profile_options"),SettingsStatus.viewLiveAnonymously);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -237,6 +237,23 @@ public class ScreenBuilder {
             );
         }
 
+        if (SettingsStatus.saveDeletedMessages) {
+            addPreference(
+                    helper.switchPreference(
+                            str("piko_save_deleted_messages"),
+                            str("piko_save_deleted_messages_desc"),
+                            Settings.SAVE_DELETED_MESSAGES
+                    )
+            );
+            addPreference(
+                    helper.buttonPreference(
+                            str("piko_view_deleted_messages"),
+                            "",
+                            "view_deleted_messages"
+                    )
+            );
+        }
+
 
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -83,7 +83,7 @@ public class ButtonPref extends Preference {
                         DownloadMapping.downloadMapping();
 
                     } else if (key.equals("view_deleted_messages")) {
-                        SavedMessagesHook.openDeletedMessages(context);
+                        SavedMessagesHook.openDeletedMessages(context, false);
 
                     } else if (isFragmentNavigation(key)) {
                         FragmentHook.startFragment(key);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -26,6 +26,7 @@ import app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.InstaUtils;
+import app.morphe.extension.instagram.patches.dm.SavedMessagesHook;
 
 public class ButtonPref extends Preference {
     private final Context context;
@@ -80,6 +81,9 @@ public class ButtonPref extends Preference {
 
                     } else if (key.equals("piko_download_id_mapping")) {
                         DownloadMapping.downloadMapping();
+
+                    } else if (key.equals("view_deleted_messages")) {
+                        SavedMessagesHook.openDeletedMessages(context);
 
                     } else if (isFragmentNavigation(key)) {
                         FragmentHook.startFragment(key);
@@ -145,7 +149,8 @@ public class ButtonPref extends Preference {
                 || key.equals("piko_export_experiment_list")
                 || key.equals("piko_export_experiment_mappings")
                 || key.equals("piko_download_id_mapping")
-                || key.equals("piko_rec_flags_refresh_file")));
+                || key.equals("piko_rec_flags_refresh_file")
+                || key.equals("view_deleted_messages")));
     }
 
     private static boolean hasPressedHighlight(String key) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -53,6 +53,10 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.HIDE_SUGGESTED_CONTENT);
     }
 
+    public static boolean saveDeletedMessages() {
+        return SharedPref.getBooleanPref(Settings.SAVE_DELETED_MESSAGES);
+    }
+
     public static boolean openLinksExternally() {
         return SharedPref.getBooleanPref(Settings.OPEN_LINKS_EXTERNALLY);
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
@@ -15,6 +15,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
@@ -185,6 +186,85 @@ val directItemEntity =
                     wrapped("clip", FieldClipExtension, FieldClipMediaExtension)
                     wrapped("reel_share", FieldReelExtension, FieldReelMediaExtension)
                     wrapped("voice_media", FieldVoiceExtension, FieldVoiceMediaExtension)
+                }
+
+                // xma reshare permalink: best-effort, never fatal. An xma reshare (shared post/reel)
+                // has no Media object; instead the item holds a List of xma elements (built by a
+                // converter method) whose permalink is a String under JSON key "target_url". Resolve
+                // the item's xma List field and the element's permalink field at patch time so the
+                // runtime does named reflection only. If neither can be resolved on a future build,
+                // xma degrades to the "[type]" label (see DirectItem).
+                //
+                // The permalink field is confirmed by the "target_url" -> String iput on the element
+                // class; the item's xma List field is disambiguated (from three sibling List fields
+                // that share the same converter) by following the xma_ dispatch keys' branch target.
+                runCatching {
+                    val itemClass = mutableClassDefBy { it.type == method.definingClass }
+
+                    // On class [clsType], find "target_url" then the next iput-object (before the
+                    // following key) that writes a String on [elementType]. The serializer occurrence
+                    // writes via a call, not an iput, so only the deserializer's iput matches.
+                    fun targetUrlField(clsType: String, elementType: String): FieldReference? {
+                        val cls = runCatching { mutableClassDefBy { it.type == clsType } }.getOrNull()
+                            ?: return null
+                        return cls.methods.firstNotNullOfOrNull { m ->
+                            val insns = runCatching { m.instructions.toList() }.getOrNull()
+                                ?: return@firstNotNullOfOrNull null
+                            val ki = insns.indexOfFirst {
+                                (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                    (it as ReferenceInstruction).reference.toString() == "target_url"
+                            }
+                            if (ki < 0) return@firstNotNullOfOrNull null
+                            insns.drop(ki + 1)
+                                .takeWhile {
+                                    it.opcode != Opcode.CONST_STRING && it.opcode != Opcode.CONST_STRING_JUMBO
+                                }
+                                .firstOrNull {
+                                    it.opcode == Opcode.IPUT_OBJECT &&
+                                        ((it as ReferenceInstruction).reference as? FieldReference)
+                                            ?.let { r -> r.type == "Ljava/lang/String;" && r.definingClass == elementType } == true
+                                }?.let { (it as ReferenceInstruction).reference as FieldReference }
+                        }
+                    }
+
+                    var xmaField: FieldReference? = null
+                    var linkField: FieldReference? = null
+                    run {
+                        for (m in itemClass.methods) {
+                            val insns = runCatching { m.instructions.toList() }.getOrNull() ?: continue
+                            // The item stores four List<xma-element> fields, all built from the same
+                            // converter (so all share "target_url"); only the one reached from the
+                            // "xma_*" reshare keys is the field we want. Each xma_ key does
+                            // equals -> if-nez -> shared handler block, so follow that branch to pin
+                            // the correct block, then read its List iput + converter.
+                            val xmaKeyIdx = insns.indexOfFirst {
+                                (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                    (it as ReferenceInstruction).reference.toString().startsWith("xma_")
+                            }
+                            if (xmaKeyIdx < 0) continue
+                            val ifNez = insns.drop(xmaKeyIdx + 1).firstOrNull { it.opcode == Opcode.IF_NEZ } ?: continue
+                            val targetAddr = ifNez.location.codeAddress + (ifNez as OffsetInstruction).codeOffset
+                            val targetIdx = insns.indexOfFirst { it.location.codeAddress == targetAddr }
+                            if (targetIdx < 0) continue
+                            val block = insns.drop(targetIdx)
+                            val listPut = block.firstOrNull {
+                                it.opcode == Opcode.IPUT_OBJECT &&
+                                    ((it as ReferenceInstruction).reference as? FieldReference)?.type == "Ljava/util/List;"
+                            }?.let { (it as ReferenceInstruction).reference as FieldReference } ?: continue
+                            val conv = block.firstNotNullOfOrNull {
+                                if (it.opcode != Opcode.INVOKE_STATIC) return@firstNotNullOfOrNull null
+                                ((it as ReferenceInstruction).reference as? MethodReference)
+                                    ?.takeIf { r -> r.returnType.startsWith("LX/") && r.definingClass.startsWith("LX/") }
+                            } ?: continue
+                            val lf = targetUrlField(conv.definingClass, conv.returnType) ?: continue
+                            xmaField = listPut
+                            linkField = lf
+                            return@run
+                        }
+                    }
+                    val xf = xmaField ?: error("xma converter not found in ${method.definingClass}")
+                    FieldXmaExtension.changeFirstString(xf.name)
+                    FieldXmaLinkExtension.changeFirstString(linkField!!.name)
                 }
             }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
@@ -7,10 +7,12 @@
 package app.crimera.patches.instagram.entity.directItem
 
 import app.crimera.utils.changeFirstString
+import app.crimera.utils.changeString
 import app.crimera.utils.changeStringAt
 import app.crimera.utils.classNameToExtension
 import app.crimera.utils.extensionToClassName
 import app.crimera.utils.fieldExtractor
+import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.AccessFlags
@@ -55,8 +57,8 @@ val directItemEntity =
                 GetUserIdExtension.changeFirstString(fieldAfter("user_id").name)
 
                 val textField = fieldAfter("text").name
-                GetTextExtension.changeStringAt(0, textField)
-                SetTextExtension.changeStringAt(0, textField)
+                GetTextExtension.changeString("baseTextField", textField)
+                SetTextExtension.changeString("baseTextField", textField)
 
                 GetTimestampRawExtension.changeFirstString(fieldAfter("timestamp").name)
 
@@ -115,8 +117,8 @@ val directItemEntity =
                         }
                     }
                 subTextField?.let {
-                    GetTextExtension.changeStringAt(1, it)
-                    SetTextExtension.changeStringAt(1, it)
+                    GetTextExtension.changeString("subTextField", it)
+                    SetTextExtension.changeString("subTextField", it)
                 }
                 }
 
@@ -160,7 +162,7 @@ val directItemEntity =
                     }
 
                     // Direct Media fields: type must be Media.
-                    fun direct(key: String, fp: app.morphe.patcher.Fingerprint) = runCatching {
+                    fun direct(key: String, fp: Fingerprint) = runCatching {
                         val f = iputFieldAfter(key) ?: return@runCatching
                         if (f.type != mediaClass) return@runCatching
                         setItemClass(f); fp.changeFirstString(f.name)
@@ -173,8 +175,8 @@ val directItemEntity =
                     // field, found BY TYPE (so the obfuscated wrapper name is never depended on).
                     fun wrapped(
                         key: String,
-                        wrapperFp: app.morphe.patcher.Fingerprint,
-                        innerFp: app.morphe.patcher.Fingerprint,
+                        wrapperFp: Fingerprint,
+                        innerFp: Fingerprint,
                     ) = runCatching {
                         val wf = iputFieldAfter(key) ?: return@runCatching
                         val inner = mutableClassDefBy { it.type == wf.type }
@@ -186,6 +188,8 @@ val directItemEntity =
                     wrapped("clip", FieldClipExtension, FieldClipMediaExtension)
                     wrapped("reel_share", FieldReelExtension, FieldReelMediaExtension)
                     wrapped("voice_media", FieldVoiceExtension, FieldVoiceMediaExtension)
+                    // Disappearing media: carries the payload that raven_media leaves null.
+                    wrapped("visual_media", FieldVisualExtension, FieldVisualMediaExtension)
                 }
 
                 // xma reshare permalink: best-effort, never fatal. An xma reshare (shared post/reel)
@@ -201,11 +205,9 @@ val directItemEntity =
                 runCatching {
                     val itemClass = mutableClassDefBy { it.type == method.definingClass }
 
-                    // On class [clsType], find "target_url" then the next iput-object (before the
-                    // following key) that writes a String on [elementType]. The serializer occurrence
-                    // writes via a call, not an iput, so only the deserializer's iput matches.
-                    fun targetUrlField(clsType: String, elementType: String): FieldReference? {
-                        val cls = runCatching { mutableClassDefBy { it.type == clsType } }.getOrNull()
+                    // Only the deserializer stores target_url with an iput; the serializer uses a call.
+                    fun targetUrlField(parserType: String): FieldReference? {
+                        val cls = runCatching { mutableClassDefBy { it.type == parserType } }.getOrNull()
                             ?: return null
                         return cls.methods.firstNotNullOfOrNull { m ->
                             val insns = runCatching { m.instructions.toList() }.getOrNull()
@@ -222,7 +224,7 @@ val directItemEntity =
                                 .firstOrNull {
                                     it.opcode == Opcode.IPUT_OBJECT &&
                                         ((it as ReferenceInstruction).reference as? FieldReference)
-                                            ?.let { r -> r.type == "Ljava/lang/String;" && r.definingClass == elementType } == true
+                                            ?.type == "Ljava/lang/String;"
                                 }?.let { (it as ReferenceInstruction).reference as FieldReference }
                         }
                     }
@@ -251,12 +253,19 @@ val directItemEntity =
                                 it.opcode == Opcode.IPUT_OBJECT &&
                                     ((it as ReferenceInstruction).reference as? FieldReference)?.type == "Ljava/util/List;"
                             }?.let { (it as ReferenceInstruction).reference as FieldReference } ?: continue
-                            val conv = block.firstNotNullOfOrNull {
-                                if (it.opcode != Opcode.INVOKE_STATIC) return@firstNotNullOfOrNull null
-                                ((it as ReferenceInstruction).reference as? MethodReference)
-                                    ?.takeIf { r -> r.returnType.startsWith("LX/") && r.definingClass.startsWith("LX/") }
-                            } ?: continue
-                            val lf = targetUrlField(conv.definingClass, conv.returnType) ?: continue
+                            // The call is declared on the abstract base, so take the parser class
+                            // from the sget rather than the call itself.
+                            val parseIdx = block.indexOfFirst {
+                                it.opcode == Opcode.INVOKE_VIRTUAL &&
+                                    ((it as ReferenceInstruction).reference as? MethodReference)
+                                        ?.name == "parseFromJsonParser"
+                            }
+                            if (parseIdx < 0) continue
+                            val parserType = block.take(parseIdx)
+                                .lastOrNull { it.opcode == Opcode.SGET_OBJECT }
+                                ?.let { (it as ReferenceInstruction).reference as? FieldReference }
+                                ?.type ?: continue
+                            val lf = targetUrlField(parserType) ?: continue
                             xmaField = listPut
                             linkField = lf
                             return@run

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/DirectItemEntity.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.entity.directItem
+
+import app.crimera.utils.changeFirstString
+import app.crimera.utils.changeStringAt
+import app.crimera.utils.classNameToExtension
+import app.crimera.utils.extensionToClassName
+import app.crimera.utils.fieldExtractor
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+/**
+ * Resolves every obfuscated DirectItem field name at patch time and bakes it into the
+ * {@code DirectItem} extension entity, so the runtime never has to discover field/method
+ * names by reflection. See {@code mediaDataEntity} for the reference pattern.
+ */
+val directItemEntity =
+    bytecodePatch(
+        description = "Decodes obfuscated DirectItem (DM) field names at patch time.",
+    ) {
+        execute {
+            DirectItemDispatchFingerprint.apply {
+                // Scan all methods: v426 deserializer is A00, v430+ moved it to unsafeParseFromJson.
+                fun fieldAfter(key: String) =
+                    mutableClassDefBy { it.type == method.definingClass }
+                        .methods.firstNotNullOfOrNull { m ->
+                            val insns = runCatching { m.instructions.toList() }.getOrNull()
+                                ?: return@firstNotNullOfOrNull null
+                            val keyIndex =
+                                insns.indexOfFirst {
+                                    (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                        (it as ReferenceInstruction).reference.toString() == key
+                                }
+                            if (keyIndex < 0) return@firstNotNullOfOrNull null
+                            insns.drop(keyIndex + 1).firstOrNull {
+                                it.opcode.name.startsWith("iput", ignoreCase = true)
+                            }?.fieldExtractor()
+                        } ?: error("no iput after '$key' in ${method.definingClass}")
+
+                val itemId = fieldAfter("item_id")
+                GetItemIdExtension.changeFirstString(itemId.name)
+                GetBaseClassNameExtension.changeFirstString(itemId.definingClass)
+
+                GetUserIdExtension.changeFirstString(fieldAfter("user_id").name)
+
+                val textField = fieldAfter("text").name
+                GetTextExtension.changeStringAt(0, textField)
+                SetTextExtension.changeStringAt(0, textField)
+
+                GetTimestampRawExtension.changeFirstString(fieldAfter("timestamp").name)
+
+                val hideField = fieldAfter("hide_in_thread").name
+                IsHideInThreadExtension.changeFirstString(hideField)
+                SetHideInThreadExtension.changeFirstString(hideField)
+
+                IsSentByViewerExtension.changeFirstString(fieldAfter("is_sent_by_viewer").name)
+
+                GetThreadKeyExtension.changeFirstString(fieldAfter("thread_key").name)
+
+                // item_type + MQTT sub-text: best-effort, never fatal. If a future build restructures the
+                // base/sub class so these can't resolve, skip and leave the placeholders — runtime reflection
+                // then no-ops instead of aborting the patch (mirrors the media block below).
+                runCatching {
+                // item_type: the only enum with 2+ fields on the base class; primary sorts last by name.
+                val baseDescriptor = extensionToClassName(itemId.definingClass)
+                val baseClass = mutableClassDefBy { it.type == baseDescriptor }
+
+                fun isEnumType(type: String) =
+                    runCatching {
+                        mutableClassDefBy { it.type == type }.superclass == "Ljava/lang/Enum;"
+                    }.getOrDefault(false)
+
+                val itemTypeField =
+                    baseClass.fields
+                        .filter { !AccessFlags.STATIC.isSet(it.accessFlags) && isEnumType(it.type) }
+                        .groupBy { it.type }
+                        .maxByOrNull { it.value.size }!!
+                        .value
+                        .maxByOrNull { it.name }!!
+                        .name
+                GetItemTypeExtension.changeFirstString(itemTypeField)
+
+                // MQTT items store text in an Object field on the subclass, set after the item-type setter.
+                val itemTypeEnum = baseClass.fields.first { it.name == itemTypeField }.type
+                val subClass = mutableClassDefBy { it.superclass == baseDescriptor }
+                val subTextField =
+                    subClass.methods.firstNotNullOfOrNull { m ->
+                        val insns = runCatching { m.instructions.toList() }.getOrNull()
+                            ?: return@firstNotNullOfOrNull null
+                        insns.indices.firstNotNullOfOrNull fn@{ i ->
+                            val insn = insns[i]
+                            if (insn.opcode != Opcode.INVOKE_VIRTUAL) return@fn null
+                            val ref = (insn as ReferenceInstruction).reference as? MethodReference
+                            if (ref == null || ref.parameterTypes.size != 1 ||
+                                ref.parameterTypes[0].toString() != itemTypeEnum
+                            ) {
+                                return@fn null
+                            }
+                            insns.drop(i + 1).take(3)
+                                .firstOrNull { it.opcode.name.startsWith("iput", true) }
+                                ?.let { (it as ReferenceInstruction).reference as? FieldReference }
+                                ?.takeIf { it.type == "Ljava/lang/Object;" }
+                                ?.name
+                        }
+                    }
+                subTextField?.let {
+                    GetTextExtension.changeStringAt(1, it)
+                    SetTextExtension.changeStringAt(1, it)
+                }
+                }
+
+                // Media resolution: best-effort, never fatal. Every supported DM media shape carries a
+                // com.instagram.feed.media.Media object — the unobfuscated anchor that survives version
+                // rotation. We resolve each shape's field by its stable JSON key on the deserializer.
+                // Concrete item class (X/6fW) = the definingClass of those fields (a subclass of the
+                // scalar base X/8t8, which is why media MUST be read off it, not the scalar base).
+                //
+                // NOTE: animated_media, story_share, xma and link are intentionally NOT resolved — their
+                // URL sits in an obfuscated wrapper with no stable type/getter anchor (e.g. GifUrlImpl:
+                // three indistinguishable String fields). Adding them would be fragile to maintain, so
+                // those shapes degrade to a "[type]" label at runtime. See DirectItem.getMediaUrl().
+                val mediaClass = "Lcom/instagram/feed/media/Media;"
+
+                // First iput-object stored right after a JSON key in the (split) serializer/deserializer.
+                fun iputFieldAfter(key: String) =
+                    mutableClassDefBy { it.type == method.definingClass }
+                        .methods.firstNotNullOfOrNull { m ->
+                            val insns = runCatching { m.instructions.toList() }.getOrNull()
+                                ?: return@firstNotNullOfOrNull null
+                            val ki = insns.indexOfFirst {
+                                (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                    (it as ReferenceInstruction).reference.toString() == key
+                            }
+                            if (ki < 0) return@firstNotNullOfOrNull null
+                            insns.drop(ki + 1)
+                                .firstOrNull { it.opcode.name.startsWith("iput-object", ignoreCase = true) }
+                                ?.let { (it as ReferenceInstruction).reference as? FieldReference }
+                        }
+
+                runCatching {
+                    // Item class is set once, from the first field that resolves (all share definingClass).
+                    var itemClassSet = false
+                    fun setItemClass(fr: FieldReference) {
+                        if (!itemClassSet) {
+                            // Class.forName needs the binary name (X.6fW), not the smali descriptor (LX/6fW;).
+                            GetMediaClassNameExtension.changeFirstString(classNameToExtension(fr.definingClass))
+                            itemClassSet = true
+                        }
+                    }
+
+                    // Direct Media fields: type must be Media.
+                    fun direct(key: String, fp: app.morphe.patcher.Fingerprint) = runCatching {
+                        val f = iputFieldAfter(key) ?: return@runCatching
+                        if (f.type != mediaClass) return@runCatching
+                        setItemClass(f); fp.changeFirstString(f.name)
+                    }
+                    direct("media", FieldMediaExtension)
+                    direct("media_share", FieldMediaShareExtension)
+                    direct("raven_media", FieldRavenMediaExtension)
+
+                    // Wrapped shapes: wrapper field on the item class, then the wrapper's single Media
+                    // field, found BY TYPE (so the obfuscated wrapper name is never depended on).
+                    fun wrapped(
+                        key: String,
+                        wrapperFp: app.morphe.patcher.Fingerprint,
+                        innerFp: app.morphe.patcher.Fingerprint,
+                    ) = runCatching {
+                        val wf = iputFieldAfter(key) ?: return@runCatching
+                        val inner = mutableClassDefBy { it.type == wf.type }
+                            .fields.firstOrNull { it.type == mediaClass } ?: return@runCatching
+                        setItemClass(wf)
+                        wrapperFp.changeFirstString(wf.name)
+                        innerFp.changeFirstString(inner.name)
+                    }
+                    wrapped("clip", FieldClipExtension, FieldClipMediaExtension)
+                    wrapped("reel_share", FieldReelExtension, FieldReelMediaExtension)
+                    wrapped("voice_media", FieldVoiceExtension, FieldVoiceMediaExtension)
+                }
+            }
+
+            // DirectThreadKey is stable but its thread-id field is obfuscated: first String instance field.
+            val threadKeyClass =
+                mutableClassDefBy { it.type == "Lcom/instagram/model/direct/DirectThreadKey;" }
+            val threadIdField =
+                threadKeyClass.fields
+                    .first {
+                        !AccessFlags.STATIC.isSet(it.accessFlags) && it.type == "Ljava/lang/String;"
+                    }.name
+            GetThreadIdExtension.changeFirstString(threadIdField)
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
@@ -36,6 +36,9 @@ internal object FieldReelExtension : Fingerprint(name = "fieldReel", definingCla
 internal object FieldReelMediaExtension : Fingerprint(name = "fieldReelMedia", definingClass = DIRECT_ITEM_CLASS)
 internal object FieldVoiceExtension : Fingerprint(name = "fieldVoice", definingClass = DIRECT_ITEM_CLASS)
 internal object FieldVoiceMediaExtension : Fingerprint(name = "fieldVoiceMedia", definingClass = DIRECT_ITEM_CLASS)
+// xma reshare: item List field + the permalink String field on each element (JSON key "target_url").
+internal object FieldXmaExtension : Fingerprint(name = "fieldXma", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldXmaLinkExtension : Fingerprint(name = "fieldXmaLink", definingClass = DIRECT_ITEM_CLASS)
 
 // returnType omitted: v426 returns Z, v433+ returns V. const-string → iput pattern is present in both.
 internal object DirectItemDispatchFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.entity.directItem
+
+import app.crimera.patches.instagram.utils.Constants.ENTITY_CLASS
+import app.morphe.patcher.Fingerprint
+
+internal const val DIRECT_ITEM_CLASS = "$ENTITY_CLASS/DirectItem;"
+
+// --- Extension getters whose placeholder strings are rewritten at patch time. ---
+internal object GetBaseClassNameExtension : Fingerprint(name = "getBaseClassName", definingClass = DIRECT_ITEM_CLASS)
+internal object GetItemIdExtension : Fingerprint(name = "getItemId", definingClass = DIRECT_ITEM_CLASS)
+internal object GetUserIdExtension : Fingerprint(name = "getUserId", definingClass = DIRECT_ITEM_CLASS)
+internal object GetTextExtension : Fingerprint(name = "getText", definingClass = DIRECT_ITEM_CLASS)
+internal object SetTextExtension : Fingerprint(name = "setText", definingClass = DIRECT_ITEM_CLASS)
+internal object GetTimestampRawExtension : Fingerprint(name = "getTimestampRaw", definingClass = DIRECT_ITEM_CLASS)
+internal object IsHideInThreadExtension : Fingerprint(name = "isHideInThread", definingClass = DIRECT_ITEM_CLASS)
+internal object IsSentByViewerExtension : Fingerprint(name = "isSentByViewer", definingClass = DIRECT_ITEM_CLASS)
+internal object SetHideInThreadExtension : Fingerprint(name = "setHideInThread", definingClass = DIRECT_ITEM_CLASS)
+internal object GetItemTypeExtension : Fingerprint(name = "getItemType", definingClass = DIRECT_ITEM_CLASS)
+internal object GetThreadKeyExtension : Fingerprint(name = "getThreadKey", definingClass = DIRECT_ITEM_CLASS)
+internal object GetThreadIdExtension : Fingerprint(name = "getThreadId", definingClass = DIRECT_ITEM_CLASS)
+// Media resolution: concrete item class (X/6fW) + one field-name provider per supported shape.
+// All resolved by stable JSON key + the unobfuscated com.instagram.feed.media.Media type.
+internal object GetMediaClassNameExtension : Fingerprint(name = "mediaClassName", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldMediaExtension : Fingerprint(name = "fieldMedia", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldMediaShareExtension : Fingerprint(name = "fieldMediaShare", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldRavenMediaExtension : Fingerprint(name = "fieldRavenMedia", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldClipExtension : Fingerprint(name = "fieldClip", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldClipMediaExtension : Fingerprint(name = "fieldClipMedia", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldReelExtension : Fingerprint(name = "fieldReel", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldReelMediaExtension : Fingerprint(name = "fieldReelMedia", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldVoiceExtension : Fingerprint(name = "fieldVoice", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldVoiceMediaExtension : Fingerprint(name = "fieldVoiceMedia", definingClass = DIRECT_ITEM_CLASS)
+
+// returnType omitted: v426 returns Z, v433+ returns V. const-string → iput pattern is present in both.
+internal object DirectItemDispatchFingerprint : Fingerprint(
+    strings = listOf("item_id", "user_id", "text", "timestamp", "hide_in_thread", "thread_key"),
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/directItem/Fingerprint.kt
@@ -36,6 +36,8 @@ internal object FieldReelExtension : Fingerprint(name = "fieldReel", definingCla
 internal object FieldReelMediaExtension : Fingerprint(name = "fieldReelMedia", definingClass = DIRECT_ITEM_CLASS)
 internal object FieldVoiceExtension : Fingerprint(name = "fieldVoice", definingClass = DIRECT_ITEM_CLASS)
 internal object FieldVoiceMediaExtension : Fingerprint(name = "fieldVoiceMedia", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldVisualExtension : Fingerprint(name = "fieldVisual", definingClass = DIRECT_ITEM_CLASS)
+internal object FieldVisualMediaExtension : Fingerprint(name = "fieldVisualMedia", definingClass = DIRECT_ITEM_CLASS)
 // xma reshare: item List field + the permalink String field on each element (JSON key "target_url").
 internal object FieldXmaExtension : Fingerprint(name = "fieldXma", definingClass = DIRECT_ITEM_CLASS)
 internal object FieldXmaLinkExtension : Fingerprint(name = "fieldXmaLink", definingClass = DIRECT_ITEM_CLASS)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -18,16 +18,15 @@ import com.android.tools.smali.dexlib2.iface.Method
 
 internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
-internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
+internal const val LIVE_TREE_MEDIA_DICT_CLASS = "Lcom/instagram/feed/media/LiveTreeMediaDict;"
 
 /**
- * True when the method belongs to whichever class currently carries the LiveTree-backed media
- * getters: `LiveTreeMediaDict` up to v439, or `Media` from v441, which absorbed them when that
- * wrapper was deleted (the same move `LiveTreeUserDict` -> `User` made in the user model).
+ * Class carrying the LiveTree-backed media getters. Both candidates ship together, so
+ * `mediaDataEntity` pins one before these fingerprints resolve.
  */
-private fun Method.inMediaModel(): Boolean =
-    definingClass.endsWith(LIVE_TREE_MEDIA_DICT_CLASS) ||
-        definingClass == "Lcom/instagram/feed/media/Media;"
+internal var mediaModelClass: String = LIVE_TREE_MEDIA_DICT_CLASS
+
+private fun Method.inMediaModel(): Boolean = definingClass == mediaModelClass
 
 internal object GetHelperClassExtensionFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS_DESCRIPTOR,
@@ -151,14 +150,6 @@ internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
 internal object AudioIntfMapperFingerprint : Fingerprint(
     returnType = "Ljava/util/Map;",
     strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
-)
-
-internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "igPlayerController must be initialized",
-            "audioMetadata must be set before preparing",
-        ),
 )
 
 internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -14,11 +14,20 @@ import app.crimera.patches.instagram.utils.Constants.EDIT_MEDIA_INFO_FRAGMENT_CL
 import app.crimera.patches.instagram.utils.Constants.ORIGINAL_SOUND_DATA_INTF
 import app.crimera.patches.instagram.utils.Constants.USER_SESSION_CLASS
 import app.morphe.patcher.Fingerprint
-import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.Method
 
 internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
+
+/**
+ * True when the method belongs to whichever class currently carries the LiveTree-backed media
+ * getters: `LiveTreeMediaDict` up to v439, or `Media` from v441, which absorbed them when that
+ * wrapper was deleted (the same move `LiveTreeUserDict` -> `User` made in the user model).
+ */
+private fun Method.inMediaModel(): Boolean =
+    definingClass.endsWith(LIVE_TREE_MEDIA_DICT_CLASS) ||
+        definingClass == "Lcom/instagram/feed/media/Media;"
 
 internal object GetHelperClassExtensionFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS_DESCRIPTOR,
@@ -139,18 +148,6 @@ internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
     strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"),
 )
 
-internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF),
-)
-
-internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
-    classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint,
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME),
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
-)
-
 internal object AudioIntfMapperFingerprint : Fingerprint(
     returnType = "Ljava/util/Map;",
     strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
@@ -176,13 +173,13 @@ internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
 internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
     returnType = "Ljava/util/List;",
     strings = listOf("reel_mentions"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inMediaModel() },
 )
 
 internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
     returnType = USER_MODEL_CLASS_NAME,
     strings = listOf("user"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inMediaModel() },
 )
 
 internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -7,6 +7,7 @@
 package app.crimera.patches.instagram.entity.mediadata
 
 import app.crimera.patches.instagram.entity.decoder.EditMediaInfoGetCurrentMediaIdFingerprint
+import app.crimera.patches.instagram.entity.decoder.MEDIA_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.MEDIAEXT_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.utils.Constants.MUSIC_INFO_CLASS
@@ -37,6 +38,10 @@ val mediaDataEntity =
     ) {
         dependsOn(decoderEntity)
         execute {
+            // Pin the getter class before any fingerprint resolves.
+            mediaModelClass =
+                if (classDefByOrNull(LIVE_TREE_MEDIA_DICT_CLASS) != null) LIVE_TREE_MEDIA_DICT_CLASS else MEDIA_CLASS_NAME
+
             GetHelperClassExtensionFingerprint.changeFirstString(classNameToExtension(MEDIAEXT_CLASS_NAME))
 
             // Extracting get original sound info data using media and user session.
@@ -83,14 +88,7 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(isVideoCallingMethodName)
             }
 
-            // Extraction of extended media data field.
-            // Extraction of media list from extended media data.
-            // Up to v439 the list lives on a mutable dict hanging off the media object
-            // (media.A04.A89()), so the getter is preceded by the iget-object for that field. v441
-            // folded the dict into Media, so the list is fetched straight off the media object
-            // (media.A8V()) and the extended-data placeholder is left alone — the extension then
-            // falls back to the media object itself. Anchoring on the first List-returning virtual
-            // call covers both shapes.
+            // Extraction of the media list, and of the extended data field it hangs off when present.
             fun Method.resolveMediaList(): Boolean {
                 val listInvokeIndex =
                     instructions.indexOfFirst {
@@ -148,11 +146,7 @@ val mediaDataEntity =
                     }.name
             GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
 
-            // Extraction of trackInfo.
-            // The track container is the object the media helper builds out of a MusicInfo, so
-            // anchor on that constructor call. Up to v439 this was reached indirectly through the
-            // display-artist helper, but v441 moved that helper onto the container itself, so the
-            // old anchor no longer exists.
+            // Extraction of trackInfo: the media helper method that builds a container from a MusicInfo.
             val trackContainerBuilderName =
                 mutableClassDefBy { it.type == MEDIAEXT_CLASS_NAME }
                     .methods
@@ -170,27 +164,26 @@ val mediaDataEntity =
                 GetTrackDataIntfExtensionFingerprint.changeFirstString(trackContainerBuilderName)
             }
 
-            // Message audio.
-            IgPlayerControllerRelatedFingerprint.method.apply {
-                instructions.filter { it.opcode == Opcode.INVOKE_INTERFACE }.firstOrNull {
-                    val methodExt = it.methodExtractor()
-                    if (methodExt.returnType.endsWith("AudioIntf")) {
-                        GetMessageAudioUrlExtensionFingerprint.changeFirstString(methodExt.name)
-                        true
-                    } else {
-                        false
-                    }
+            // Message audio (voice notes): media -> audio interface -> url. The interface is taken
+            // from the "audio_src" getter, since its name changes between builds.
+            val audioIntfClass =
+                AudioIntfMapperFingerprint.run {
+                    val strIndex = stringMatches.first { it.string == AUDIO_SRC_KEY }.index
+                    val urlGetter =
+                        method
+                            .getInstruction(method.indexOfFirstInstruction(strIndex, Opcode.INVOKE_INTERFACE))
+                            .methodExtractor()
+                    GetMessageAudioUrlExtensionFingerprint.changeStringAt(1, urlGetter.name)
+                    urlGetter.definingClass
                 }
-            }
 
-            AudioIntfMapperFingerprint.apply {
-                val strIndex = stringMatches.first { it.string == AUDIO_SRC_KEY }.index
-                method.apply {
-                    val getAudioSrcInvokeIndex = indexOfFirstInstruction(strIndex, Opcode.INVOKE_INTERFACE)
-                    val methodName = getInstruction(getAudioSrcInvokeIndex).methodExtractor().name
-                    GetMessageAudioUrlExtensionFingerprint.changeStringAt(1, methodName)
-                }
-            }
+            val messageAudioMethodName =
+                mutableClassDefBy { it.type == mediaModelClass }
+                    .methods
+                    .singleOrNull {
+                        it.parameters.isEmpty() && classNameToExtension(it.returnType) == audioIntfClass
+                    }?.name
+            messageAudioMethodName?.let { GetMessageAudioUrlExtensionFingerprint.changeFirstString(it) }
 
             // More extended data.
             ExtMediaDictVideoInfoMapperFingerprint.apply {
@@ -200,13 +193,13 @@ val mediaDataEntity =
                         .name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
 
-                // The mapper writes each json key next to the field holding its value, but whether
-                // that field is read before or after the key depends on which serialiser helper
-                // the key goes through, so match on the field type near the key instead of a fixed
-                // offset from it.
-                method.fieldNameNearString("video_versions") { it == "Ljava/util/List;" }?.let {
-                    GetVideoVariantsV2ExtensionFingerprint.changeFirstString(it)
-                }
+                // Match by field type near the key, not a fixed offset — the read can sit on either
+                // side of it, and for video_versions it is in the model's getter, not the mapper.
+                mutableClassDefBy { it.type == mediaModelClass }
+                    .methods
+                    .firstNotNullOfOrNull { m ->
+                        m.fieldNameNearString("video_versions") { type -> type == "Ljava/util/List;" }
+                    }?.let { GetVideoVariantsV2ExtensionFingerprint.changeFirstString(it) }
 
                 ExtMediaDictImageInfoMapperFingerprint.method
                     .fieldNameNearString("image_versions2") { it.endsWith("/ImageInfo;") }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -9,6 +9,7 @@ package app.crimera.patches.instagram.entity.mediadata
 import app.crimera.patches.instagram.entity.decoder.EditMediaInfoGetCurrentMediaIdFingerprint
 import app.crimera.patches.instagram.entity.decoder.MEDIAEXT_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
+import app.crimera.patches.instagram.utils.Constants.MUSIC_INFO_CLASS
 import app.crimera.utils.changeFirstString
 import app.crimera.utils.changeStringAt
 import app.crimera.utils.classNameToExtension
@@ -16,9 +17,19 @@ import app.crimera.utils.fieldExtractor
 import app.crimera.utils.methodExtractor
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.util.getReference
 import app.morphe.util.indexOfFirstInstruction
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import kotlin.math.abs
+
+// How far from a json key the field holding its value can sit in the mapper.
+private const val FIELD_SEARCH_WINDOW = 8
 
 val mediaDataEntity =
     bytecodePatch(
@@ -74,41 +85,37 @@ val mediaDataEntity =
 
             // Extraction of extended media data field.
             // Extraction of media list from extended media data.
-            var foundMediaListMethod = false
-            EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
-                val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
+            // Up to v439 the list lives on a mutable dict hanging off the media object
+            // (media.A04.A89()), so the getter is preceded by the iget-object for that field. v441
+            // folded the dict into Media, so the list is fetched straight off the media object
+            // (media.A8V()) and the extended-data placeholder is left alone — the extension then
+            // falls back to the media object itself. Anchoring on the first List-returning virtual
+            // call covers both shapes.
+            fun Method.resolveMediaList(): Boolean {
+                val listInvokeIndex =
+                    instructions.indexOfFirst {
+                        it.opcode == Opcode.INVOKE_VIRTUAL && it.methodExtractor().returnType == "java.util.List"
+                    }
+                if (listInvokeIndex < 0) return false
 
-                val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
-                // If iget-object is found after return instruction.
-                if (extendedDataFieldIndex > 0) {
-                    val extendedDataFieldName =
-                        getInstruction(
-                            extendedDataFieldIndex,
-                        ).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
+                GetMediaListExtensionFingerprint.changeFirstString(getInstruction(listInvokeIndex).methodExtractor().name)
 
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
+                val fieldReadIndex = listInvokeIndex - 1
+                if (fieldReadIndex >= 0 && getInstruction(fieldReadIndex).opcode == Opcode.IGET_OBJECT) {
+                    GetExtendedDataExtensionFingerprint.changeFirstString(getInstruction(fieldReadIndex).fieldExtractor().name)
                 }
+                return true
             }
+
+            var foundMediaListMethod = EditMediaInfoFragmentMediaSizeFingerprint.method.resolveMediaList()
 
             // Backup for media list extraction if the first fingerprint fails.
             if (!foundMediaListMethod) {
-                GetAndroidLinkFromMediaObject.method.apply {
-                    val firstIfNeIndex = indexOfFirstInstruction(Opcode.IF_NE)
-
-                    val extendedDataFieldIndex = indexOfFirstInstruction(firstIfNeIndex, Opcode.IGET_OBJECT)
-                    val extendedDataFieldName =
-                        getInstruction(
-                            extendedDataFieldIndex,
-                        ).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
-                }
+                foundMediaListMethod =
+                    GetAndroidLinkFromMediaObject.matchOrNull()?.method?.resolveMediaList() == true
+            }
+            if (!foundMediaListMethod) {
+                throw PatchException("Could not resolve the media list method")
             }
 
             // Extraction of media pkid from media class.
@@ -141,17 +148,26 @@ val mediaDataEntity =
                     }.name
             GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
 
-            // Extraction of trackInfo
-            MusicAudioTypeEnumStringFingerprint.method.apply {
-                instructions.filter { it.opcode == Opcode.INVOKE_STATIC }.firstOrNull {
-                    val methodExt = it.methodExtractor()
-                    if (methodExt.returnType != "V") {
-                        GetTrackDataIntfExtensionFingerprint.changeFirstString(methodExt.name)
-                        true
-                    } else {
-                        false
-                    }
-                }
+            // Extraction of trackInfo.
+            // The track container is the object the media helper builds out of a MusicInfo, so
+            // anchor on that constructor call. Up to v439 this was reached indirectly through the
+            // display-artist helper, but v441 moved that helper onto the container itself, so the
+            // old anchor no longer exists.
+            val trackContainerBuilderName =
+                mutableClassDefBy { it.type == MEDIAEXT_CLASS_NAME }
+                    .methods
+                    .firstOrNull { method ->
+                        method.implementation?.instructions?.any {
+                            it.opcode == Opcode.INVOKE_DIRECT &&
+                                it.getReference<MethodReference>()?.let { ref ->
+                                    ref.name == "<init>" &&
+                                        ref.parameterTypes.singleOrNull()?.toString() == MUSIC_INFO_CLASS
+                                } == true
+                        } == true
+                    }?.name
+
+            if (trackContainerBuilderName != null) {
+                GetTrackDataIntfExtensionFingerprint.changeFirstString(trackContainerBuilderName)
             }
 
             // Message audio.
@@ -184,20 +200,17 @@ val mediaDataEntity =
                         .name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
 
-                val strIndex = stringMatches.last().index
-                method.apply {
-                    val videoVariantsListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-
-                    GetVideoVariantsV2ExtensionFingerprint.changeFirstString(videoVariantsListFieldName)
+                // The mapper writes each json key next to the field holding its value, but whether
+                // that field is read before or after the key depends on which serialiser helper
+                // the key goes through, so match on the field type near the key instead of a fixed
+                // offset from it.
+                method.fieldNameNearString("video_versions") { it == "Ljava/util/List;" }?.let {
+                    GetVideoVariantsV2ExtensionFingerprint.changeFirstString(it)
                 }
 
-                ExtMediaDictImageInfoMapperFingerprint.apply {
-                    val strIndex = stringMatches.first().index
-                    method.apply {
-                        val imageInfoListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-                        GetImageVariantsExtensionFingerprint.changeFirstString(imageInfoListFieldName)
-                    }
-                }
+                ExtMediaDictImageInfoMapperFingerprint.method
+                    .fieldNameNearString("image_versions2") { it.endsWith("/ImageInfo;") }
+                    ?.let { GetImageVariantsExtensionFingerprint.changeFirstString(it) }
             }
 
             ProductInfoMapperFingerprint.apply {
@@ -212,3 +225,28 @@ val mediaDataEntity =
             // End.
         }
     }
+
+/**
+ * Name of the field read closest to where [value] is loaded, restricted to fields whose type
+ * satisfies [matchesType]. Returns null when the string or a matching field read is absent.
+ */
+private fun Method.fieldNameNearString(
+    value: String,
+    matchesType: (String) -> Boolean,
+): String? {
+    val stringIndex =
+        instructions.indexOfFirst {
+            (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                it.getReference<StringReference>()?.string == value
+        }
+    if (stringIndex < 0) return null
+
+    return instructions
+        .withIndex()
+        .filter { (index, instruction) ->
+            instruction.opcode == Opcode.IGET_OBJECT && abs(index - stringIndex) <= FIELD_SEARCH_WINDOW
+        }.sortedBy { (index, _) -> abs(index - stringIndex) }
+        .firstNotNullOfOrNull { (_, instruction) ->
+            instruction.getReference<FieldReference>()?.takeIf { matchesType(it.type) }?.name
+        }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
@@ -18,9 +18,50 @@ import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/UserData;"
-internal const val LIVE_TREE_USER_DICT_CLASS = "Lcom/instagram/user/model/LiveTreeUserDict;"
+
+/**
+ * Classes that have carried the LiveTree-backed user getters.
+ *
+ * Up to v439 these lived on their own `LiveTreeUserDict` wrapper. v441 deleted that class (along
+ * with its `LiveTreeMediaDict` sibling) and folded the identical getters — same JSON keys, same
+ * `LiveTreeJNI` field ids — straight into `User`. Accepting either keeps both builds working.
+ */
+private val USER_MODEL_CLASSES =
+    setOf(
+        "Lcom/instagram/user/model/LiveTreeUserDict;",
+        "Lcom/instagram/user/model/User;",
+    )
+
+private fun Method.inUserModel(): Boolean = definingClass in USER_MODEL_CLASSES
+
+private const val GET_OPTIONAL_STRING_VALUE_NATIVE = "getOptionalStringValueNative"
+
+/**
+ * True for the `username` getter, which — unlike its siblings — never spells its JSON key out as a
+ * `const-string`; it decodes it from a byte blob at runtime.
+ *
+ * The username field id alone is not enough to pin it on v441: three String-returning methods on
+ * `User` mention that literal. Requiring "reads a LiveTree string value and has no literal key"
+ * narrows it back to exactly one method in both builds (v439 `LiveTreeUserDict.DYW`, v441 `User.A81`).
+ */
+private fun Method.readsLiveTreeStringWithoutLiteralKey(): Boolean {
+    val instructions = implementation?.instructions ?: return false
+    var readsLiveTreeString = false
+    for (instruction in instructions) {
+        when {
+            instruction.opcode == Opcode.CONST_STRING || instruction.opcode == Opcode.CONST_STRING_JUMBO -> return false
+            instruction is ReferenceInstruction &&
+                (instruction.reference as? MethodReference)?.name == GET_OPTIONAL_STRING_VALUE_NATIVE ->
+                readsLiveTreeString = true
+        }
+    }
+    return readsLiveTreeString
+}
 
 internal object GetAdditionalUserInfoExtensionFingerprint : Fingerprint(
     name = "getAdditionalUserInfo",
@@ -70,7 +111,7 @@ internal object SelectHighlightsCoverFragmentOnCreateFingerprint : Fingerprint(
 )
 
 internal object FullNameLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     filters =
         listOf(
             string("full_name"),
@@ -80,7 +121,9 @@ internal object FullNameLiveTreeUserDictFingerprint : Fingerprint(
 
 internal object UserNameLiveTreeUserDictFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ ->
+        methodDef.inUserModel() && methodDef.readsLiveTreeStringWithoutLiteralKey()
+    },
     filters =
         listOf(
             literal(-265713450),
@@ -88,12 +131,12 @@ internal object UserNameLiveTreeUserDictFingerprint : Fingerprint(
 )
 
 internal object FriendshipStatusLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     returnType = "FriendshipStatus;",
 )
 
 internal object BiographyLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     returnType = "Ljava/lang/String;",
     filters =
         listOf(
@@ -102,7 +145,7 @@ internal object BiographyLiveTreeUserDictFingerprint : Fingerprint(
 )
 
 internal object LowResProfilePictureUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     returnType = "ImageUrl;",
     filters =
         listOf(
@@ -111,7 +154,7 @@ internal object LowResProfilePictureUserTreeDictFingerprint : Fingerprint(
 )
 
 internal object HDProfileInfoUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     filters =
         listOf(
             string("hd_profile_pic_url_info"),
@@ -120,9 +163,9 @@ internal object HDProfileInfoUserTreeDictFingerprint : Fingerprint(
 )
 
 internal object IsVerifiedUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
     strings = listOf("is_verified"),
     returnType = "Ljava/lang/Boolean;",
+    custom = { methodDef, _ -> methodDef.inUserModel() },
     filters =
         listOf(
             literal(1565553213),

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
@@ -24,20 +24,15 @@ import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/UserData;"
 
-/**
- * Classes that have carried the LiveTree-backed user getters.
- *
- * Up to v439 these lived on their own `LiveTreeUserDict` wrapper. v441 deleted that class (along
- * with its `LiveTreeMediaDict` sibling) and folded the identical getters — same JSON keys, same
- * `LiveTreeJNI` field ids — straight into `User`. Accepting either keeps both builds working.
- */
-private val USER_MODEL_CLASSES =
-    setOf(
-        "Lcom/instagram/user/model/LiveTreeUserDict;",
-        "Lcom/instagram/user/model/User;",
-    )
+internal const val LIVE_TREE_USER_DICT_CLASS = "Lcom/instagram/user/model/LiveTreeUserDict;"
 
-private fun Method.inUserModel(): Boolean = definingClass in USER_MODEL_CLASSES
+/**
+ * Class carrying the LiveTree-backed user getters. Both candidates ship together and `User` has
+ * look-alike delegates, so `userDataEntity` pins one before these resolve.
+ */
+internal var userModelClass: String = LIVE_TREE_USER_DICT_CLASS
+
+private fun Method.inUserModel(): Boolean = definingClass == userModelClass
 
 private const val GET_OPTIONAL_STRING_VALUE_NATIVE = "getOptionalStringValueNative"
 
@@ -45,9 +40,8 @@ private const val GET_OPTIONAL_STRING_VALUE_NATIVE = "getOptionalStringValueNati
  * True for the `username` getter, which — unlike its siblings — never spells its JSON key out as a
  * `const-string`; it decodes it from a byte blob at runtime.
  *
- * The username field id alone is not enough to pin it on v441: three String-returning methods on
- * `User` mention that literal. Requiring "reads a LiveTree string value and has no literal key"
- * narrows it back to exactly one method in both builds (v439 `LiveTreeUserDict.DYW`, v441 `User.A81`).
+ * The field id alone can match several String-returning methods, so also require that the method
+ * reads a LiveTree string value and carries no literal key — that leaves exactly one.
  */
 private fun Method.readsLiveTreeStringWithoutLiteralKey(): Boolean {
     val instructions = implementation?.instructions ?: return false

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/UserDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/UserDataEntity.kt
@@ -6,6 +6,7 @@
 
 package app.crimera.patches.instagram.entity.userdata
 
+import app.crimera.patches.instagram.entity.decoder.USER_MODEL_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.entity.userfriendshipstatus.userFriendshipStatusEntity
 import app.crimera.patches.instagram.utils.Constants.FRIENDSHIP_STATUS_CLASS
@@ -32,6 +33,10 @@ val userDataEntity =
         execute {
 
             fun Fingerprint.getMethodName(): String = method.name
+
+            // Pin the getter class before any fingerprint resolves.
+            userModelClass =
+                if (classDefByOrNull(LIVE_TREE_USER_DICT_CLASS) != null) LIVE_TREE_USER_DICT_CLASS else USER_MODEL_CLASS_NAME
 
             GetUsernameExtensionFingerprint.changeFirstString(UserNameLiveTreeUserDictFingerprint.getMethodName())
             GetFullNameExtensionFingerprint.changeFirstString(FullNameLiveTreeUserDictFingerprint.getMethodName())

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/DeletedMessagesResourcePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/DeletedMessagesResourcePatch.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.dm.saveMessages
+
+import app.morphe.patcher.patch.resourcePatch
+import org.w3c.dom.Element
+
+/**
+ * Registers the viewer activity for saved deleted (unsent) direct messages. Kept separate from
+ * the shared settings resource patch so the activity is only added to the manifest when the
+ * "Save deleted messages" patch is actually applied.
+ */
+val deletedMessagesResourcePatch =
+    resourcePatch(
+        description = "Adds the deleted-messages viewer activity to the Android manifest.",
+    ) {
+        finalize {
+            document("AndroidManifest.xml").use { document ->
+                val application = document.getElementsByTagName("application").item(0) as Element
+
+                val activity = document.createElement("activity")
+                activity.setAttribute("android:name", "app.morphe.extension.instagram.patches.dm.DeletedMessagesActivity")
+                activity.setAttribute("android:theme", "@android:style/Theme.DeviceDefault.NoActionBar")
+                activity.setAttribute("android:exported", "false")
+                application.appendChild(activity)
+            }
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/Fingerprint.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.dm.saveMessages
+
+import app.morphe.patcher.Fingerprint
+
+// returnType omitted: v426 returns Z, v433+ returns V. Only classDef is used, not the method directly.
+internal object DirectItemFieldParserFingerprint : Fingerprint(
+    strings = listOf("item_id", "hide_in_thread"),
+)
+
+// MQTT post-processing step (not on REST path). returnType omitted to avoid hardcoding the obfuscated class name.
+internal object DirectItemPostprocessFingerprint : Fingerprint(
+    strings = listOf("DirectMessage.postprocess.%s", "Encountered DirectMessage with null type"),
+)
+
+// SQLite DAO hide-by-id. Injected at entry so our DB record is still present when the hook fires.
+internal object DirectItemDbHideFingerprint : Fingerprint(
+    strings = listOf("Both message ID and client context is null."),
+    parameters = listOf(
+        "Lcom/instagram/model/direct/DirectThreadKey;",
+        "Ljava/lang/String;",
+        "Ljava/lang/String;",
+    ),
+    returnType = "V",
+)
+
+// DM thread deserializer dispatch. returnType omitted: v426 returns Z, v430+ returns V.
+internal object ThreadUsersDispatchFingerprint : Fingerprint(
+    strings = listOf("users", "admin_user_ids", "left_users", "thread_v2_id", "input_mode"),
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
@@ -14,9 +14,11 @@ import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.INTEGRATIONS_PACKAGE
 import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.util.getFreeRegisterProvider
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.AccessFlags
@@ -35,27 +37,15 @@ val saveDeletedMessagesPatch =
         description = "Captures incoming DMs locally as they arrive from the server and marks them when the sender deletes them.",
         default = true,
     ) {
-        // NOTE: userDataEntity is intentionally NOT a hard dependency. It only backs Hook 6's
-        // best-effort username harvesting (UserData reflection), and its resolver is fragile across
-        // Instagram versions (e.g. GetFullNameExtensionFingerprint fails to resolve on v435). Making
-        // it a dependsOn would abort this entire capture feature whenever that resolver breaks. When
-        // userDataEntity IS applied (pulled by another enabled patch) UserData works and Hook 6
-        // enriches names; when it isn't, UserData reflection no-ops and we fall back to thread title
-        // / sender directory. Either way DM capture (Hooks 1/2/4) stays patch-safe.
+        // userDataEntity is deliberately not a dependency: it only backs Hook 6's username
+        // enrichment, so a break in its resolver must not abort capture.
         dependsOn(settingsPatch, chatActionBarButtonPatch, directItemEntity, deletedMessagesResourcePatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
 
-            // PATCH-TIME SAFETY: each hook is wrapped in runCatching so that if a future Instagram
-            // build renames a method, restructures the MQTT converter, or drops an anchor, ONLY that
-            // hook is skipped — the patch still applies and the remaining hooks (and every other
-            // patch in the session) keep working. This mirrors the "best-effort, never fatal"
-            // resolution used in DirectItemEntity. All anchor strings/resources are verified present
-            // in the current target (v435); the wrapping guards against the NEXT version drifting.
-            // The hooks are independent capture points, so partial success still yields a usable
-            // feature: Hook 1 (REST history) and Hook 2 (MQTT live) each capture messages on their
-            // own, Hook 4 detects DB-level deletes, Hook 5/6 only enrich thread-id and usernames.
+            // Each hook is independently runCatching-wrapped: the hooks are separate capture points,
+            // so a drifted anchor should skip only that hook, never abort the patch.
 
             // Hook 1: REST/JSON path — inject at return of parseFromJson (v426) or unsafeParseFromJson (v430+).
             runCatching {
@@ -74,11 +64,8 @@ val saveDeletedMessagesPatch =
                 }
             }
 
-            // Hook 2: MQTT/MSys real-time path — A0P post-processing step, never touched by REST.
-            // Derive delta class from A0P's second parameter, then find the static converter
-            // (delta → DirectThreadKey) by signature search — no dependency on the action-bar builder fingerprint.
-            // The converter-search / field-derivation is the most version-fragile step, so the entire
-            // Hook 2 resolution AND injection share one runCatching (all-or-nothing for this hook).
+            // Hook 2: MQTT/MSys real-time path, which REST never touches. The delta class comes from
+            // the method's own second parameter, then its converter is found by signature.
             runCatching {
                 val deltaClass = DirectItemPostprocessFingerprint.method.parameterTypes[1].toString()
                 fun isConverter(m: com.android.tools.smali.dexlib2.iface.Method) =
@@ -137,17 +124,79 @@ val saveDeletedMessagesPatch =
                 }
             }
 
-            // Hook 5: pass the action-bar controller (p0) to the extension — thread-id is resolved lazily from its object graph.
-            // Reuses the existing chatActionBarButton header builder fingerprint (same layout_direct_thread_header anchor).
             runCatching {
+                val threadIdField =
+                    mutableClassDefBy { it.type == DIRECT_THREAD_KEY }
+                        .methods.first { it.name == "toString" }
+                        .instructions.toList()
+                        .let { insns ->
+                            val literalIndex =
+                                insns.indexOfFirst {
+                                    (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                        (it as ReferenceInstruction).reference.toString().contains("mThreadId")
+                                }
+                            insns.drop(literalIndex + 1).first {
+                                it.opcode == Opcode.IGET_OBJECT &&
+                                    (it as ReferenceInstruction).reference
+                                        .let { r -> r is FieldReference && r.type == "Ljava/lang/String;" }
+                            }
+                        }.let { (it as ReferenceInstruction).reference as FieldReference }
+
                 ChatActionBarBuilderFingerprint.method.apply {
-                    val reg = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 1).getFreeRegister()
-                    addInstructions(
-                        0,
+                    val insns = instructions.toList()
+                    val keyConverter =
+                        insns.first {
+                            it.opcode == Opcode.INVOKE_STATIC &&
+                                (it as ReferenceInstruction).reference
+                                    .let { r -> r is MethodReference && r.returnType == DIRECT_THREAD_KEY }
+                        }.let { (it as ReferenceInstruction).reference as MethodReference }
+                    val descriptorType = keyConverter.parameterTypes[0].toString()
+                    val descriptorField =
+                        insns.first {
+                            it.opcode == Opcode.IGET_OBJECT &&
+                                (it as ReferenceInstruction).reference
+                                    .let { r -> r is FieldReference && r.type == descriptorType }
+                        }.let { (it as ReferenceInstruction).reference as FieldReference }
+                    val viewModelType = descriptorField.definingClass
+
+                    // Inject after the view-model's first consumer, where its two producers rejoin. A
+                    // branch label sits on that call, so anything inserted before it is jumped over.
+                    val joinInstruction =
+                        insns.first {
+                            it.opcode == Opcode.INVOKE_STATIC &&
+                                (it as ReferenceInstruction).reference
+                                    .let { r -> r is MethodReference && r.parameterTypes.firstOrNull()?.toString() == viewModelType }
+                        }
+                    val viewModelRegister = joinInstruction.registersUsed[0]
+                    // A move-result must stay welded to its call, so step past it when present.
+                    val afterJoinIndex =
+                        joinInstruction.location.index + 1
+                    val injectIndex =
+                        if (insns[afterJoinIndex].opcode == Opcode.MOVE_RESULT ||
+                            insns[afterJoinIndex].opcode == Opcode.MOVE_RESULT_OBJECT ||
+                            insns[afterJoinIndex].opcode == Opcode.MOVE_RESULT_WIDE
+                        ) {
+                            afterJoinIndex + 1
+                        } else {
+                            afterJoinIndex
+                        }
+                    val reg = getFreeRegisterProvider(injectIndex, 1).getFreeRegister()
+
+                    // The skip target must be an ExternalLabel; an in-snippet label is not anchored
+                    // where it is written when inserting mid-method.
+                    addInstructionsWithLabels(
+                        injectIndex,
                         """
-                        move-object/from16 v$reg, p0
-                        invoke-static {v$reg}, $HOOK_CLASS->noteOpenThreadController(Ljava/lang/Object;)V
+                        if-eqz v$viewModelRegister, :piko_no_thread
+                        iget-object v$reg, v$viewModelRegister, $viewModelType->${descriptorField.name}:$descriptorType
+                        if-eqz v$reg, :piko_no_thread
+                        invoke-static {v$reg}, ${keyConverter.definingClass}->${keyConverter.name}($descriptorType)$DIRECT_THREAD_KEY
+                        move-result-object v$reg
+                        if-eqz v$reg, :piko_no_thread
+                        iget-object v$reg, v$reg, $DIRECT_THREAD_KEY->${threadIdField.name}:Ljava/lang/String;
+                        invoke-static {v$reg}, $HOOK_CLASS->noteOpenThreadId(Ljava/lang/String;)V
                         """.trimIndent(),
+                        ExternalLabel("piko_no_thread", insns[injectIndex]),
                     )
                 }
             }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
@@ -42,7 +42,7 @@ val saveDeletedMessagesPatch =
         // userDataEntity IS applied (pulled by another enabled patch) UserData works and Hook 6
         // enriches names; when it isn't, UserData reflection no-ops and we fall back to thread title
         // / sender directory. Either way DM capture (Hooks 1/2/4) stays patch-safe.
-        dependsOn(settingsPatch, chatActionBarButtonPatch, directItemEntity)
+        dependsOn(settingsPatch, chatActionBarButtonPatch, directItemEntity, deletedMessagesResourcePatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.dm.saveMessages
+
+import app.crimera.patches.instagram.entity.directItem.directItemEntity
+import app.crimera.patches.instagram.misc.actionBar.chatActionBarButton.ChatActionBarBuilderFingerprint
+import app.crimera.patches.instagram.misc.actionBar.chatActionBarButton.chatActionBarButtonPatch
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.INTEGRATIONS_PACKAGE
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.util.getFreeRegisterProvider
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val HOOK_CLASS = "$INTEGRATIONS_PACKAGE/patches/dm/SavedMessagesHook;"
+private const val DIRECT_THREAD_KEY = "Lcom/instagram/model/direct/DirectThreadKey;"
+
+@Suppress("unused")
+val saveDeletedMessagesPatch =
+    bytecodePatch(
+        name = "Save deleted messages",
+        description = "Captures incoming DMs locally as they arrive from the server and marks them when the sender deletes them.",
+        default = true,
+    ) {
+        // NOTE: userDataEntity is intentionally NOT a hard dependency. It only backs Hook 6's
+        // best-effort username harvesting (UserData reflection), and its resolver is fragile across
+        // Instagram versions (e.g. GetFullNameExtensionFingerprint fails to resolve on v435). Making
+        // it a dependsOn would abort this entire capture feature whenever that resolver breaks. When
+        // userDataEntity IS applied (pulled by another enabled patch) UserData works and Hook 6
+        // enriches names; when it isn't, UserData reflection no-ops and we fall back to thread title
+        // / sender directory. Either way DM capture (Hooks 1/2/4) stays patch-safe.
+        dependsOn(settingsPatch, chatActionBarButtonPatch, directItemEntity)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+
+            // PATCH-TIME SAFETY: each hook is wrapped in runCatching so that if a future Instagram
+            // build renames a method, restructures the MQTT converter, or drops an anchor, ONLY that
+            // hook is skipped — the patch still applies and the remaining hooks (and every other
+            // patch in the session) keep working. This mirrors the "best-effort, never fatal"
+            // resolution used in DirectItemEntity. All anchor strings/resources are verified present
+            // in the current target (v435); the wrapping guards against the NEXT version drifting.
+            // The hooks are independent capture points, so partial success still yields a usable
+            // feature: Hook 1 (REST history) and Hook 2 (MQTT live) each capture messages on their
+            // own, Hook 4 detects DB-level deletes, Hook 5/6 only enrich thread-id and usernames.
+
+            // Hook 1: REST/JSON path — inject at return of parseFromJson (v426) or unsafeParseFromJson (v430+).
+            runCatching {
+                DirectItemFieldParserFingerprint.classDef.methods
+                    .first { it.name == "parseFromJson" || it.name == "unsafeParseFromJson" }.apply {
+                    val returnObjInstruction = instructions.last { it.opcode == Opcode.RETURN_OBJECT }
+                    val returnObjIndex = returnObjInstruction.location.index
+                    val itemRegister = returnObjInstruction.registersUsed[0]
+
+                    addInstructions(
+                        returnObjIndex,
+                        """
+                        invoke-static {v$itemRegister}, $HOOK_CLASS->onMessageReceived(Ljava/lang/Object;)V
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            // Hook 2: MQTT/MSys real-time path — A0P post-processing step, never touched by REST.
+            // Derive delta class from A0P's second parameter, then find the static converter
+            // (delta → DirectThreadKey) by signature search — no dependency on the action-bar builder fingerprint.
+            // The converter-search / field-derivation is the most version-fragile step, so the entire
+            // Hook 2 resolution AND injection share one runCatching (all-or-nothing for this hook).
+            runCatching {
+                val deltaClass = DirectItemPostprocessFingerprint.method.parameterTypes[1].toString()
+                fun isConverter(m: com.android.tools.smali.dexlib2.iface.Method) =
+                    AccessFlags.STATIC.isSet(m.accessFlags) &&
+                        m.returnType == DIRECT_THREAD_KEY &&
+                        m.parameterTypes.size == 1 &&
+                        m.parameterTypes[0].toString() == deltaClass
+                val deltaThreadIdField =
+                    mutableClassDefBy { cd -> cd.methods.any { isConverter(it) } }
+                    .methods.first { isConverter(it) }
+                    .instructions
+                        .first {
+                            it.opcode == Opcode.IGET_OBJECT &&
+                                (it as ReferenceInstruction).reference
+                                    .let { r -> r is FieldReference && r.type == "Ljava/lang/String;" }
+                        }.let { (it as ReferenceInstruction).reference as FieldReference }
+
+                DirectItemPostprocessFingerprint.method.apply {
+                    val regs = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 3)
+                    val rItem = regs.getFreeRegister()
+                    val rDelta = regs.getFreeRegister()
+                    val rTid = regs.getFreeRegister()
+                    // p2 (MSys delta) is null on some A0P calls — pass null thread-id hint in that case.
+                    addInstructions(
+                        0,
+                        """
+                        move-object/from16 v$rItem, p0
+                        const/4 v$rTid, 0x0
+                        move-object/from16 v$rDelta, p2
+                        if-eqz v$rDelta, :piko_no_delta
+                        iget-object v$rTid, v$rDelta, $deltaClass->${deltaThreadIdField.name}:Ljava/lang/String;
+                        :piko_no_delta
+                        invoke-static {v$rItem, v$rTid}, $HOOK_CLASS->onMessageReceived(Ljava/lang/Object;Ljava/lang/String;)V
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            // Hook 4: SQLite DAO delete — inject at entry so our DB record is still present when the hook fires.
+            runCatching {
+                DirectItemDbHideFingerprint.method.apply {
+                    val regs = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 3)
+                    val r0 = regs.getFreeRegister()
+                    val r1 = regs.getFreeRegister()
+                    val r2 = regs.getFreeRegister()
+
+                    addInstructions(
+                        0,
+                        """
+                        move-object/from16 v$r0, p0
+                        move-object/from16 v$r1, p2
+                        move-object/from16 v$r2, p3
+                        invoke-static {v$r0, v$r1, v$r2}, $HOOK_CLASS->onMessageHiddenFromDb(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            // Hook 5: pass the action-bar controller (p0) to the extension — thread-id is resolved lazily from its object graph.
+            // Reuses the existing chatActionBarButton header builder fingerprint (same layout_direct_thread_header anchor).
+            runCatching {
+                ChatActionBarBuilderFingerprint.method.apply {
+                    val reg = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 1).getFreeRegister()
+                    addInstructions(
+                        0,
+                        """
+                        move-object/from16 v$reg, p0
+                        invoke-static {v$reg}, $HOOK_CLASS->noteOpenThreadController(Ljava/lang/Object;)V
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            // Hook 6: harvest participant usernames from the thread deserializer's "users" iput-object.
+            runCatching {
+                ThreadUsersDispatchFingerprint.method.apply {
+                    val insns = instructions.toList()
+                    val usersKeyIndex =
+                        insns.indexOfFirst {
+                            (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                (it as ReferenceInstruction).reference.toString() == "users"
+                        }
+                    if (usersKeyIndex < 0) return@apply
+                    val listPutInstruction =
+                        insns.drop(usersKeyIndex + 1).firstOrNull {
+                            it.opcode == Opcode.IPUT_OBJECT &&
+                                (it as ReferenceInstruction).reference.toString().endsWith(":Ljava/util/List;")
+                        } ?: return@apply
+                    val listRegister = listPutInstruction.registersUsed[0]
+                    val putIndex = listPutInstruction.location.index
+                    val free = getFreeRegisterProvider(putIndex + 1, 1).getFreeRegister()
+                    addInstructions(
+                        putIndex + 1,
+                        """
+                        move-object/from16 v$free, v$listRegister
+                        invoke-static {v$free}, $HOOK_CLASS->noteThreadUsers(Ljava/util/List;)V
+                        """.trimIndent(),
+                    )
+                }
+            }
+
+            enableSettings("saveDeletedMessages")
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
@@ -11,7 +11,7 @@ import app.crimera.patches.instagram.misc.actionBar.chatActionBarButton.ChatActi
 import app.crimera.patches.instagram.misc.actionBar.chatActionBarButton.chatActionBarButtonPatch
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.crimera.patches.instagram.utils.Constants.INTEGRATIONS_PACKAGE
+import app.crimera.patches.instagram.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
@@ -27,7 +27,7 @@ import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
-private const val HOOK_CLASS = "$INTEGRATIONS_PACKAGE/patches/dm/SavedMessagesHook;"
+private const val HOOK_CLASS = "$PATCHES_DESCRIPTOR/dm/SavedMessagesHook;"
 private const val DIRECT_THREAD_KEY = "Lcom/instagram/model/direct/DirectThreadKey;"
 
 @Suppress("unused")

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsResourcePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsResourcePatch.kt
@@ -44,13 +44,6 @@ val addSettingsActivityPatch =
                     activity.setAttribute("android:exported", "false")
                     application.appendChild(activity)
                 }
-
-                // Viewer for saved deleted (unsent) direct messages
-                activity = document.createElement("activity")
-                activity.setAttribute("android:name", "app.morphe.extension.instagram.patches.dm.DeletedMessagesActivity")
-                activity.setAttribute("android:theme", "@android:style/Theme.DeviceDefault.NoActionBar")
-                activity.setAttribute("android:exported", "false")
-                application.appendChild(activity)
             }
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsResourcePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsResourcePatch.kt
@@ -44,6 +44,13 @@ val addSettingsActivityPatch =
                     activity.setAttribute("android:exported", "false")
                     application.appendChild(activity)
                 }
+
+                // Viewer for saved deleted (unsent) direct messages
+                activity = document.createElement("activity")
+                activity.setAttribute("android:name", "app.morphe.extension.instagram.patches.dm.DeletedMessagesActivity")
+                activity.setAttribute("android:theme", "@android:style/Theme.DeviceDefault.NoActionBar")
+                activity.setAttribute("android:exported", "false")
+                application.appendChild(activity)
             }
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -40,6 +40,7 @@ object Constants {
     const val USER_SESSION_CLASS = "Lcom/instagram/common/session/UserSession;"
     const val USER_DETAIL_VIEW_MODEL_CLASS = "Lcom/instagram/profile/fragment/UserDetailViewModel;"
     const val ORIGINAL_SOUND_DATA_INTF = "Lcom/instagram/api/schemas/OriginalSoundDataIntf;"
+    const val MUSIC_INFO_CLASS = "Lcom/instagram/api/schemas/MusicInfo;"
 
     // Extension classes.
     const val INTEGRATIONS_PACKAGE = "Lapp/morphe/extension/instagram"

--- a/patches/src/main/kotlin/app/crimera/utils/Utils.kt
+++ b/patches/src/main/kotlin/app/crimera/utils/Utils.kt
@@ -157,9 +157,10 @@ fun Fingerprint.changeString(
             (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
                 it.getReference<StringReference>()?.string == sentinel
         }
-    val register = (instruction as OneRegisterInstruction).registerA
+    val register = instruction.registersUsed[0]
     method.replaceInstruction(instruction.location.index, "const-string v$register, \"$value\"")
 }
+
 context(patchContext: BytecodePatchContext)
 fun Fingerprint.changeFirstString(value: String) {
     changeStringAt(0, value)

--- a/patches/src/main/kotlin/app/crimera/utils/Utils.kt
+++ b/patches/src/main/kotlin/app/crimera/utils/Utils.kt
@@ -26,10 +26,12 @@ import com.android.tools.smali.dexlib2.iface.Method
 import com.android.tools.smali.dexlib2.iface.MethodImplementation
 import com.android.tools.smali.dexlib2.iface.MethodParameter
 import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.formats.*
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 import com.android.tools.smali.dexlib2.iface.reference.Reference
 import jdk.javadoc.internal.doclets.formats.html.markup.HtmlStyle
 import org.w3c.dom.Element
@@ -144,6 +146,20 @@ fun Fingerprint.changeStringAt(
     }
 }
 
+/** Rewrites the placeholder equal to [sentinel], so slot order can shift without breaking. */
+context(patchContext: BytecodePatchContext)
+fun Fingerprint.changeString(
+    sentinel: String,
+    value: String,
+) {
+    val instruction =
+        method.instructions.first {
+            (it.opcode == Opcode.CONST_STRING || it.opcode == Opcode.CONST_STRING_JUMBO) &&
+                it.getReference<StringReference>()?.string == sentinel
+        }
+    val register = (instruction as OneRegisterInstruction).registerA
+    method.replaceInstruction(instruction.location.index, "const-string v$register, \"$value\"")
+}
 context(patchContext: BytecodePatchContext)
 fun Fingerprint.changeFirstString(value: String) {
     changeStringAt(0, value)

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -337,6 +337,7 @@
     <string name="piko_delete">Delete</string>
     <string name="piko_unknown">Unknown</string>
     <string name="piko_tap_to_view">tap to view</string>
+    <string name="piko_media_expired">link expired</string>
     <string name="piko_media_not_available">media not available</string>
     <string name="piko_deleted_a_message">%s deleted a message</string>
     <string name="piko_someone">Someone</string>

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -320,4 +320,41 @@
     <string name="piko_filter_story_minimum_item_count_desc">Stories having less than x items will be hidden (default 1)</string>
     <string name="piko_filter_story_maximum_item_count">Maximum story items</string>
     <string name="piko_filter_story_maximum_item_count_desc">Stories having more than x items will be hidden (default 9999)</string>
+
+    <!-- Save & view deleted (unsent) direct messages -->
+    <string name="piko_open_share_in_instagram">Open in Instagram</string>
+    <string name="piko_open_voice_with_player">Open with music player</string>
+    <string name="piko_save_deleted_messages">Save deleted messages</string>
+    <string name="piko_save_deleted_messages_desc">Captures incoming DMs locally as they arrive from the server. Marks messages as deleted when unsent, so you can view them even after the sender deletes them.</string>
+    <string name="piko_view_deleted_messages">View deleted messages</string>
+    <string name="piko_deleted_in_chat">Deleted in this chat</string>
+    <string name="piko_all_deleted_messages">All deleted messages</string>
+    <string name="piko_clear">Clear</string>
+    <string name="piko_clear_chat_confirm">Clear deleted messages for this chat?</string>
+    <string name="piko_clear_all_confirm">Clear ALL saved deleted messages?</string>
+    <string name="piko_no_deleted_messages">No deleted messages captured yet.\nEnable the feature and messages will be saved as they arrive.</string>
+    <string name="piko_delete_saved_confirm">Delete this saved message?</string>
+    <string name="piko_delete">Delete</string>
+    <string name="piko_unknown">Unknown</string>
+    <string name="piko_tap_to_view">tap to view</string>
+    <string name="piko_media_not_available">media not available</string>
+    <string name="piko_deleted_a_message">%s deleted a message</string>
+    <string name="piko_someone">Someone</string>
+    <string name="piko_deleted_messages_channel">Deleted messages</string>
+    <string name="piko_deleted_messages_channel_desc">Notifies when a received message is unsent</string>
+    <string name="piko_media_label">[%s]</string>
+    <string name="piko_media_deleted">[%s deleted]</string>
+    <string name="piko_media_deleted_generic">[deleted]</string>
+    <string name="piko_media_unknown">media</string>
+    <string name="piko_media_photo">photo</string>
+    <string name="piko_media_disappearing_photo">disappearing photo</string>
+    <string name="piko_media_video">video</string>
+    <string name="piko_media_voice">voice message</string>
+    <string name="piko_media_gif">GIF</string>
+    <string name="piko_media_reel">reel</string>
+    <string name="piko_media_story">story</string>
+    <string name="piko_media_post">post</string>
+    <string name="piko_media_like">like</string>
+    <string name="piko_media_link">link</string>
+    <string name="piko_media_activity">activity</string>
 </resources>


### PR DESCRIPTION
Saves incoming DMs as they arrive so you can still read them after they're unsent.
Adds a button on the DM header to view a chat's deleted messages (or all of them). Works for text and media — photos, videos, shared posts/reels and voice notes. Tapping a saved message lets you open, download or copy it.
Toggle it under DM settings.