### PR TITLE
fix(Instagram): Restore native off switch colors

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -489,8 +489,8 @@ public final class InstagramPreferenceStyle {
             int onTrack = primaryTextColor();
             int onThumb = backgroundColor();
 
-            int offTrack = UI.getThemedColour("igds_color_creation_tools_grey_07");
-            int offThumb = onThumb;
+            int offTrack = ResourceUtils.getColor("material_unselected_track", pressedBackgroundColor());
+            int offThumb = ResourceUtils.getColor("checkbox_unchecked_enabled", secondaryTextColor());
 
             if (!enabled) {
                 onTrack = UI.getThemedColour("igds_color_divider");
@@ -523,7 +523,7 @@ public final class InstagramPreferenceStyle {
 
             int trackColor = blend(offTrack, onTrack, colorProgress);
             int thumbColor = blend(offThumb, onThumb, colorProgress);
-            int stroke = trackColor;
+            int stroke = blend(offThumb, onTrack, colorProgress);
 
             float strokeWidth = dp(getContext(), 2);
             float radius = getHeight() / 2f;


### PR DESCRIPTION
The themed color update caused the piko settings switches to use a generic grey track and the on-state background for the thumb while off, they no longer matched Instagram's native switches. use Instagram's native `material_unselected_track` and `checkbox_unchecked_enabled` resources for the off state.

## Testing
- `.\gradlew.bat :patches:buildAndroid --console=plain --no-daemon`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26