### PR TITLE
fix(Instagram): Refresh localized download folder path

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -17,6 +17,7 @@ import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
@@ -32,6 +33,7 @@ import app.morphe.extension.instagram.settings.preference.Helper;
 import app.morphe.extension.instagram.settings.preference.ScreenBuilder;
 import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
 import app.morphe.extension.instagram.settings.SettingsStatus;
+import app.morphe.extension.instagram.utils.Pref;
 
 public class SettingsActivity extends Activity {
 
@@ -206,6 +208,15 @@ public class SettingsActivity extends Activity {
     public static class SettingsFragment extends PreferenceFragment {
 
         Context context;
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            Preference downloadPathPreference = findPreference("piko_download_set_path");
+            if (downloadPathPreference != null) {
+                downloadPathPreference.setSummary(Pref.getCustomDownloadPath());
+            }
+        }
 
         @Override
         public void onCreate(Bundle savedInstanceState) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -28,12 +28,14 @@ import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import java.util.function.Supplier;
+
+import app.morphe.extension.crimera.downloader.StorageUtils;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.settings.preference.Helper;
 import app.morphe.extension.instagram.settings.preference.ScreenBuilder;
 import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
 import app.morphe.extension.instagram.settings.SettingsStatus;
-import app.morphe.extension.instagram.utils.Pref;
 
 public class SettingsActivity extends Activity {
 
@@ -209,13 +211,23 @@ public class SettingsActivity extends Activity {
 
         Context context;
 
+        private void refreshPreferenceSummary(
+                String key,
+                Supplier<CharSequence> summaryProvider
+        ) {
+            Preference preference = findPreference(key);
+            if (preference != null) {
+                preference.setSummary(summaryProvider.get());
+            }
+        }
+
         @Override
         public void onResume() {
             super.onResume();
-            Preference downloadPathPreference = findPreference("piko_download_set_path");
-            if (downloadPathPreference != null) {
-                downloadPathPreference.setSummary(Pref.getCustomDownloadPath());
-            }
+            refreshPreferenceSummary(
+                    "piko_download_set_path",
+                    StorageUtils::getCustomPathForDisplay
+            );
         }
 
         @Override

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -16,6 +16,7 @@ import android.preference.PreferenceCategory;
 import java.util.TreeMap;
 import java.util.Map;
 
+import app.morphe.extension.crimera.downloader.StorageUtils;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.widgets.*;
@@ -636,7 +637,7 @@ public class ScreenBuilder {
         addPreference(
                 helper.buttonPreference(
                         str("piko_download_set_path"),
-                        Pref.getCustomDownloadPath(),
+                        StorageUtils.getCustomPathForDisplay(),
                         "piko_download_set_path"
                 )
         );

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -7,6 +7,15 @@
 
 package app.morphe.extension.instagram.utils;
 
+import android.app.LocaleManager;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.os.LocaleList;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
+
 import java.util.Set;
 
 import app.morphe.extension.instagram.settings.Settings;
@@ -14,6 +23,7 @@ import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.constants.Constants;
 
 import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.shared.Utils;
 
 @SuppressWarnings("unused")
 public class Pref {
@@ -218,8 +228,121 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.DOWNLOAD_USERNAME_FOLDER);
     }
 
+    static String formatDownloadPathForDisplay(String storedPath, String resolvedStorageLabel) {
+        int separatorIndex = storedPath.indexOf(':');
+        if (separatorIndex < 0) {
+            return storedPath;
+        }
+
+        String storageId = storedPath.substring(0, separatorIndex);
+        String relativePath = storedPath.substring(separatorIndex + 1);
+        String displayStorageLabel = resolvedStorageLabel;
+        if (displayStorageLabel == null || displayStorageLabel.trim().isEmpty()) {
+            displayStorageLabel = isPrimaryStorageId(storageId) ? "" : storageId;
+        }
+
+        if (displayStorageLabel.isEmpty()) {
+            return relativePath;
+        }
+        return relativePath.isEmpty()
+                ? displayStorageLabel
+                : displayStorageLabel + "/" + relativePath;
+    }
+
+    static boolean isPrimaryStorageId(String storageId) {
+        return "primary".equals(storageId);
+    }
+
+    static boolean storageUuidMatches(String storageId, String volumeUuid) {
+        return storageId != null
+                && volumeUuid != null
+                && storageId.equalsIgnoreCase(volumeUuid);
+    }
+
+    private static StorageVolume findStorageVolume(
+            StorageManager storageManager,
+            String storageId
+    ) {
+        if (isPrimaryStorageId(storageId)) {
+            return storageManager.getPrimaryStorageVolume();
+        }
+
+        for (StorageVolume storageVolume : storageManager.getStorageVolumes()) {
+            if (storageUuidMatches(storageId, storageVolume.getUuid())) {
+                return storageVolume;
+            }
+        }
+        return null;
+    }
+
+    private static Context createSystemLocaleContext(Context context) {
+        LocaleList systemLocales = Resources.getSystem()
+                .getConfiguration()
+                .getLocales();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            LocaleManager localeManager = context.getSystemService(LocaleManager.class);
+            if (localeManager != null) {
+                LocaleList localeManagerLocales = localeManager.getSystemLocales();
+                if (!localeManagerLocales.isEmpty()) {
+                    systemLocales = localeManagerLocales;
+                }
+            }
+        }
+
+        if (systemLocales.isEmpty()) {
+            return null;
+        }
+
+        Configuration configuration = new Configuration(
+                context.getResources().getConfiguration()
+        );
+        configuration.setLocales(systemLocales);
+        return context.createConfigurationContext(configuration);
+    }
+
+    private static String resolveStorageLabel(String storageId) {
+        try {
+            Context context = Utils.getContext();
+            if (context == null) {
+                return null;
+            }
+
+            StorageManager storageManager = context.getSystemService(StorageManager.class);
+            if (storageManager == null) {
+                return null;
+            }
+
+            StorageVolume storageVolume = findStorageVolume(storageManager, storageId);
+            if (storageVolume == null) {
+                return null;
+            }
+
+            Context systemLocaleContext = createSystemLocaleContext(context);
+            if (systemLocaleContext == null) {
+                return null;
+            }
+
+            String description = storageVolume.getDescription(systemLocaleContext);
+            return description == null || description.trim().isEmpty()
+                    ? null
+                    : description;
+        } catch (Exception ignored) {
+            return null;
+        }
+    }
+
     public static String getCustomDownloadPath() {
-        return SharedPref.getStringPref(Settings.CUSTOM_DOWNLOAD_PATH);
+        String storedPath = SharedPref.getStringPref(Settings.CUSTOM_DOWNLOAD_PATH);
+        int separatorIndex = storedPath.indexOf(':');
+        if (separatorIndex < 0) {
+            return storedPath;
+        }
+
+        String storageId = storedPath.substring(0, separatorIndex);
+        return formatDownloadPathForDisplay(
+                storedPath,
+                resolveStorageLabel(storageId)
+        );
     }
 
     public static boolean hideNavigationFeed() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -7,15 +7,6 @@
 
 package app.morphe.extension.instagram.utils;
 
-import android.app.LocaleManager;
-import android.content.Context;
-import android.content.res.Configuration;
-import android.content.res.Resources;
-import android.os.Build;
-import android.os.LocaleList;
-import android.os.storage.StorageManager;
-import android.os.storage.StorageVolume;
-
 import java.util.Set;
 
 import app.morphe.extension.instagram.settings.Settings;
@@ -23,7 +14,6 @@ import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.constants.Constants;
 
 import app.morphe.extension.crimera.SharedPref;
-import app.morphe.extension.shared.Utils;
 
 @SuppressWarnings("unused")
 public class Pref {
@@ -226,123 +216,6 @@ public class Pref {
 
     public static boolean downloadUsernameFolder() {
         return SharedPref.getBooleanPref(Settings.DOWNLOAD_USERNAME_FOLDER);
-    }
-
-    static String formatDownloadPathForDisplay(String storedPath, String resolvedStorageLabel) {
-        int separatorIndex = storedPath.indexOf(':');
-        if (separatorIndex < 0) {
-            return storedPath;
-        }
-
-        String storageId = storedPath.substring(0, separatorIndex);
-        String relativePath = storedPath.substring(separatorIndex + 1);
-        String displayStorageLabel = resolvedStorageLabel;
-        if (displayStorageLabel == null || displayStorageLabel.trim().isEmpty()) {
-            displayStorageLabel = isPrimaryStorageId(storageId) ? "" : storageId;
-        }
-
-        if (displayStorageLabel.isEmpty()) {
-            return relativePath;
-        }
-        return relativePath.isEmpty()
-                ? displayStorageLabel
-                : displayStorageLabel + "/" + relativePath;
-    }
-
-    static boolean isPrimaryStorageId(String storageId) {
-        return "primary".equals(storageId);
-    }
-
-    static boolean storageUuidMatches(String storageId, String volumeUuid) {
-        return storageId != null
-                && volumeUuid != null
-                && storageId.equalsIgnoreCase(volumeUuid);
-    }
-
-    private static StorageVolume findStorageVolume(
-            StorageManager storageManager,
-            String storageId
-    ) {
-        if (isPrimaryStorageId(storageId)) {
-            return storageManager.getPrimaryStorageVolume();
-        }
-
-        for (StorageVolume storageVolume : storageManager.getStorageVolumes()) {
-            if (storageUuidMatches(storageId, storageVolume.getUuid())) {
-                return storageVolume;
-            }
-        }
-        return null;
-    }
-
-    private static Context createSystemLocaleContext(Context context) {
-        LocaleList systemLocales = Resources.getSystem()
-                .getConfiguration()
-                .getLocales();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            LocaleManager localeManager = context.getSystemService(LocaleManager.class);
-            if (localeManager != null) {
-                LocaleList localeManagerLocales = localeManager.getSystemLocales();
-                if (!localeManagerLocales.isEmpty()) {
-                    systemLocales = localeManagerLocales;
-                }
-            }
-        }
-
-        if (systemLocales.isEmpty()) {
-            return null;
-        }
-
-        Configuration configuration = new Configuration(
-                context.getResources().getConfiguration()
-        );
-        configuration.setLocales(systemLocales);
-        return context.createConfigurationContext(configuration);
-    }
-
-    private static String resolveStorageLabel(String storageId) {
-        try {
-            Context context = Utils.getContext();
-            if (context == null) {
-                return null;
-            }
-
-            StorageManager storageManager = context.getSystemService(StorageManager.class);
-            if (storageManager == null) {
-                return null;
-            }
-
-            StorageVolume storageVolume = findStorageVolume(storageManager, storageId);
-            if (storageVolume == null) {
-                return null;
-            }
-
-            Context systemLocaleContext = createSystemLocaleContext(context);
-            if (systemLocaleContext == null) {
-                return null;
-            }
-
-            String description = storageVolume.getDescription(systemLocaleContext);
-            return description == null || description.trim().isEmpty()
-                    ? null
-                    : description;
-        } catch (Exception ignored) {
-            return null;
-        }
-    }
-
-    public static String getCustomDownloadPath() {
-        String storedPath = SharedPref.getStringPref(Settings.CUSTOM_DOWNLOAD_PATH);
-        int separatorIndex = storedPath.indexOf(':');
-        if (separatorIndex < 0) {
-            return storedPath;
-        }
-
-        String storageId = storedPath.substring(0, separatorIndex);
-        return formatDownloadPathForDisplay(
-                storedPath,
-                resolveStorageLabel(storageId)
-        );
     }
 
     public static boolean hideNavigationFeed() {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/StorageUtils.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/StorageUtils.java
@@ -7,10 +7,17 @@
 
 package app.morphe.extension.crimera.downloader;
 
+import android.app.LocaleManager;
 import android.content.Context;
 import android.content.Intent;
+import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.net.Uri;
 import android.content.UriPermission;
+import android.os.Build;
+import android.os.LocaleList;
+import android.os.storage.StorageManager;
+import android.os.storage.StorageVolume;
 
 import app.morphe.extension.crimera.SharedPref;
 import app.morphe.extension.crimera.constants.ExtensionStrings;
@@ -22,6 +29,126 @@ public class StorageUtils {
 
     public static void saveCustomPath(String path) {
         SharedPref.setStringPref(KEY_BASE_PATH, path);
+    }
+
+    public static String getCustomPathForDisplay() {
+        String storedPath = SharedPref.getStringPref(KEY_BASE_PATH, "");
+        int separatorIndex = storedPath.indexOf(':');
+        if (separatorIndex < 0) {
+            return storedPath;
+        }
+
+        String storageId = storedPath.substring(0, separatorIndex);
+        return formatCustomPathForDisplay(
+                storedPath,
+                resolveStorageLabel(storageId)
+        );
+    }
+
+    static String formatCustomPathForDisplay(
+            String storedPath,
+            String resolvedStorageLabel
+    ) {
+        int separatorIndex = storedPath.indexOf(':');
+        if (separatorIndex < 0) {
+            return storedPath;
+        }
+
+        String storageId = storedPath.substring(0, separatorIndex);
+        String relativePath = storedPath.substring(separatorIndex + 1);
+        String displayStorageLabel = resolvedStorageLabel;
+        if (displayStorageLabel == null || displayStorageLabel.trim().isEmpty()) {
+            displayStorageLabel = isPrimaryStorageId(storageId) ? "" : storageId;
+        }
+
+        if (displayStorageLabel.isEmpty()) {
+            return relativePath;
+        }
+        return relativePath.isEmpty()
+                ? displayStorageLabel
+                : displayStorageLabel + "/" + relativePath;
+    }
+
+    private static boolean isPrimaryStorageId(String storageId) {
+        return "primary".equals(storageId);
+    }
+
+    private static boolean storageUuidMatches(String storageId, String volumeUuid) {
+        return storageId != null
+                && volumeUuid != null
+                && storageId.equalsIgnoreCase(volumeUuid);
+    }
+
+    private static StorageVolume findStorageVolume(
+            StorageManager storageManager,
+            String storageId
+    ) {
+        if (isPrimaryStorageId(storageId)) {
+            return storageManager.getPrimaryStorageVolume();
+        }
+
+        for (StorageVolume storageVolume : storageManager.getStorageVolumes()) {
+            if (storageUuidMatches(storageId, storageVolume.getUuid())) {
+                return storageVolume;
+            }
+        }
+        return null;
+    }
+
+    private static Context createSystemLocaleContext(Context context) {
+        LocaleList systemLocales = Resources.getSystem()
+                .getConfiguration()
+                .getLocales();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            LocaleManager localeManager = context.getSystemService(LocaleManager.class);
+            if (localeManager != null) {
+                LocaleList localeManagerLocales = localeManager.getSystemLocales();
+                if (!localeManagerLocales.isEmpty()) {
+                    systemLocales = localeManagerLocales;
+                }
+            }
+        }
+
+        if (systemLocales.isEmpty()) {
+            return null;
+        }
+
+        Configuration configuration = new Configuration(
+                context.getResources().getConfiguration()
+        );
+        configuration.setLocales(systemLocales);
+        return context.createConfigurationContext(configuration);
+    }
+
+    private static String resolveStorageLabel(String storageId) {
+        try {
+            Context context = PikoUtils.getContext();
+            if (context == null) {
+                return null;
+            }
+
+            StorageManager storageManager = context.getSystemService(StorageManager.class);
+            if (storageManager == null) {
+                return null;
+            }
+
+            StorageVolume storageVolume = findStorageVolume(storageManager, storageId);
+            if (storageVolume == null) {
+                return null;
+            }
+
+            Context systemLocaleContext = createSystemLocaleContext(context);
+            if (systemLocaleContext == null) {
+                return null;
+            }
+
+            String description = storageVolume.getDescription(systemLocaleContext);
+            return description == null || description.trim().isEmpty()
+                    ? null
+                    : description;
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     public static void saveCustomTreeUri(Uri treeUri) {


### PR DESCRIPTION
The download folder summary is only populated when the preference screen is created, it stays stale after returning from the system folder picker. the stored document ID can also expose internal identifiers such as `primary:`. refresh the summary when the settings screen resumes and format the path with Android's storage volume label using the device system locale.

## Testing
- `.\gradlew.bat :extensions:instagram:compileReleaseJavaWithJavac :patches:buildAndroid --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26 and OPPO Find X9 Pro