### PR TITLE
fix(Instagram): Refine Piko settings title styling

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -47,10 +47,12 @@ public class SettingsActivity extends Activity {
         super.onCreate(bundle);
 
         String displayTitle = null;
+        String fragmentName = null;
 
         // Extract both variables safely from the incoming intent bundle
         if (getIntent() != null && getIntent().getExtras() != null) {
             displayTitle = str(getIntent().getStringExtra(Constants.PIKO_FRAGMENT_TITLE));
+            fragmentName = getIntent().getStringExtra(Constants.PIKO_FRAGMENT_NAME);
         }
 
         // Fallback to default localized string if no custom title was provided in the intent
@@ -58,7 +60,8 @@ public class SettingsActivity extends Activity {
             displayTitle = str("piko_title_settings");
         }
 
-        createLayout( displayTitle);
+        boolean isRootSettings = fragmentName == null || Constants.PIKO_FRAGMENT_SETTINGS.equals(fragmentName);
+        createLayout(displayTitle, isRootSettings);
 
         SettingsFragment fragment = new SettingsFragment();
         if (getIntent() != null && getIntent().getExtras() != null) {
@@ -69,7 +72,7 @@ public class SettingsActivity extends Activity {
     }
 
     @SuppressLint("ResourceType")
-    private void createLayout(String displayTitle) {
+    private void createLayout(String displayTitle, boolean isRootSettings) {
         root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setBackgroundColor(InstagramPreferenceStyle.backgroundColor());
@@ -100,12 +103,23 @@ public class SettingsActivity extends Activity {
 
         titleTextView = new TextView(this);
         titleTextView.setText(displayTitle); // Dynamically bound from intent data
-        titleTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, 26);
+        int titleTextSize = isRootSettings ? 25 : 20;
+        titleTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, titleTextSize);
         titleTextView.setTypeface(Typeface.create("sans-serif", Typeface.NORMAL));
         titleTextView.setIncludeFontPadding(false);
+        titleTextView.setMaxLines(1);
+        if (!isRootSettings) {
+            titleTextView.setAutoSizeTextTypeUniformWithConfiguration(
+                    18,
+                    20,
+                    1,
+                    TypedValue.COMPLEX_UNIT_SP
+            );
+        }
         LinearLayout.LayoutParams titleParams = new LinearLayout.LayoutParams(
+                0,
                 LinearLayout.LayoutParams.WRAP_CONTENT,
-                LinearLayout.LayoutParams.WRAP_CONTENT
+                1.0f
         );
         titleParams.gravity = android.view.Gravity.CENTER_VERTICAL;
         titleParams.leftMargin = InstagramPreferenceStyle.dp(this, 7);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/CategoryPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/CategoryPref.java
@@ -37,8 +37,8 @@ public class CategoryPref extends PreferenceCategory {
     @Override
     protected View onCreateView(ViewGroup parent) {
         TextView title = new TextView(getContext());
-        title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
-        title.setTypeface(Typeface.DEFAULT, Typeface.NORMAL);
+        title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        title.setTypeface(Typeface.DEFAULT, Typeface.BOLD);
         applyCategoryStyle(title);
         title.setLayoutParams(new ViewGroup.LayoutParams(
                 ViewGroup.LayoutParams.MATCH_PARENT,


### PR DESCRIPTION
Piko settings screen titles could wrap to a second line with longer translations, while category titles were too large compared with Instagram's settings UI.

Keep screen titles on one line, preserving a 25sp root title and automatically scaling subpage titles from 20sp to 18sp when needed. Use 15sp bold text for preference category titles.

## Testing
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain --no-daemon`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26