### PR TITLE
 feat(Instagram): Save and view received Instants

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Constants.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
     public static final String PIKO_FRAGMENT_DM = "piko_frag_dm";
     public static final String PIKO_FRAGMENT_FILTER_CONTENT = "piko_frag_filter_content";
     public static final String PIKO_FRAGMENT_REC_FLAGS = "piko_frag_rec_flags";
+    public static final String PIKO_FRAGMENT_INSTANTS = "piko_frag_instants";
 
     public static void load() {
         ExtensionStrings.setDefaultPikoFolder(Constants.DEFAULT_PIKO_FOLDER);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoInstantsDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoInstantsDb.java
@@ -15,19 +15,17 @@ import android.database.sqlite.SQLiteOpenHelper;
 import java.util.ArrayList;
 import java.util.List;
 
+import app.morphe.extension.instagram.utils.MediaUrls;
 import app.morphe.extension.shared.Logger;
 
 /**
- * Local persistent store for captured Instants (quicksnap). View-once instants change on tap and
- * vanish after viewing, so InstantsDownloadHook records each one's CDN links as it's viewed; the
- * "Saved Instants" screen (InstantsVaultActivity) reads them back for viewing and download.
- *
- * <p>Modelled on the DM vault (PikoMessageDb) but a separate table/file — instants are not messages.
+ * Store for captured Instants: InstantsDownloadHook writes their CDN links here, and the
+ * "Saved Instants" screen reads them back for viewing and download.
  */
 public class PikoInstantsDb extends SQLiteOpenHelper {
 
     private static final String DB_NAME = "piko_instants_vault.db";
-    private static final int DB_VERSION = 2;
+    private static final int DB_VERSION = 3;
     private static final String TABLE = "saved_instants";
 
     private static final String COL_ID = "media_id";
@@ -37,6 +35,7 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
     private static final String COL_IS_VIDEO = "is_video";
     private static final String COL_TS = "ts";
     private static final String COL_USERID = "userid";
+    private static final String COL_EXPIRES_AT = "expires_at";
 
     private static volatile PikoInstantsDb sInstance;
 
@@ -61,7 +60,8 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
                 COL_VIDEO_URL + " TEXT, " +
                 COL_IS_VIDEO + " INTEGER DEFAULT 0, " +
                 COL_TS + " INTEGER, " +
-                COL_USERID + " TEXT" +
+                COL_USERID + " TEXT, " +
+                COL_EXPIRES_AT + " INTEGER DEFAULT 0" +
             ")"
         );
     }
@@ -76,6 +76,15 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
                 Logger.printException(() -> "PikoInstantsDb.onUpgrade v2 failed", t);
             }
         }
+        // v2 -> v3: remember when the CDN link dies so dead rows can be dropped on open.
+        if (oldVersion < 3) {
+            try {
+                db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN " + COL_EXPIRES_AT
+                        + " INTEGER DEFAULT 0");
+            } catch (Throwable t) {
+                Logger.printException(() -> "PikoInstantsDb.onUpgrade v3 failed", t);
+            }
+        }
     }
 
     /** Records an instant, ignoring duplicates (same media id). Best-effort — never throws. */
@@ -83,6 +92,8 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
                                String videoUrl, boolean isVideo) {
         if (mediaId == null || mediaId.isEmpty()) return;
         try {
+            String playbackUrl = isVideo && videoUrl != null && !videoUrl.isEmpty()
+                    ? videoUrl : imageUrl;
             ContentValues cv = new ContentValues();
             cv.put(COL_ID, mediaId);
             cv.put(COL_USERNAME, username);
@@ -91,6 +102,7 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
             cv.put(COL_VIDEO_URL, videoUrl);
             cv.put(COL_IS_VIDEO, isVideo ? 1 : 0);
             cv.put(COL_TS, System.currentTimeMillis());
+            cv.put(COL_EXPIRES_AT, MediaUrls.expiresAt(playbackUrl));
             getWritableDatabase().insertWithOnConflict(
                 TABLE, null, cv, SQLiteDatabase.CONFLICT_IGNORE);
         } catch (Throwable t) {
@@ -109,24 +121,41 @@ public class PikoInstantsDb extends SQLiteOpenHelper {
         }
     }
 
-    /** Newest first. Each row: {media_id, username, image_url, video_url, is_video, ts, userid}. */
+    /**
+     * Newest first. Each row:
+     * {media_id, username, image_url, video_url, is_video, ts, userid, expires_at}.
+     */
     public List<String[]> getAll() {
         List<String[]> out = new ArrayList<>();
         try (Cursor c = getReadableDatabase().query(
                 TABLE,
-                new String[]{COL_ID, COL_USERNAME, COL_IMAGE_URL, COL_VIDEO_URL, COL_IS_VIDEO, COL_TS, COL_USERID},
+                new String[]{COL_ID, COL_USERNAME, COL_IMAGE_URL, COL_VIDEO_URL, COL_IS_VIDEO, COL_TS,
+                        COL_USERID, COL_EXPIRES_AT},
                 null, null, null, null, COL_TS + " DESC")) {
             while (c.moveToNext()) {
                 out.add(new String[]{
                     c.getString(0), c.getString(1), c.getString(2),
                     c.getString(3), String.valueOf(c.getInt(4)), String.valueOf(c.getLong(5)),
-                    c.getString(6),
+                    c.getString(6), String.valueOf(c.getLong(7)),
                 });
             }
         } catch (Throwable t) {
             Logger.printException(() -> "PikoInstantsDb.getAll failed", t);
         }
         return out;
+    }
+
+    /** Drops rows whose CDN link has already died. Returns how many went. */
+    public int purgeExpired() {
+        try {
+            return getWritableDatabase().delete(
+                    TABLE,
+                    COL_EXPIRES_AT + " > 0 AND " + COL_EXPIRES_AT + " <= ?",
+                    new String[]{String.valueOf(System.currentTimeMillis())});
+        } catch (Throwable t) {
+            Logger.printException(() -> "PikoInstantsDb.purgeExpired failed", t);
+            return 0;
+        }
     }
 
     public void delete(String mediaId) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoInstantsDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoInstantsDb.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.db;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import app.morphe.extension.shared.Logger;
+
+/**
+ * Local persistent store for captured Instants (quicksnap). View-once instants change on tap and
+ * vanish after viewing, so InstantsDownloadHook records each one's CDN links as it's viewed; the
+ * "Saved Instants" screen (InstantsVaultActivity) reads them back for viewing and download.
+ *
+ * <p>Modelled on the DM vault (PikoMessageDb) but a separate table/file — instants are not messages.
+ */
+public class PikoInstantsDb extends SQLiteOpenHelper {
+
+    private static final String DB_NAME = "piko_instants_vault.db";
+    private static final int DB_VERSION = 2;
+    private static final String TABLE = "saved_instants";
+
+    private static final String COL_ID = "media_id";
+    private static final String COL_USERNAME = "username";
+    private static final String COL_IMAGE_URL = "image_url";
+    private static final String COL_VIDEO_URL = "video_url";
+    private static final String COL_IS_VIDEO = "is_video";
+    private static final String COL_TS = "ts";
+    private static final String COL_USERID = "userid";
+
+    private static volatile PikoInstantsDb sInstance;
+
+    public static synchronized PikoInstantsDb getInstance(Context context) {
+        if (sInstance == null) {
+            sInstance = new PikoInstantsDb(context.getApplicationContext());
+        }
+        return sInstance;
+    }
+
+    private PikoInstantsDb(Context context) {
+        super(context, DB_NAME, null, DB_VERSION);
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        db.execSQL(
+            "CREATE TABLE " + TABLE + " (" +
+                COL_ID + " TEXT PRIMARY KEY, " +
+                COL_USERNAME + " TEXT, " +
+                COL_IMAGE_URL + " TEXT, " +
+                COL_VIDEO_URL + " TEXT, " +
+                COL_IS_VIDEO + " INTEGER DEFAULT 0, " +
+                COL_TS + " INTEGER, " +
+                COL_USERID + " TEXT" +
+            ")"
+        );
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // v1 -> v2: add a stable userid so grouping survives username changes. Best-effort.
+        if (oldVersion < 2) {
+            try {
+                db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN " + COL_USERID + " TEXT");
+            } catch (Throwable t) {
+                Logger.printException(() -> "PikoInstantsDb.onUpgrade v2 failed", t);
+            }
+        }
+    }
+
+    /** Records an instant, ignoring duplicates (same media id). Best-effort — never throws. */
+    public void insertOrIgnore(String mediaId, String username, String userId, String imageUrl,
+                               String videoUrl, boolean isVideo) {
+        if (mediaId == null || mediaId.isEmpty()) return;
+        try {
+            ContentValues cv = new ContentValues();
+            cv.put(COL_ID, mediaId);
+            cv.put(COL_USERNAME, username);
+            cv.put(COL_USERID, userId);
+            cv.put(COL_IMAGE_URL, imageUrl);
+            cv.put(COL_VIDEO_URL, videoUrl);
+            cv.put(COL_IS_VIDEO, isVideo ? 1 : 0);
+            cv.put(COL_TS, System.currentTimeMillis());
+            getWritableDatabase().insertWithOnConflict(
+                TABLE, null, cv, SQLiteDatabase.CONFLICT_IGNORE);
+        } catch (Throwable t) {
+            Logger.printException(() -> "PikoInstantsDb.insertOrIgnore failed", t);
+        }
+    }
+
+    public boolean has(String mediaId) {
+        if (mediaId == null || mediaId.isEmpty()) return false;
+        try (Cursor c = getReadableDatabase().query(
+                TABLE, new String[]{COL_ID}, COL_ID + "=?", new String[]{mediaId},
+                null, null, null, "1")) {
+            return c.moveToFirst();
+        } catch (Throwable t) {
+            return false;
+        }
+    }
+
+    /** Newest first. Each row: {media_id, username, image_url, video_url, is_video, ts, userid}. */
+    public List<String[]> getAll() {
+        List<String[]> out = new ArrayList<>();
+        try (Cursor c = getReadableDatabase().query(
+                TABLE,
+                new String[]{COL_ID, COL_USERNAME, COL_IMAGE_URL, COL_VIDEO_URL, COL_IS_VIDEO, COL_TS, COL_USERID},
+                null, null, null, null, COL_TS + " DESC")) {
+            while (c.moveToNext()) {
+                out.add(new String[]{
+                    c.getString(0), c.getString(1), c.getString(2),
+                    c.getString(3), String.valueOf(c.getInt(4)), String.valueOf(c.getLong(5)),
+                    c.getString(6),
+                });
+            }
+        } catch (Throwable t) {
+            Logger.printException(() -> "PikoInstantsDb.getAll failed", t);
+        }
+        return out;
+    }
+
+    public void delete(String mediaId) {
+        try {
+            getWritableDatabase().delete(TABLE, COL_ID + "=?", new String[]{mediaId});
+        } catch (Throwable t) {
+            Logger.printException(() -> "PikoInstantsDb.delete failed", t);
+        }
+    }
+
+    public void clearAll() {
+        try {
+            getWritableDatabase().delete(TABLE, null, null);
+        } catch (Throwable t) {
+            Logger.printException(() -> "PikoInstantsDb.clearAll failed", t);
+        }
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.instants;
+
+import android.content.Context;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.instagram.db.PikoInstantsDb;
+import app.morphe.extension.instagram.entity.MediaData;
+import app.morphe.extension.instagram.settings.Settings;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+
+/**
+ * Runtime capture for the "Save Instants" feature. View-once instants (quicksnap) change on tap and
+ * vanish after viewing, so rather than a per-instant button this passively records each viewed
+ * instant's CDN links into {@link PikoInstantsDb} as the viewer surfaces it. The "Saved Instants"
+ * screen ({@link InstantsVaultActivity}) lists them for viewing and download.
+ *
+ * <p>Capture reads the live viewer ViewModel: {@code vm.<A0Q>.getValue().<A03>() -> item.<A01>}
+ * (a {@code Media}), then reuses piko's {@link MediaData} entity to pull the image/video url,
+ * username and type. All obfuscated names are resolved at patch time (§11, see {@link #names()}).
+ */
+@SuppressWarnings("unused")
+public class InstantsDownloadHook {
+
+    // Indices into names(). The patch resolves entries by placeholder text, not position.
+    private static final int N_MARKER = 0;
+    private static final int N_VM_STATE_FIELD = 1;    // 5Ur -> A0Q (StateFlow-like, getValue() -> state)
+    private static final int N_STATE_ITEM_METHOD = 2; // 5VB -> A03 () -> current item (5Xq)
+    private static final int N_ITEM_MEDIA_FIELD = 3;  // 5Xq -> A01 (Lcom/instagram/feed/media/Media;)
+
+    /** Value of N_MARKER once patch-time resolution has committed. */
+    private static final String MARKER_RESOLVED = "1";
+
+    /**
+     * Obfuscated field/method names the capture path reflects on, resolved at patch time (§11) by
+     * instantsDownloadPatch from the target dex. Each entry is a sentinel the resolver locates by
+     * value and rewrites; there is no last-known-good fallback, since obfuscated names rotate on
+     * every R8 run. If resolution didn't run the marker stays unset and capture no-ops.
+     */
+    private static String[] names() {
+        return new String[] {
+                "piko.instants.dl.marker",          // patched to "1" — commit flag, written last
+                "piko.instants.dl.vmStateField",    // viewer VM state field (getValue() -> viewer state)
+                "piko.instants.dl.stateItemMethod", // state method returning the current item
+                "piko.instants.dl.itemMediaField",  // current item's Media field
+        };
+    }
+
+    /** The last media id captured — avoids re-hitting the DB on every VM method call while the same
+     *  instant is on screen (noteViewerVm fires very frequently). */
+    private static volatile String sLastCapturedId;
+
+    /**
+     * Injected at the entry of the viewer ViewModel's instance methods (p0 = VM). Pulls the instant
+     * currently on screen and records it. Fully guarded — any failure just skips this capture.
+     */
+    public static void noteViewerVm(Object vm) {
+        try {
+            if (vm == null) return;
+            if (!MARKER_RESOLVED.equals(names()[N_MARKER])) return;
+            if (!SharedPref.getBooleanPref(Settings.INSTANTS_DOWNLOAD)) return;
+
+            Object media = currentInstantMedia(vm);
+            if (media != null) captureMedia(media);
+        } catch (Throwable t) {
+            Logger.printException(() -> "instants capture: noteViewerVm failed", t);
+        }
+    }
+
+    /** Reads the Media backing the instant currently shown, via the live VM. Null on any mismatch. */
+    private static Object currentInstantMedia(Object vm) {
+        try {
+            String[] N = names();
+            Object stateHolder = declaredField(vm, N[N_VM_STATE_FIELD]);              // LX/EuU
+            if (stateHolder == null) return null;
+            Object state = publicMethod(stateHolder, "getValue").invoke(stateHolder);  // LX/5VB
+            if (state == null) return null;
+            Object item = publicMethod(state, N[N_STATE_ITEM_METHOD]).invoke(state);   // LX/5Xq
+            if (item == null) return null;
+            return declaredField(item, N[N_ITEM_MEDIA_FIELD]);                         // Media
+        } catch (Throwable t) {
+            // Off-cycle calls (VM alive but no current item) land here — expected, keep quiet.
+            return null;
+        }
+    }
+
+    /** Extracts the instant's links via piko's MediaData entity and stores them (deduped by id). */
+    private static void captureMedia(Object media) {
+        try {
+            MediaData md = new MediaData(media, null);
+
+            String id;
+            try {
+                id = md.getMediaPkId();
+            } catch (Throwable t) {
+                return; // no stable id -> can't dedupe or reference later
+            }
+            if (id == null || id.isEmpty() || id.equals(sLastCapturedId)) return;
+            sLastCapturedId = id;
+
+            Context ctx = Utils.getContext();
+            if (ctx == null) return;
+            PikoInstantsDb db = PikoInstantsDb.getInstance(ctx);
+            if (db.has(id)) return;
+
+            boolean isVideo = safeBool(() -> md.isVideo());
+            String imageUrl = safeStr(() -> md.getImageLink());
+            String videoUrl = isVideo ? safeStr(() -> md.getVideoLink()) : null;
+            String username = safeStr(() -> md.getUserData().getUsername());
+            String userId = safeStr(() -> md.getUserData().getUserId());
+
+            db.insertOrIgnore(id, username, userId, imageUrl, videoUrl, isVideo);
+            Logger.printException(() -> "[piko] instants capture: saved "
+                    + (isVideo ? "video" : "photo") + " from " + username);
+        } catch (Throwable t) {
+            Logger.printException(() -> "instants capture: captureMedia failed", t);
+        }
+    }
+
+    // ---- reflection + best-effort helpers ----
+
+    private interface StrCall { String get() throws Exception; }
+    private interface BoolCall { boolean get() throws Exception; }
+
+    private static String safeStr(StrCall c) {
+        try { return c.get(); } catch (Throwable t) { return null; }
+    }
+
+    private static boolean safeBool(BoolCall c) {
+        try { return c.get(); } catch (Throwable t) { return false; }
+    }
+
+    private static Object declaredField(Object obj, String name) throws Exception {
+        Field f = obj.getClass().getDeclaredField(name);
+        f.setAccessible(true);
+        return f.get(obj);
+    }
+
+    private static Method publicMethod(Object obj, String name) throws Exception {
+        Method m = obj.getClass().getMethod(name);
+        m.setAccessible(true);
+        return m;
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
@@ -8,11 +8,9 @@ package app.morphe.extension.instagram.patches.instants;
 
 import android.content.Context;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-
 import app.morphe.extension.crimera.SharedPref;
 import app.morphe.extension.instagram.db.PikoInstantsDb;
+import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.shared.Logger;
@@ -88,16 +86,18 @@ public class InstantsDownloadHook {
         }
     }
 
-    /** Reads the Media backing the instant currently shown, via the live VM. Null on any mismatch. */
+    /** Reads the Media backing the instant currently shown, via the live VM, using the repo's
+     *  {@link Entity} helper (getField for field steps, getMethod for the calls) rather than raw
+     *  reflection. Null on any mismatch. */
     private static Object currentInstantMedia(Object vm) {
         try {
-            Object stateHolder = declaredField(vm, NAMES.vmStateField);                // LX/EuU
+            Object stateHolder = new Entity(vm).getField(NAMES.vmStateField);          // LX/EuU
             if (stateHolder == null) return null;
-            Object state = publicMethod(stateHolder, "getValue").invoke(stateHolder);  // LX/5VB
+            Object state = new Entity(stateHolder).getMethod("getValue");              // LX/5VB
             if (state == null) return null;
-            Object item = publicMethod(state, NAMES.stateItemMethod).invoke(state);    // LX/5Xq
+            Object item = new Entity(state).getMethod(NAMES.stateItemMethod);          // LX/5Xq
             if (item == null) return null;
-            return declaredField(item, NAMES.itemMediaField);                         // Media
+            return new Entity(item).getField(NAMES.itemMediaField);                    // Media
         } catch (Throwable t) {
             // Off-cycle calls (VM alive but no current item) land here — expected, keep quiet.
             return null;
@@ -146,17 +146,5 @@ public class InstantsDownloadHook {
 
     private static boolean safeBool(BoolCall c) {
         try { return c.get(); } catch (Throwable t) { return false; }
-    }
-
-    private static Object declaredField(Object obj, String name) throws Exception {
-        Field f = obj.getClass().getDeclaredField(name);
-        f.setAccessible(true);
-        return f.get(obj);
-    }
-
-    private static Method publicMethod(Object obj, String name) throws Exception {
-        Method m = obj.getClass().getMethod(name);
-        m.setAccessible(true);
-        return m;
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
@@ -26,34 +26,46 @@ import app.morphe.extension.shared.Utils;
  *
  * <p>Capture reads the live viewer ViewModel: {@code vm.<A0Q>.getValue().<A03>() -> item.<A01>}
  * (a {@code Media}), then reuses piko's {@link MediaData} entity to pull the image/video url,
- * username and type. All obfuscated names are resolved at patch time (§11, see {@link #names()}).
+ * username and type. All obfuscated names are resolved at patch time (§11).
+ *
+ * <p>The obfuscated names are seeded as sentinel placeholders in {@link #names()}; instantsDownloadPatch
+ * locates each by value and rewrites it from the target dex. They live in a returned array (not
+ * static fields) because R8 minifies this extension and would constant-fold single-assigned string
+ * fields away before the patch runs — the array-return form keeps them as real {@code const-string}s
+ * for the patch to find. {@link Names} maps that array into named fields in one place, so nothing
+ * downstream depends on array position. No last-known-good fallback — obfuscated names rotate on every
+ * R8 run; if resolution didn't run the marker stays unset and capture no-ops.
  */
 @SuppressWarnings("unused")
 public class InstantsDownloadHook {
 
-    // Indices into names(). The patch resolves entries by placeholder text, not position.
-    private static final int N_MARKER = 0;
-    private static final int N_VM_STATE_FIELD = 1;    // 5Ur -> A0Q (StateFlow-like, getValue() -> state)
-    private static final int N_STATE_ITEM_METHOD = 2; // 5VB -> A03 () -> current item (5Xq)
-    private static final int N_ITEM_MEDIA_FIELD = 3;  // 5Xq -> A01 (Lcom/instagram/feed/media/Media;)
-
-    /** Value of N_MARKER once patch-time resolution has committed. */
-    private static final String MARKER_RESOLVED = "1";
-
-    /**
-     * Obfuscated field/method names the capture path reflects on, resolved at patch time (§11) by
-     * instantsDownloadPatch from the target dex. Each entry is a sentinel the resolver locates by
-     * value and rewrites; there is no last-known-good fallback, since obfuscated names rotate on
-     * every R8 run. If resolution didn't run the marker stays unset and capture no-ops.
-     */
+    /** Sentinel placeholders, rewritten at patch time by matching each value (not by position). */
     private static String[] names() {
         return new String[] {
-                "piko.instants.dl.marker",          // patched to "1" — commit flag, written last
+                "piko.instants.dl.marker",          // commit flag — patched to "1" last
                 "piko.instants.dl.vmStateField",    // viewer VM state field (getValue() -> viewer state)
                 "piko.instants.dl.stateItemMethod", // state method returning the current item
                 "piko.instants.dl.itemMediaField",  // current item's Media field
         };
     }
+
+    /** Names as fields, so the reflection path never indexes the array by hand. The only place the
+     *  array order is assumed is right here, next to {@link #names()}. */
+    private static final class Names {
+        final String marker, vmStateField, stateItemMethod, itemMediaField;
+
+        Names(String[] a) {
+            marker = a[0];
+            vmStateField = a[1];
+            stateItemMethod = a[2];
+            itemMediaField = a[3];
+        }
+    }
+
+    private static final Names NAMES = new Names(names());
+
+    /** Value of {@link Names#marker} once patch-time resolution has committed. */
+    private static final String MARKER_RESOLVED = "1";
 
     /** The last media id captured — avoids re-hitting the DB on every VM method call while the same
      *  instant is on screen (noteViewerVm fires very frequently). */
@@ -66,7 +78,7 @@ public class InstantsDownloadHook {
     public static void noteViewerVm(Object vm) {
         try {
             if (vm == null) return;
-            if (!MARKER_RESOLVED.equals(names()[N_MARKER])) return;
+            if (!MARKER_RESOLVED.equals(NAMES.marker)) return;
             if (!SharedPref.getBooleanPref(Settings.INSTANTS_DOWNLOAD)) return;
 
             Object media = currentInstantMedia(vm);
@@ -79,14 +91,13 @@ public class InstantsDownloadHook {
     /** Reads the Media backing the instant currently shown, via the live VM. Null on any mismatch. */
     private static Object currentInstantMedia(Object vm) {
         try {
-            String[] N = names();
-            Object stateHolder = declaredField(vm, N[N_VM_STATE_FIELD]);              // LX/EuU
+            Object stateHolder = declaredField(vm, NAMES.vmStateField);                // LX/EuU
             if (stateHolder == null) return null;
             Object state = publicMethod(stateHolder, "getValue").invoke(stateHolder);  // LX/5VB
             if (state == null) return null;
-            Object item = publicMethod(state, N[N_STATE_ITEM_METHOD]).invoke(state);   // LX/5Xq
+            Object item = publicMethod(state, NAMES.stateItemMethod).invoke(state);    // LX/5Xq
             if (item == null) return null;
-            return declaredField(item, N[N_ITEM_MEDIA_FIELD]);                         // Media
+            return declaredField(item, NAMES.itemMediaField);                         // Media
         } catch (Throwable t) {
             // Off-cycle calls (VM alive but no current item) land here — expected, keep quiet.
             return null;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
@@ -8,112 +8,44 @@ package app.morphe.extension.instagram.patches.instants;
 
 import android.content.Context;
 
-import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.crimera.sharedPreference.SharedPref;
 import app.morphe.extension.instagram.db.PikoInstantsDb;
-import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 
 /**
- * Runtime capture for the "Save Instants" feature. View-once instants (quicksnap) change on tap and
- * vanish after viewing, so rather than a per-instant button this passively records each viewed
- * instant's CDN links into {@link PikoInstantsDb} as the viewer surfaces it. The "Saved Instants"
- * screen ({@link InstantsVaultActivity}) lists them for viewing and download.
- *
- * <p>Capture reads the live viewer ViewModel: {@code vm.<A0Q>.getValue().<A03>() -> item.<A01>}
- * (a {@code Media}), then reuses piko's {@link MediaData} entity to pull the image/video url,
- * username and type. All obfuscated names are resolved at patch time (§11).
- *
- * <p>The obfuscated names are seeded as sentinel placeholders in {@link #names()}; instantsDownloadPatch
- * locates each by value and rewrites it from the target dex. They live in a returned array (not
- * static fields) because R8 minifies this extension and would constant-fold single-assigned string
- * fields away before the patch runs — the array-return form keeps them as real {@code const-string}s
- * for the patch to find. {@link Names} maps that array into named fields in one place, so nothing
- * downstream depends on array position. No last-known-good fallback — obfuscated names rotate on every
- * R8 run; if resolution didn't run the marker stays unset and capture no-ops.
+ * Records each view-once Instant as the app builds it, so it can be re-viewed and downloaded later
+ * from {@link InstantsVaultActivity}.
  */
 @SuppressWarnings("unused")
 public class InstantsDownloadHook {
 
-    /** Sentinel placeholders, rewritten at patch time by matching each value (not by position). */
-    private static String[] names() {
-        return new String[] {
-                "piko.instants.dl.marker",          // commit flag — patched to "1" last
-                "piko.instants.dl.vmStateField",    // viewer VM state field (getValue() -> viewer state)
-                "piko.instants.dl.stateItemMethod", // state method returning the current item
-                "piko.instants.dl.itemMediaField",  // current item's Media field
-        };
-    }
-
-    /** Names as fields, so the reflection path never indexes the array by hand. The only place the
-     *  array order is assumed is right here, next to {@link #names()}. */
-    private static final class Names {
-        final String marker, vmStateField, stateItemMethod, itemMediaField;
-
-        Names(String[] a) {
-            marker = a[0];
-            vmStateField = a[1];
-            stateItemMethod = a[2];
-            itemMediaField = a[3];
-        }
-    }
-
-    private static final Names NAMES = new Names(names());
-
-    /** Value of {@link Names#marker} once patch-time resolution has committed. */
-    private static final String MARKER_RESOLVED = "1";
-
-    /** The last media id captured — avoids re-hitting the DB on every VM method call while the same
-     *  instant is on screen (noteViewerVm fires very frequently). */
+    /** The item constructor runs again whenever the app rebuilds an item. */
     private static volatile String sLastCapturedId;
 
-    /**
-     * Injected at the entry of the viewer ViewModel's instance methods (p0 = VM). Pulls the instant
-     * currently on screen and records it. Fully guarded — any failure just skips this capture.
-     */
-    public static void noteViewerVm(Object vm) {
+    /** Called from the per-instant item's constructor with that instant's Media. */
+    public static void noteInstantMedia(Object media) {
         try {
-            if (vm == null) return;
-            if (!MARKER_RESOLVED.equals(NAMES.marker)) return;
+            if (media == null) return;
             if (!SharedPref.getBooleanPref(Settings.INSTANTS_DOWNLOAD)) return;
 
-            Object media = currentInstantMedia(vm);
-            if (media != null) captureMedia(media);
+            captureMedia(media);
         } catch (Throwable t) {
-            Logger.printException(() -> "instants capture: noteViewerVm failed", t);
+            Logger.printException(() -> "instants capture: noteInstantMedia failed", t);
         }
     }
 
-    /** Reads the Media backing the instant currently shown, via the live VM, using the repo's
-     *  {@link Entity} helper (getField for field steps, getMethod for the calls) rather than raw
-     *  reflection. Null on any mismatch. */
-    private static Object currentInstantMedia(Object vm) {
-        try {
-            Object stateHolder = new Entity(vm).getField(NAMES.vmStateField);          // LX/EuU
-            if (stateHolder == null) return null;
-            Object state = new Entity(stateHolder).getMethod("getValue");              // LX/5VB
-            if (state == null) return null;
-            Object item = new Entity(state).getMethod(NAMES.stateItemMethod);          // LX/5Xq
-            if (item == null) return null;
-            return new Entity(item).getField(NAMES.itemMediaField);                    // Media
-        } catch (Throwable t) {
-            // Off-cycle calls (VM alive but no current item) land here — expected, keep quiet.
-            return null;
-        }
-    }
-
-    /** Extracts the instant's links via piko's MediaData entity and stores them (deduped by id). */
     private static void captureMedia(Object media) {
         try {
-            MediaData md = new MediaData(media, null);
+            MediaData md = new MediaData(media);
 
             String id;
             try {
                 id = md.getMediaPkId();
             } catch (Throwable t) {
-                return; // no stable id -> can't dedupe or reference later
+                return; // without a stable id it can't be deduped or referenced later
             }
             if (id == null || id.isEmpty() || id.equals(sLastCapturedId)) return;
             sLastCapturedId = id;
@@ -135,7 +67,7 @@ public class InstantsDownloadHook {
         }
     }
 
-    // ---- reflection + best-effort helpers ----
+    // ---- best-effort helpers ----
 
     private interface StrCall { String get() throws Exception; }
     private interface BoolCall { boolean get() throws Exception; }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsDownloadHook.java
@@ -130,8 +130,6 @@ public class InstantsDownloadHook {
             String userId = safeStr(() -> md.getUserData().getUserId());
 
             db.insertOrIgnore(id, username, userId, imageUrl, videoUrl, isVideo);
-            Logger.printException(() -> "[piko] instants capture: saved "
-                    + (isVideo ? "video" : "photo") + " from " + username);
         } catch (Throwable t) {
             Logger.printException(() -> "instants capture: captureMedia failed", t);
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -17,11 +17,14 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.text.format.DateFormat;
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.LruCache;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
+import android.view.inputmethod.EditorInfo;
+import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
@@ -31,14 +34,20 @@ import android.widget.Toast;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.InputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Date;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -46,6 +55,7 @@ import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.db.PikoInstantsDb;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 
 /**
@@ -60,9 +70,13 @@ public class InstantsVaultActivity extends Activity {
     private static final int COLUMNS = 3;
 
     private List<String[]> items;
+    private String filter = "";
+    private FrameLayout content;
     private float density;
     private int tileSize;
     private ThumbLoader thumbs;
+    private final Handler ui = new Handler(Looper.getMainLooper());
+    private final Runnable rebuild = this::rebuildContent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -74,28 +88,21 @@ public class InstantsVaultActivity extends Activity {
         int gap = dp(2);
         tileSize = (screenW - gap * (COLUMNS + 1)) / COLUMNS;
 
-        items = PikoInstantsDb.getInstance(this).getAll();
+        PikoInstantsDb db = PikoInstantsDb.getInstance(this);
+        db.purgeExpired();
+        items = db.getAll();
+        pruneThumbCache();
 
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setBackgroundColor(themed("igds_color_primary_background", 0xFF000000));
         root.addView(buildToolbar());
+        if (!items.isEmpty()) root.addView(buildSearchField());
 
-        if (items.isEmpty()) {
-            TextView empty = new TextView(this);
-            empty.setText(str("piko_instants_vault_empty"));
-            empty.setTextColor(themed("igds_color_secondary_text", 0xFFB0B0B0));
-            empty.setGravity(Gravity.CENTER);
-            empty.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
-            empty.setPadding(dp(24), dp(24), dp(24), dp(24));
-            root.addView(empty, new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
-        } else {
-            ScrollView scroll = new ScrollView(this);
-            scroll.addView(buildGroupedBody());
-            root.addView(scroll, new LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
-        }
+        content = new FrameLayout(this);
+        root.addView(content, new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
+        rebuildContent();
 
         root.setOnApplyWindowInsetsListener((v, insets) -> {
             v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
@@ -104,13 +111,119 @@ public class InstantsVaultActivity extends Activity {
         setContentView(root);
     }
 
+    /** Search field over the sender's username. Filtering rebuilds the body only — a full
+     *  recreate() would restart every thumbnail fetch on each keystroke. */
+    private EditText buildSearchField() {
+        EditText search = new EditText(this);
+        search.setSingleLine(true);
+        search.setImeOptions(EditorInfo.IME_ACTION_SEARCH);
+        search.setHint(str("piko_search_username"));
+        search.setHintTextColor(themed("igds_color_secondary_text", 0xFFB0B0B0));
+        search.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
+        search.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        search.setBackgroundColor(themed("igds_color_secondary_background", 0xFF1A1A1A));
+        search.setPadding(dp(14), dp(10), dp(14), dp(10));
+
+        LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT);
+        lp.setMargins(dp(12), 0, dp(12), dp(8));
+        search.setLayoutParams(lp);
+
+        search.addTextChangedListener(new TextWatcher() {
+            @Override public void beforeTextChanged(CharSequence s, int a, int b, int c) { }
+            @Override public void onTextChanged(CharSequence s, int a, int b, int c) { }
+            @Override public void afterTextChanged(Editable s) {
+                filter = s.toString().trim().toLowerCase(Locale.ROOT);
+                rebuildContent();
+            }
+        });
+        return search;
+    }
+
+    private List<String[]> visibleItems() {
+        if (filter.isEmpty()) return items;
+        List<String[]> out = new ArrayList<>();
+        for (String[] m : items) {
+            String username = m[1];
+            if (username != null && username.toLowerCase(Locale.ROOT).contains(filter)) out.add(m);
+        }
+        return out;
+    }
+
+    private void rebuildContent() {
+        content.removeAllViews();
+        List<String[]> visible = visibleItems();
+
+        if (visible.isEmpty()) {
+            content.addView(centeredMessage(items.isEmpty()
+                    ? str("piko_instants_vault_empty")
+                    : str("piko_instants_no_matches")));
+            return;
+        }
+        ScrollView scroll = new ScrollView(this);
+        scroll.addView(buildGroupedBody(visible));
+        content.addView(scroll, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+    }
+
+    /** Purging expired rows leaves their thumbnails behind, so drop any that no longer have one. */
+    private void pruneThumbCache() {
+        try {
+            File dir = new File(getCacheDir(), "instants_thumbs");
+            File[] files = dir.listFiles();
+            if (files == null) return;
+
+            Set<String> live = new HashSet<>();
+            for (String[] m : items) live.add(m[0] + ".jpg");
+            for (File f : files) {
+                if (!live.contains(f.getName())) f.delete();
+            }
+        } catch (Throwable t) {
+            Logger.printException(() -> "instants vault: thumb cache prune failed", t);
+        }
+    }
+
+    /** Where a tile's thumbnail is kept between visits. Null if the cache dir isn't available. */
+    private File cacheFile(String mediaId) {
+        File dir = getCacheDir();
+        if (dir == null || mediaId == null || mediaId.isEmpty()) return null;
+        return new File(new File(dir, "instants_thumbs"), mediaId + ".jpg");
+    }
+
+    /** Drops a row that is gone for good, coalescing the redraw when several tiles die at once. */
+    private void forget(String mediaId) {
+        PikoInstantsDb.getInstance(this).delete(mediaId);
+        File cached = cacheFile(mediaId);
+        if (cached != null) cached.delete();
+        for (int i = 0; i < items.size(); i++) {
+            if (mediaId.equals(items.get(i)[0])) {
+                items.remove(i);
+                break;
+            }
+        }
+        ui.removeCallbacks(rebuild);
+        ui.post(rebuild);
+    }
+
+    private TextView centeredMessage(CharSequence text) {
+        TextView view = new TextView(this);
+        view.setText(text);
+        view.setTextColor(themed("igds_color_secondary_text", 0xFFB0B0B0));
+        view.setGravity(Gravity.CENTER);
+        view.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        view.setPadding(dp(24), dp(24), dp(24), dp(24));
+        view.setLayoutParams(new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+        return view;
+    }
+
     /** Groups items by a stable user id (fallback: username), preserving recency order of groups. */
-    private LinearLayout buildGroupedBody() {
+    private LinearLayout buildGroupedBody(List<String[]> source) {
         LinearLayout container = new LinearLayout(this);
         container.setOrientation(LinearLayout.VERTICAL);
 
         Map<String, List<String[]>> groups = new LinkedHashMap<>();
-        for (String[] m : items) {
+        for (String[] m : source) {
             String userId = m.length > 6 ? m[6] : null;
             String key = (userId != null && !userId.isEmpty()) ? userId : "name:" + (m[1] == null ? "" : m[1]);
             List<String[]> list = groups.get(key);
@@ -124,7 +237,7 @@ public class InstantsVaultActivity extends Activity {
         for (Map.Entry<String, List<String[]>> e : groups.entrySet()) {
             List<String[]> rows = e.getValue();
             String username = rows.get(0)[1];
-            if (username == null || username.isEmpty()) username = str("piko_media_unknown");
+            if (username == null || username.isEmpty()) username = str("piko_instants_unknown_user");
             container.addView(buildHeader(username));
 
             LinearLayout grid = new LinearLayout(this);
@@ -167,8 +280,24 @@ public class InstantsVaultActivity extends Activity {
         tile.addView(image, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
 
-        // thumbnail source is the image url (present even for video instants)
-        thumbs.load(row[2], image);
+        TextView unavailable = new TextView(this);
+        unavailable.setText(str("piko_instants_unavailable"));
+        unavailable.setTextColor(themed("igds_color_secondary_text", 0xFFB0B0B0));
+        unavailable.setTextSize(TypedValue.COMPLEX_UNIT_SP, 11);
+        unavailable.setGravity(Gravity.CENTER);
+        unavailable.setVisibility(View.GONE);
+        tile.addView(unavailable, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+
+        // Normally the image url, which is present even for video instants — but fall back to the
+        // playback url so a video that saved without one isn't mistaken for a dead row.
+        String thumbUrl = (row[2] != null && !row[2].isEmpty()) ? row[2] : urlOf(row);
+        thumbs.load(thumbUrl, row[0], image, dead -> {
+            // A dead link is gone for good, so drop the row. Anything else (no network, a
+            // timeout, a 5xx) may well work later — keep it and just say so on the tile.
+            if (dead) forget(row[0]);
+            else unavailable.setVisibility(View.VISIBLE);
+        });
 
         if ("1".equals(row[4])) {
             TextView badge = new TextView(this);
@@ -186,10 +315,7 @@ public class InstantsVaultActivity extends Activity {
 
         tile.setOnClickListener(v -> showOptions(row));
         tile.setOnLongClickListener(v -> {
-            confirm(str("piko_delete_saved_confirm"), str("piko_delete"), () -> {
-                PikoInstantsDb.getInstance(this).delete(row[0]);
-                recreate();
-            });
+            confirm(str("piko_instants_delete_confirm"), str("piko_delete"), () -> forget(row[0]));
             return true;
         });
         return tile;
@@ -203,13 +329,16 @@ public class InstantsVaultActivity extends Activity {
         bar.setPadding(pad, pad, pad, pad);
         bar.setBackgroundColor(themed("igds_color_primary_background", 0xFF101010));
 
-        TextView back = new TextView(this);
-        back.setText("←");
-        back.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
-        back.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
-        back.setPadding(0, 0, dp(16), 0);
-        back.setOnClickListener(v -> finish());
-        bar.addView(back);
+        // Instagram's own back arrow, themed. If the drawable can't be resolved on this build we'd
+        // otherwise ship a toolbar with no way back, so fall back to a plain glyph.
+        if (UI.addImageViewToViewGroup(bar, UI.DRAWABLE_ARROW_BACK, this::finish) == null) {
+            TextView back = new TextView(this);
+            back.setText("←");
+            back.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
+            back.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+            back.setOnClickListener(v -> finish());
+            bar.addView(back);
+        }
 
         TextView title = new TextView(this);
         title.setText(str("piko_view_saved_instants"));
@@ -220,10 +349,10 @@ public class InstantsVaultActivity extends Activity {
 
         if (!items.isEmpty()) {
             TextView clear = new TextView(this);
-            clear.setText(str("piko_clear_all"));
+            clear.setText(str("piko_instants_clear_all"));
             clear.setTextColor(themed("igds_color_error_or_destructive", 0xFFFF5C5C));
             clear.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
-            clear.setOnClickListener(v -> confirm(str("piko_clear_all_confirm"), str("piko_clear_all"),
+            clear.setOnClickListener(v -> confirm(str("piko_instants_clear_all_confirm"), str("piko_instants_clear_all"),
                     () -> {
                         PikoInstantsDb.getInstance(this).clearAll();
                         recreate();
@@ -233,7 +362,18 @@ public class InstantsVaultActivity extends Activity {
         return bar;
     }
 
-    /** Prefer the video url for a video instant, else the image url. */
+    /** When this instant was captured, or null if the row predates the timestamp column. */
+    private static CharSequence savedOn(String[] row) {
+        try {
+            long ts = Long.parseLong(row[5]);
+            if (ts <= 0) return null;
+            return str("piko_saved_on") + " "
+                    + new SimpleDateFormat("d MMM yyyy, HH:mm", Locale.getDefault()).format(new Date(ts));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     private static String urlOf(String[] row) {
         boolean isVideo = "1".equals(row[4]);
         String video = row[3];
@@ -245,7 +385,7 @@ public class InstantsVaultActivity extends Activity {
     private void showOptions(String[] row) {
         String url = urlOf(row);
         if (url == null || !url.startsWith("http")) {
-            Toast.makeText(this, str("piko_media_not_available"), Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, str("piko_instants_link_unavailable"), Toast.LENGTH_SHORT).show();
             return;
         }
         boolean isVideo = "1".equals(row[4]);
@@ -273,8 +413,10 @@ public class InstantsVaultActivity extends Activity {
 
         // Plain AlertDialog: the IGDS native box needs an Instagram-themed context, which a
         // standalone piko activity doesn't have (same as DeletedMessagesActivity).
+        // Title carries the date, not setMessage — a message would replace the option list entirely.
+        CharSequence saved = savedOn(row);
         new android.app.AlertDialog.Builder(this)
-                .setTitle(str("piko_download_options"))
+                .setTitle(saved == null ? str("piko_download_options") : saved)
                 .setItems(options, onPick)
                 .show();
     }
@@ -301,8 +443,13 @@ public class InstantsVaultActivity extends Activity {
         }
     }
 
-    /** Loads tile thumbnails off the main thread, caches them, and never throws — a failed fetch
-     *  just leaves the tile's placeholder. Views are url-tagged so scrolled/reused tiles stay correct. */
+    /** Told a thumbnail didn't load. {@code dead} means the CDN answered that it is gone. */
+    private interface OnLoadFailed {
+        void onFailed(boolean dead);
+    }
+
+    /** Thumbnails are cached in memory and on disk, so reopening the vault doesn't refetch the
+     *  whole grid. Views are url-tagged so reused tiles stay correct. */
     private final class ThumbLoader {
         private final ExecutorService pool = Executors.newFixedThreadPool(3);
         private final Handler main = new Handler(Looper.getMainLooper());
@@ -313,19 +460,34 @@ public class InstantsVaultActivity extends Activity {
                     }
                 };
 
-        void load(String url, ImageView view) {
+        void load(String url, String mediaId, ImageView view, OnLoadFailed onFailed) {
             view.setImageBitmap(null);
-            if (url == null || !url.startsWith("http")) return;
             view.setTag(url);
 
-            Bitmap cached = cache.get(url);
+            Bitmap cached = url == null ? null : cache.get(url);
             if (cached != null) {
                 view.setImageBitmap(cached);
                 return;
             }
             pool.execute(() -> {
-                Bitmap bmp = fetch(url);
-                if (bmp == null) return;
+                Bitmap disk = readCached(mediaId);
+                if (disk != null) {
+                    if (url != null) cache.put(url, disk);
+                    main.post(() -> {
+                        if (url == null || url.equals(view.getTag())) view.setImageBitmap(disk);
+                    });
+                    return;
+                }
+                if (url == null || !url.startsWith("http")) {
+                    main.post(() -> onFailed.onFailed(true));
+                    return;
+                }
+                boolean[] dead = new boolean[1];
+                Bitmap bmp = fetch(url, dead, mediaId);
+                if (bmp == null) {
+                    main.post(() -> onFailed.onFailed(dead[0]));
+                    return;
+                }
                 cache.put(url, bmp);
                 main.post(() -> {
                     if (url.equals(view.getTag())) view.setImageBitmap(bmp);
@@ -333,13 +495,45 @@ public class InstantsVaultActivity extends Activity {
             });
         }
 
-        private Bitmap fetch(String url) {
+        private Bitmap readCached(String mediaId) {
+            try {
+                File f = cacheFile(mediaId);
+                if (f == null || !f.isFile()) return null;
+                return BitmapFactory.decodeFile(f.getAbsolutePath());
+            } catch (Throwable t) {
+                return null;
+            }
+        }
+
+        private void writeCached(String mediaId, Bitmap bmp) {
+            try {
+                File f = cacheFile(mediaId);
+                if (f == null) return;
+                File dir = f.getParentFile();
+                if (dir != null && !dir.isDirectory() && !dir.mkdirs()) return;
+                try (FileOutputStream out = new FileOutputStream(f)) {
+                    bmp.compress(Bitmap.CompressFormat.JPEG, 80, out);
+                }
+            } catch (Throwable t) {
+                // A thumbnail we couldn't cache just gets refetched next time.
+            }
+        }
+
+        private Bitmap fetch(String url, boolean[] dead, String mediaId) {
             HttpURLConnection conn = null;
             try {
                 conn = (HttpURLConnection) new URL(url).openConnection();
                 conn.setConnectTimeout(10000);
                 conn.setReadTimeout(15000);
                 conn.setInstanceFollowRedirects(true);
+
+                int code = conn.getResponseCode();
+                if (code != HttpURLConnection.HTTP_OK) {
+                    dead[0] = code == HttpURLConnection.HTTP_FORBIDDEN
+                            || code == HttpURLConnection.HTTP_NOT_FOUND
+                            || code == HttpURLConnection.HTTP_GONE;
+                    return null;
+                }
                 try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
                     ByteArrayOutputStream bos = new ByteArrayOutputStream();
                     byte[] buf = new byte[8192];
@@ -352,7 +546,9 @@ public class InstantsVaultActivity extends Activity {
                     BitmapFactory.decodeByteArray(data, 0, data.length, o);
                     o.inSampleSize = sampleSize(o.outWidth, o.outHeight, tileSize);
                     o.inJustDecodeBounds = false;
-                    return BitmapFactory.decodeByteArray(data, 0, data.length, o);
+                    Bitmap bmp = BitmapFactory.decodeByteArray(data, 0, data.length, o);
+                    if (bmp != null) writeCached(mediaId, bmp);
+                    return bmp;
                 }
             } catch (Throwable t) {
                 return null;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -121,7 +121,7 @@ public class InstantsVaultActivity extends Activity {
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setBackgroundColor(themed("igds_color_primary_background", 0xFF000000));
-        applySystemBarStyle();
+        InstagramPreferenceStyle.applySystemBarStyle(this);
         root.addView(buildToolbar());
         if (!items.isEmpty()) root.addView(buildSearchField());
 
@@ -531,21 +531,6 @@ public class InstantsVaultActivity extends Activity {
                 .setPositiveButton(positiveText, (d, w) -> onConfirm.run())
                 .setNegativeButton(str("piko_cancel"), null)
                 .show();
-    }
-    private void applySystemBarStyle() {
-        int background = themed("igds_color_primary_background", 0xFF000000);
-        getWindow().setStatusBarColor(background);
-        getWindow().setNavigationBarColor(background);
-
-        int flags = getWindow().getDecorView().getSystemUiVisibility();
-        if (UI.isDarkMode()) {
-            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-        } else {
-            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-        }
-        getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 
     private int dp(int v) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -53,6 +53,7 @@ import java.util.concurrent.Executors;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.constants.UI;
+import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
 import app.morphe.extension.instagram.db.PikoInstantsDb;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 import app.morphe.extension.shared.Logger;
@@ -120,6 +121,7 @@ public class InstantsVaultActivity extends Activity {
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
         root.setBackgroundColor(themed("igds_color_primary_background", 0xFF000000));
+        applySystemBarStyle();
         root.addView(buildToolbar());
         if (!items.isEmpty()) root.addView(buildSearchField());
 
@@ -517,18 +519,33 @@ public class InstantsVaultActivity extends Activity {
         // standalone piko activity doesn't have (same as DeletedMessagesActivity).
         // Title carries the date, not setMessage — a message would replace the option list entirely.
         CharSequence saved = savedOn(row);
-        new android.app.AlertDialog.Builder(this)
+        new android.app.AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(this))
                 .setTitle(saved == null ? str("piko_download_options") : saved)
                 .setItems(options, onPick)
                 .show();
     }
 
     private void confirm(CharSequence message, String positiveText, Runnable onConfirm) {
-        new android.app.AlertDialog.Builder(this)
+        new android.app.AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(this))
                 .setMessage(message)
                 .setPositiveButton(positiveText, (d, w) -> onConfirm.run())
                 .setNegativeButton(str("piko_cancel"), null)
                 .show();
+    }
+    private void applySystemBarStyle() {
+        int background = themed("igds_color_primary_background", 0xFF000000);
+        getWindow().setStatusBarColor(background);
+        getWindow().setNavigationBarColor(background);
+
+        int flags = getWindow().getDecorView().getSystemUiVisibility();
+        if (UI.isDarkMode()) {
+            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        } else {
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        }
+        getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 
     private int dp(int v) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -9,6 +9,7 @@ package app.morphe.extension.instagram.patches.instants;
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
 import android.app.Activity;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
@@ -42,6 +43,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.db.PikoInstantsDb;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 import app.morphe.extension.shared.Utils;
@@ -76,13 +78,13 @@ public class InstantsVaultActivity extends Activity {
 
         LinearLayout root = new LinearLayout(this);
         root.setOrientation(LinearLayout.VERTICAL);
-        root.setBackgroundColor(0xFF000000);
+        root.setBackgroundColor(themed("igds_color_primary_background", 0xFF000000));
         root.addView(buildToolbar());
 
         if (items.isEmpty()) {
             TextView empty = new TextView(this);
             empty.setText(str("piko_instants_vault_empty"));
-            empty.setTextColor(0xFFB0B0B0);
+            empty.setTextColor(themed("igds_color_secondary_text", 0xFFB0B0B0));
             empty.setGravity(Gravity.CENTER);
             empty.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
             empty.setPadding(dp(24), dp(24), dp(24), dp(24));
@@ -147,7 +149,7 @@ public class InstantsVaultActivity extends Activity {
     private TextView buildHeader(String username) {
         TextView header = new TextView(this);
         header.setText(username);
-        header.setTextColor(0xFFFFFFFF);
+        header.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
         header.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
         header.setPadding(dp(14), dp(14), dp(14), dp(6));
         return header;
@@ -161,7 +163,7 @@ public class InstantsVaultActivity extends Activity {
 
         ImageView image = new ImageView(this);
         image.setScaleType(ImageView.ScaleType.CENTER_CROP);
-        image.setBackgroundColor(0xFF1A1A1A);
+        image.setBackgroundColor(themed("igds_color_secondary_background", 0xFF1A1A1A));
         tile.addView(image, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
 
@@ -184,14 +186,10 @@ public class InstantsVaultActivity extends Activity {
 
         tile.setOnClickListener(v -> showOptions(row));
         tile.setOnLongClickListener(v -> {
-            new android.app.AlertDialog.Builder(this)
-                    .setMessage(str("piko_delete_saved_confirm"))
-                    .setPositiveButton(str("piko_delete"), (d, w) -> {
-                        PikoInstantsDb.getInstance(this).delete(row[0]);
-                        recreate();
-                    })
-                    .setNegativeButton(str("piko_cancel"), null)
-                    .show();
+            confirm(str("piko_delete_saved_confirm"), str("piko_delete"), () -> {
+                PikoInstantsDb.getInstance(this).delete(row[0]);
+                recreate();
+            });
             return true;
         });
         return tile;
@@ -203,11 +201,11 @@ public class InstantsVaultActivity extends Activity {
         bar.setOrientation(LinearLayout.HORIZONTAL);
         bar.setGravity(Gravity.CENTER_VERTICAL);
         bar.setPadding(pad, pad, pad, pad);
-        bar.setBackgroundColor(0xFF101010);
+        bar.setBackgroundColor(themed("igds_color_primary_background", 0xFF101010));
 
         TextView back = new TextView(this);
         back.setText("←");
-        back.setTextColor(0xFFFFFFFF);
+        back.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
         back.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
         back.setPadding(0, 0, dp(16), 0);
         back.setOnClickListener(v -> finish());
@@ -215,7 +213,7 @@ public class InstantsVaultActivity extends Activity {
 
         TextView title = new TextView(this);
         title.setText(str("piko_view_saved_instants"));
-        title.setTextColor(0xFFFFFFFF);
+        title.setTextColor(themed("igds_color_primary_text", 0xFFFFFFFF));
         title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
         bar.addView(title, new LinearLayout.LayoutParams(0,
                 LinearLayout.LayoutParams.WRAP_CONTENT, 1));
@@ -223,16 +221,13 @@ public class InstantsVaultActivity extends Activity {
         if (!items.isEmpty()) {
             TextView clear = new TextView(this);
             clear.setText(str("piko_clear_all"));
-            clear.setTextColor(0xFFFF5C5C);
+            clear.setTextColor(themed("igds_color_error_or_destructive", 0xFFFF5C5C));
             clear.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
-            clear.setOnClickListener(v -> new android.app.AlertDialog.Builder(this)
-                    .setMessage(str("piko_clear_all_confirm"))
-                    .setPositiveButton(str("piko_clear_all"), (d, w) -> {
+            clear.setOnClickListener(v -> confirm(str("piko_clear_all_confirm"), str("piko_clear_all"),
+                    () -> {
                         PikoInstantsDb.getInstance(this).clearAll();
                         recreate();
-                    })
-                    .setNegativeButton(str("piko_cancel"), null)
-                    .show());
+                    }));
             bar.addView(clear);
         }
         return bar;
@@ -259,29 +254,51 @@ public class InstantsVaultActivity extends Activity {
                 isVideo ? str("piko_open_video_externally") : str("piko_open_image_externally"),
                 str("piko_copy_media_link"),
         };
+        DialogInterface.OnClickListener onPick = (d, which) -> {
+            try {
+                if (which == 0) {
+                    String fileName = "piko_instant_" + row[0] + (isVideo ? ".mp4" : ".jpg");
+                    DownloadUtils.downloadMediaUrl(this, url, SUBFOLDER, fileName);
+                } else if (which == 2) {
+                    Utils.setClipboard(url);
+                    Utils.showToastShort(str("piko_copied_media_link"));
+                } else {
+                    startActivity(Intent.createChooser(
+                            new Intent(Intent.ACTION_VIEW, Uri.parse(url)), null));
+                }
+            } catch (Exception e) {
+                PikoUtils.logger(e);
+            }
+        };
+
+        // Plain AlertDialog: the IGDS native box needs an Instagram-themed context, which a
+        // standalone piko activity doesn't have (same as DeletedMessagesActivity).
         new android.app.AlertDialog.Builder(this)
                 .setTitle(str("piko_download_options"))
-                .setItems(options, (d, which) -> {
-                    try {
-                        if (which == 0) {
-                            String fileName = "piko_instant_" + row[0] + (isVideo ? ".mp4" : ".jpg");
-                            DownloadUtils.downloadMediaUrl(this, url, SUBFOLDER, fileName);
-                        } else if (which == 2) {
-                            Utils.setClipboard(url);
-                            Utils.showToastShort(str("piko_copied_media_link"));
-                        } else {
-                            startActivity(Intent.createChooser(
-                                    new Intent(Intent.ACTION_VIEW, Uri.parse(url)), null));
-                        }
-                    } catch (Exception e) {
-                        PikoUtils.logger(e);
-                    }
-                })
+                .setItems(options, onPick)
+                .show();
+    }
+
+    private void confirm(CharSequence message, String positiveText, Runnable onConfirm) {
+        new android.app.AlertDialog.Builder(this)
+                .setMessage(message)
+                .setPositiveButton(positiveText, (d, w) -> onConfirm.run())
+                .setNegativeButton(str("piko_cancel"), null)
                 .show();
     }
 
     private int dp(int v) {
         return (int) (v * density);
+    }
+
+    /** Instagram's native (IGDS) colour for {@code attr}, so the screen tracks their light/dark theme.
+     *  Falls back to {@code fallback} if the attr can't be resolved on this build — never crashes. */
+    private static int themed(String attr, int fallback) {
+        try {
+            return UI.getThemedColour(attr);
+        } catch (Throwable t) {
+            return fallback;
+        }
     }
 
     /** Loads tile thumbnails off the main thread, caches them, and never throws — a failed fetch

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -78,6 +78,30 @@ public class InstantsVaultActivity extends Activity {
     private final Handler ui = new Handler(Looper.getMainLooper());
     private final Runnable rebuild = this::rebuildContent;
 
+    private final List<Tile> tiles = new ArrayList<>();
+    private ScrollView scroll;
+    private final Runnable sweep = this::sweepVisible;
+    /** Rows whose link came back dead, drained in one pass so a bad batch redraws once. */
+    private final Set<String> doomed = new HashSet<>();
+    private final Runnable drainDoomed = this::forgetDoomed;
+
+    private static final class Tile {
+        final FrameLayout view;
+        final ImageView image;
+        final TextView unavailable;
+        final String[] row;
+        final String thumbUrl;
+        boolean loaded;
+
+        Tile(FrameLayout view, ImageView image, TextView unavailable, String[] row, String thumbUrl) {
+            this.view = view;
+            this.image = image;
+            this.unavailable = unavailable;
+            this.row = row;
+            this.thumbUrl = thumbUrl;
+        }
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -109,6 +133,14 @@ public class InstantsVaultActivity extends Activity {
             return insets;
         });
         setContentView(root);
+    }
+
+    @Override
+    protected void onDestroy() {
+        ui.removeCallbacksAndMessages(null);
+        releaseTiles();
+        if (thumbs != null) thumbs.shutdown();
+        super.onDestroy();
     }
 
     /** Search field over the sender's username. Filtering rebuilds the body only — a full
@@ -151,19 +183,76 @@ public class InstantsVaultActivity extends Activity {
     }
 
     private void rebuildContent() {
+        releaseTiles();
         content.removeAllViews();
         List<String[]> visible = visibleItems();
 
         if (visible.isEmpty()) {
+            scroll = null;
             content.addView(centeredMessage(items.isEmpty()
                     ? str("piko_instants_vault_empty")
                     : str("piko_instants_no_matches")));
             return;
         }
-        ScrollView scroll = new ScrollView(this);
+        scroll = new ScrollView(this);
         scroll.addView(buildGroupedBody(visible));
         content.addView(scroll, new FrameLayout.LayoutParams(
                 FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+
+        scroll.setOnScrollChangeListener((v, x, y, ox, oy) -> scheduleSweep());
+        scroll.getViewTreeObserver().addOnGlobalLayoutListener(this::scheduleSweep);
+        scheduleSweep();
+    }
+
+    private void scheduleSweep() {
+        ui.removeCallbacks(sweep);
+        ui.post(sweep);
+    }
+
+    private void sweepVisible() {
+        if (scroll == null || tiles.isEmpty()) return;
+
+        int top = scroll.getScrollY();
+        int height = scroll.getHeight();
+        if (height == 0) return;
+        int from = top - height;
+        int to = top + height * 2;
+
+        for (Tile tile : tiles) {
+            int tileTop = topWithinScroll(tile.view);
+            boolean wanted = tileTop >= 0 && tileTop + tileSize >= from && tileTop <= to;
+            if (wanted && !tile.loaded) {
+                tile.loaded = true;
+                thumbs.load(tile.thumbUrl, tile.row[0], tile.image, dead -> {
+                    if (dead) forgetLater(tile.row[0]);
+                    else tile.unavailable.setVisibility(View.VISIBLE);
+                });
+            } else if (!wanted && tile.loaded) {
+                tile.loaded = false;
+                tile.image.setImageBitmap(null);
+                tile.image.setTag(null);
+            }
+        }
+    }
+
+    private int topWithinScroll(View view) {
+        int offset = 0;
+        View node = view;
+        while (node != null && node != scroll) {
+            offset += node.getTop();
+            if (!(node.getParent() instanceof View)) return -1;
+            node = (View) node.getParent();
+        }
+        return node == scroll ? offset : -1;
+    }
+
+    private void releaseTiles() {
+        for (Tile tile : tiles) {
+            tile.image.setImageBitmap(null);
+            tile.image.setTag(null);
+        }
+        tiles.clear();
+        ui.removeCallbacks(sweep);
     }
 
     /** Purging expired rows leaves their thumbnails behind, so drop any that no longer have one. */
@@ -190,8 +279,28 @@ public class InstantsVaultActivity extends Activity {
         return new File(new File(dir, "instants_thumbs"), mediaId + ".jpg");
     }
 
-    /** Drops a row that is gone for good, coalescing the redraw when several tiles die at once. */
+    /** Drops a row that is gone for good and redraws. */
     private void forget(String mediaId) {
+        drop(mediaId);
+        ui.removeCallbacks(rebuild);
+        ui.post(rebuild);
+    }
+
+    private void forgetLater(String mediaId) {
+        doomed.add(mediaId);
+        ui.removeCallbacks(drainDoomed);
+        ui.postDelayed(drainDoomed, 400);
+    }
+
+    private void forgetDoomed() {
+        if (doomed.isEmpty()) return;
+        for (String mediaId : doomed) drop(mediaId);
+        doomed.clear();
+        ui.removeCallbacks(rebuild);
+        ui.post(rebuild);
+    }
+
+    private void drop(String mediaId) {
         PikoInstantsDb.getInstance(this).delete(mediaId);
         File cached = cacheFile(mediaId);
         if (cached != null) cached.delete();
@@ -201,8 +310,6 @@ public class InstantsVaultActivity extends Activity {
                 break;
             }
         }
-        ui.removeCallbacks(rebuild);
-        ui.post(rebuild);
     }
 
     private TextView centeredMessage(CharSequence text) {
@@ -292,12 +399,7 @@ public class InstantsVaultActivity extends Activity {
         // Normally the image url, which is present even for video instants — but fall back to the
         // playback url so a video that saved without one isn't mistaken for a dead row.
         String thumbUrl = (row[2] != null && !row[2].isEmpty()) ? row[2] : urlOf(row);
-        thumbs.load(thumbUrl, row[0], image, dead -> {
-            // A dead link is gone for good, so drop the row. Anything else (no network, a
-            // timeout, a 5xx) may well work later — keep it and just say so on the tile.
-            if (dead) forget(row[0]);
-            else unavailable.setVisibility(View.VISIBLE);
-        });
+        tiles.add(new Tile(tile, image, unavailable, row, thumbUrl));
 
         if ("1".equals(row[4])) {
             TextView badge = new TextView(this);
@@ -460,6 +562,11 @@ public class InstantsVaultActivity extends Activity {
                     }
                 };
 
+        void shutdown() {
+            pool.shutdownNow();
+            cache.evictAll();
+        }
+
         void load(String url, String mediaId, ImageView view, OnLoadFailed onFailed) {
             view.setImageBitmap(null);
             view.setTag(url);
@@ -499,7 +606,14 @@ public class InstantsVaultActivity extends Activity {
             try {
                 File f = cacheFile(mediaId);
                 if (f == null || !f.isFile()) return null;
-                return BitmapFactory.decodeFile(f.getAbsolutePath());
+                String path = f.getAbsolutePath();
+
+                BitmapFactory.Options o = new BitmapFactory.Options();
+                o.inJustDecodeBounds = true;
+                BitmapFactory.decodeFile(path, o);
+                o.inSampleSize = sampleSize(o.outWidth, o.outHeight, tileSize);
+                o.inJustDecodeBounds = false;
+                return BitmapFactory.decodeFile(path, o);
             } catch (Throwable t) {
                 return null;
             }
@@ -560,7 +674,7 @@ public class InstantsVaultActivity extends Activity {
         private int sampleSize(int w, int h, int reqPx) {
             int sample = 1;
             if (reqPx <= 0) return 1;
-            while (w / sample > reqPx * 2 || h / sample > reqPx * 2) sample *= 2;
+            while (w / sample > reqPx || h / sample > reqPx) sample *= 2;
             return sample;
         }
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/instants/InstantsVaultActivity.java
@@ -1,0 +1,354 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.instants;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.text.format.DateFormat;
+import android.util.LruCache;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.instagram.db.PikoInstantsDb;
+import app.morphe.extension.instagram.patches.download.DownloadUtils;
+import app.morphe.extension.shared.Utils;
+
+/**
+ * "Saved Instants" screen: shows every instant captured by {@link InstantsDownloadHook} as a grid of
+ * thumbnails grouped by the sender (keyed on a stable user id, labelled by username). Tap a tile for
+ * download / open / copy (reusing piko's download pipeline); long-press to remove it. Plain
+ * programmatic UI so it has no layout-resource dependency, mirroring DeletedMessagesActivity.
+ */
+public class InstantsVaultActivity extends Activity {
+
+    private static final String SUBFOLDER = "Instants";
+    private static final int COLUMNS = 3;
+
+    private List<String[]> items;
+    private float density;
+    private int tileSize;
+    private ThumbLoader thumbs;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        density = getResources().getDisplayMetrics().density;
+        thumbs = new ThumbLoader();
+
+        int screenW = getResources().getDisplayMetrics().widthPixels;
+        int gap = dp(2);
+        tileSize = (screenW - gap * (COLUMNS + 1)) / COLUMNS;
+
+        items = PikoInstantsDb.getInstance(this).getAll();
+
+        LinearLayout root = new LinearLayout(this);
+        root.setOrientation(LinearLayout.VERTICAL);
+        root.setBackgroundColor(0xFF000000);
+        root.addView(buildToolbar());
+
+        if (items.isEmpty()) {
+            TextView empty = new TextView(this);
+            empty.setText(str("piko_instants_vault_empty"));
+            empty.setTextColor(0xFFB0B0B0);
+            empty.setGravity(Gravity.CENTER);
+            empty.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+            empty.setPadding(dp(24), dp(24), dp(24), dp(24));
+            root.addView(empty, new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
+        } else {
+            ScrollView scroll = new ScrollView(this);
+            scroll.addView(buildGroupedBody());
+            root.addView(scroll, new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.MATCH_PARENT, 1));
+        }
+
+        root.setOnApplyWindowInsetsListener((v, insets) -> {
+            v.setPadding(0, insets.getSystemWindowInsetTop(), 0, 0);
+            return insets;
+        });
+        setContentView(root);
+    }
+
+    /** Groups items by a stable user id (fallback: username), preserving recency order of groups. */
+    private LinearLayout buildGroupedBody() {
+        LinearLayout container = new LinearLayout(this);
+        container.setOrientation(LinearLayout.VERTICAL);
+
+        Map<String, List<String[]>> groups = new LinkedHashMap<>();
+        for (String[] m : items) {
+            String userId = m.length > 6 ? m[6] : null;
+            String key = (userId != null && !userId.isEmpty()) ? userId : "name:" + (m[1] == null ? "" : m[1]);
+            List<String[]> list = groups.get(key);
+            if (list == null) {
+                list = new ArrayList<>();
+                groups.put(key, list);
+            }
+            list.add(m);
+        }
+
+        for (Map.Entry<String, List<String[]>> e : groups.entrySet()) {
+            List<String[]> rows = e.getValue();
+            String username = rows.get(0)[1];
+            if (username == null || username.isEmpty()) username = str("piko_media_unknown");
+            container.addView(buildHeader(username));
+
+            LinearLayout grid = new LinearLayout(this);
+            grid.setOrientation(LinearLayout.VERTICAL);
+            int gap = dp(2);
+            grid.setPadding(gap, 0, gap, dp(8));
+
+            LinearLayout currentRow = null;
+            for (int i = 0; i < rows.size(); i++) {
+                if (i % COLUMNS == 0) {
+                    currentRow = new LinearLayout(this);
+                    currentRow.setOrientation(LinearLayout.HORIZONTAL);
+                    grid.addView(currentRow);
+                }
+                currentRow.addView(buildTile(rows.get(i), gap));
+            }
+            container.addView(grid);
+        }
+        return container;
+    }
+
+    private TextView buildHeader(String username) {
+        TextView header = new TextView(this);
+        header.setText(username);
+        header.setTextColor(0xFFFFFFFF);
+        header.setTextSize(TypedValue.COMPLEX_UNIT_SP, 15);
+        header.setPadding(dp(14), dp(14), dp(14), dp(6));
+        return header;
+    }
+
+    private View buildTile(String[] row, int gap) {
+        FrameLayout tile = new FrameLayout(this);
+        LinearLayout.LayoutParams lp = new LinearLayout.LayoutParams(tileSize, tileSize);
+        lp.setMargins(0, gap, gap, 0);
+        tile.setLayoutParams(lp);
+
+        ImageView image = new ImageView(this);
+        image.setScaleType(ImageView.ScaleType.CENTER_CROP);
+        image.setBackgroundColor(0xFF1A1A1A);
+        tile.addView(image, new FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT));
+
+        // thumbnail source is the image url (present even for video instants)
+        thumbs.load(row[2], image);
+
+        if ("1".equals(row[4])) {
+            TextView badge = new TextView(this);
+            badge.setText("▶");
+            badge.setTextColor(0xFFFFFFFF);
+            badge.setTextSize(TypedValue.COMPLEX_UNIT_SP, 12);
+            badge.setPadding(dp(4), 0, dp(4), 0);
+            badge.setBackgroundColor(0x99000000);
+            FrameLayout.LayoutParams blp = new FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+            blp.gravity = Gravity.BOTTOM | Gravity.END;
+            blp.setMargins(0, 0, dp(4), dp(4));
+            tile.addView(badge, blp);
+        }
+
+        tile.setOnClickListener(v -> showOptions(row));
+        tile.setOnLongClickListener(v -> {
+            new android.app.AlertDialog.Builder(this)
+                    .setMessage(str("piko_delete_saved_confirm"))
+                    .setPositiveButton(str("piko_delete"), (d, w) -> {
+                        PikoInstantsDb.getInstance(this).delete(row[0]);
+                        recreate();
+                    })
+                    .setNegativeButton(str("piko_cancel"), null)
+                    .show();
+            return true;
+        });
+        return tile;
+    }
+
+    private LinearLayout buildToolbar() {
+        int pad = dp(12);
+        LinearLayout bar = new LinearLayout(this);
+        bar.setOrientation(LinearLayout.HORIZONTAL);
+        bar.setGravity(Gravity.CENTER_VERTICAL);
+        bar.setPadding(pad, pad, pad, pad);
+        bar.setBackgroundColor(0xFF101010);
+
+        TextView back = new TextView(this);
+        back.setText("←");
+        back.setTextColor(0xFFFFFFFF);
+        back.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+        back.setPadding(0, 0, dp(16), 0);
+        back.setOnClickListener(v -> finish());
+        bar.addView(back);
+
+        TextView title = new TextView(this);
+        title.setText(str("piko_view_saved_instants"));
+        title.setTextColor(0xFFFFFFFF);
+        title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
+        bar.addView(title, new LinearLayout.LayoutParams(0,
+                LinearLayout.LayoutParams.WRAP_CONTENT, 1));
+
+        if (!items.isEmpty()) {
+            TextView clear = new TextView(this);
+            clear.setText(str("piko_clear_all"));
+            clear.setTextColor(0xFFFF5C5C);
+            clear.setTextSize(TypedValue.COMPLEX_UNIT_SP, 14);
+            clear.setOnClickListener(v -> new android.app.AlertDialog.Builder(this)
+                    .setMessage(str("piko_clear_all_confirm"))
+                    .setPositiveButton(str("piko_clear_all"), (d, w) -> {
+                        PikoInstantsDb.getInstance(this).clearAll();
+                        recreate();
+                    })
+                    .setNegativeButton(str("piko_cancel"), null)
+                    .show());
+            bar.addView(clear);
+        }
+        return bar;
+    }
+
+    /** Prefer the video url for a video instant, else the image url. */
+    private static String urlOf(String[] row) {
+        boolean isVideo = "1".equals(row[4]);
+        String video = row[3];
+        String image = row[2];
+        if (isVideo && video != null && !video.isEmpty()) return video;
+        return image;
+    }
+
+    private void showOptions(String[] row) {
+        String url = urlOf(row);
+        if (url == null || !url.startsWith("http")) {
+            Toast.makeText(this, str("piko_media_not_available"), Toast.LENGTH_SHORT).show();
+            return;
+        }
+        boolean isVideo = "1".equals(row[4]);
+        CharSequence[] options = new CharSequence[] {
+                str("piko_download_current_media"),
+                isVideo ? str("piko_open_video_externally") : str("piko_open_image_externally"),
+                str("piko_copy_media_link"),
+        };
+        new android.app.AlertDialog.Builder(this)
+                .setTitle(str("piko_download_options"))
+                .setItems(options, (d, which) -> {
+                    try {
+                        if (which == 0) {
+                            String fileName = "piko_instant_" + row[0] + (isVideo ? ".mp4" : ".jpg");
+                            DownloadUtils.downloadMediaUrl(this, url, SUBFOLDER, fileName);
+                        } else if (which == 2) {
+                            Utils.setClipboard(url);
+                            Utils.showToastShort(str("piko_copied_media_link"));
+                        } else {
+                            startActivity(Intent.createChooser(
+                                    new Intent(Intent.ACTION_VIEW, Uri.parse(url)), null));
+                        }
+                    } catch (Exception e) {
+                        PikoUtils.logger(e);
+                    }
+                })
+                .show();
+    }
+
+    private int dp(int v) {
+        return (int) (v * density);
+    }
+
+    /** Loads tile thumbnails off the main thread, caches them, and never throws — a failed fetch
+     *  just leaves the tile's placeholder. Views are url-tagged so scrolled/reused tiles stay correct. */
+    private final class ThumbLoader {
+        private final ExecutorService pool = Executors.newFixedThreadPool(3);
+        private final Handler main = new Handler(Looper.getMainLooper());
+        private final LruCache<String, Bitmap> cache =
+                new LruCache<String, Bitmap>((int) (Runtime.getRuntime().maxMemory() / 8192)) {
+                    @Override protected int sizeOf(String key, Bitmap b) {
+                        return b.getByteCount() / 1024;
+                    }
+                };
+
+        void load(String url, ImageView view) {
+            view.setImageBitmap(null);
+            if (url == null || !url.startsWith("http")) return;
+            view.setTag(url);
+
+            Bitmap cached = cache.get(url);
+            if (cached != null) {
+                view.setImageBitmap(cached);
+                return;
+            }
+            pool.execute(() -> {
+                Bitmap bmp = fetch(url);
+                if (bmp == null) return;
+                cache.put(url, bmp);
+                main.post(() -> {
+                    if (url.equals(view.getTag())) view.setImageBitmap(bmp);
+                });
+            });
+        }
+
+        private Bitmap fetch(String url) {
+            HttpURLConnection conn = null;
+            try {
+                conn = (HttpURLConnection) new URL(url).openConnection();
+                conn.setConnectTimeout(10000);
+                conn.setReadTimeout(15000);
+                conn.setInstanceFollowRedirects(true);
+                try (InputStream in = new BufferedInputStream(conn.getInputStream())) {
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    byte[] buf = new byte[8192];
+                    int n;
+                    while ((n = in.read(buf)) != -1) bos.write(buf, 0, n);
+                    byte[] data = bos.toByteArray();
+
+                    BitmapFactory.Options o = new BitmapFactory.Options();
+                    o.inJustDecodeBounds = true;
+                    BitmapFactory.decodeByteArray(data, 0, data.length, o);
+                    o.inSampleSize = sampleSize(o.outWidth, o.outHeight, tileSize);
+                    o.inJustDecodeBounds = false;
+                    return BitmapFactory.decodeByteArray(data, 0, data.length, o);
+                }
+            } catch (Throwable t) {
+                return null;
+            } finally {
+                if (conn != null) conn.disconnect();
+            }
+        }
+
+        private int sampleSize(int w, int h, int reqPx) {
+            int sample = 1;
+            if (reqPx <= 0) return 1;
+            while (w / sample > reqPx * 2 || h / sample > reqPx * 2) sample *= 2;
+            return sample;
+        }
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
@@ -23,6 +23,10 @@ import app.morphe.extension.instagram.constants.Constants;
 @SuppressWarnings("deprecation")
 public class ActivityHook {
 
+    public static void launchActivity(Context context, Class<?> activityClass){
+        launchActivity(context, new Intent(context, activityClass));
+    }
+
     private static void launchActivity(Context context, Intent intent){
         try {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -36,6 +36,7 @@ public class Settings {
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);
     public static final BooleanSetting DISABLE_SCREENSHOT_DETECTION = new BooleanSetting("disable_screenshot_detection", true);
     public static final BooleanSetting VIEW_DM_ANONYMOUSLY = new BooleanSetting("view_dm_anonymously", false);
+    public static final BooleanSetting INSTANTS_DOWNLOAD = new BooleanSetting("instants_download", false);
     public static final BooleanSetting DISABLE_STORIES = new BooleanSetting("disable_stories", false);
     public static final BooleanSetting DISABLE_HIGHLIGHTS = new BooleanSetting("disable_highlights", false);
     public static final BooleanSetting HIDE_STORIES_TRAY = new BooleanSetting("hide_stories_tray", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -274,6 +274,8 @@ public class SettingsActivity extends Activity {
             } else if (fragment_name.equals(Constants.PIKO_FRAGMENT_REC_FLAGS)) {
                 preferenceManager.setSharedPreferencesName(Constants.REC_FLAGS);
                 screenBuilder.buildRecommendedFlagsSection();
+            } else if (fragment_name.equals(Constants.PIKO_FRAGMENT_INSTANTS)) {
+                screenBuilder.buildInstantsSection();
             }
 
             setPreferenceScreen(screen);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -271,6 +271,7 @@ public class SettingsStatus {
         FLAGS.put(str("piko_disable_typing_status"),SettingsStatus.disableTypingStatus);
         FLAGS.put(str("piko_more_profile_options"),SettingsStatus.viewLiveAnonymously);
         FLAGS.put(str("piko_view_stories_anonymously"),SettingsStatus.viewStoriesAnonymously);
+        FLAGS.put(str("piko_instants_title"),SettingsStatus.instantsDownload);
 
         FLAGS.put(str("piko_sanitize_share_links"),SettingsStatus.sanitizeShareLinks);
         FLAGS.put(str("piko_open_links_externally"),SettingsStatus.openLinksExternally);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -81,6 +81,10 @@ public class SettingsStatus {
     public static void viewDmAnonymously() {
         viewDmAnonymously = true;
     }
+    public static boolean instantsDownload = false;
+    public static void instantsDownload() {
+        instantsDownload = true;
+    }
     public static boolean ghostSection() {
         return (viewStoriesAnonymously || viewLiveAnonymously || disableScreenshotDetection || disableTypingStatus || viewDmAnonymously);
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -460,6 +460,7 @@ public class ScreenBuilder {
         if (!(SettingsStatus.miscSection())) return;
 
         // PreferenceCategory category= addCategory(str("piko_category_misc"));
+        // Instants controls moved to their own screen (buildInstantsSection).
         if (MaterialYouTheme.isAmoledAvailable()) {
             addPreference(
                     helper.switchPreference(
@@ -645,6 +646,25 @@ public class ScreenBuilder {
                             str("piko_remove_empty_bottom_space"),
                             "",
                             Settings.REMOVE_EMPTY_BOTTOM_SPACE
+                    )
+            );
+        }
+    }
+
+    public void buildInstantsSection() {
+        if (SettingsStatus.instantsDownload) {
+            addPreference(
+                    helper.switchPreference(
+                            str("piko_instants_download"),
+                            str("piko_instants_download_desc"),
+                            Settings.INSTANTS_DOWNLOAD
+                    )
+            );
+            addPreference(
+                    helper.buttonPreference(
+                            str("piko_view_saved_instants"),
+                            "",
+                            "piko_view_saved_instants"
                     )
             );
         }
@@ -1015,6 +1035,16 @@ public class ScreenBuilder {
                             str("piko_category_download_media"),
                             "",
                             Constants.PIKO_FRAGMENT_DOWNLOAD_MEDIA
+                    )
+            );
+        }
+
+        if (SettingsStatus.instantsDownload){
+            addPreference(
+                    helper.buttonPreference(
+                            str("piko_instants_title"),
+                            "",
+                            Constants.PIKO_FRAGMENT_INSTANTS
                     )
             );
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -460,7 +460,6 @@ public class ScreenBuilder {
         if (!(SettingsStatus.miscSection())) return;
 
         // PreferenceCategory category= addCategory(str("piko_category_misc"));
-        // Instants controls moved to their own screen (buildInstantsSection).
         if (MaterialYouTheme.isAmoledAvailable()) {
             addPreference(
                     helper.switchPreference(

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/fragments/FragmentHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/fragments/FragmentHook.java
@@ -45,6 +45,8 @@ public class FragmentHook {
             actionBarTitleKey = "piko_category_filter_content";
         }else if(key.equals(Constants.PIKO_FRAGMENT_REC_FLAGS)){
             actionBarTitleKey = "piko_category_rec_flags";
+        }else if(key.equals(Constants.PIKO_FRAGMENT_INSTANTS)){
+            actionBarTitleKey = "piko_instants_title";
         }
 
         if(actionBarTitleKey!=null){

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -200,7 +200,7 @@ public class ButtonPref extends Preference {
             return UI.DRAWABLE_SHARE_TO_REEL;
         }
         if(key.equals(Constants.PIKO_FRAGMENT_INSTANTS)){
-            return UI.DRAWABLE_COLLECTIONS_ICON;
+            return UI.DRAWABLE_EYE_ICON;
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -8,7 +8,6 @@ package app.morphe.extension.instagram.settings.preference.widgets;
 
 import android.app.Activity;
 import android.content.Context;
-import android.content.Intent;
 import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
@@ -83,10 +82,8 @@ public class ButtonPref extends Preference {
                         DownloadMapping.downloadMapping();
 
                     } else if (key.equals("piko_view_saved_instants")) {
-                        Intent intent = new Intent(context,
+                        ActivityHook.launchActivity(context,
                                 app.morphe.extension.instagram.patches.instants.InstantsVaultActivity.class);
-                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-                        context.startActivity(intent);
 
                     } else if (isFragmentNavigation(key)) {
                         FragmentHook.startFragment(key);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -8,6 +8,7 @@ package app.morphe.extension.instagram.settings.preference.widgets;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.preference.Preference;
 import android.util.AttributeSet;
 import android.view.View;
@@ -81,6 +82,12 @@ public class ButtonPref extends Preference {
                     } else if (key.equals("piko_download_id_mapping")) {
                         DownloadMapping.downloadMapping();
 
+                    } else if (key.equals("piko_view_saved_instants")) {
+                        Intent intent = new Intent(context,
+                                app.morphe.extension.instagram.patches.instants.InstantsVaultActivity.class);
+                        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                        context.startActivity(intent);
+
                     } else if (isFragmentNavigation(key)) {
                         FragmentHook.startFragment(key);
 
@@ -146,7 +153,8 @@ public class ButtonPref extends Preference {
                 || key.equals("piko_export_experiment_list")
                 || key.equals("piko_export_experiment_mappings")
                 || key.equals("piko_download_id_mapping")
-                || key.equals("piko_rec_flags_refresh_file")));
+                || key.equals("piko_rec_flags_refresh_file")
+                || key.equals("piko_view_saved_instants")));
     }
 
     private static boolean hasPressedHighlight(String key) {
@@ -193,6 +201,9 @@ public class ButtonPref extends Preference {
         }
         if(key.equals(Constants.PIKO_FRAGMENT_FILTER_CONTENT)){
             return UI.DRAWABLE_SHARE_TO_REEL;
+        }
+        if(key.equals(Constants.PIKO_FRAGMENT_INSTANTS)){
+            return UI.DRAWABLE_COLLECTIONS_ICON;
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/MediaUrls.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/MediaUrls.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.utils;
+
+/** Helpers for the CDN urls piko stores and re-opens later. */
+public final class MediaUrls {
+
+    private MediaUrls() {
+    }
+
+    /**
+     * When a CDN url dies, as epoch millis, or 0 when it carries no expiry and so never does.
+     * fbcdn links hold it in their own "oe" parameter as a hex epoch; permalinks have none.
+     */
+    public static long expiresAt(String url) {
+        if (url == null) return 0L;
+        try {
+            int i = url.indexOf("oe=");
+            // Must start a parameter, so "?oe=" or "&oe=" — not the tail of another name.
+            if (i < 1 || (url.charAt(i - 1) != '?' && url.charAt(i - 1) != '&')) return 0L;
+            int end = i + 3;
+            while (end < url.length() && Character.digit(url.charAt(end), 16) >= 0) end++;
+            if (end == i + 3) return 0L;
+            return Long.parseLong(url.substring(i + 3, end), 16) * 1000L;
+        } catch (Exception e) {
+            return 0L;
+        }
+    }
+
+    /** True once {@link #expiresAt} has passed. Urls without an expiry never report expired. */
+    public static boolean isExpired(String url) {
+        long expiry = expiresAt(url);
+        return expiry > 0 && expiry <= System.currentTimeMillis();
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
@@ -6,12 +6,14 @@
 
 package app.crimera.patches.instagram.misc.instants
 
+import app.crimera.patches.instagram.utils.Constants.INSTANTS_DESCRIPTOR
 import app.morphe.patcher.Fingerprint
 
-/** Anchors InstantsDownloadHook.names(), whose const-strings are sentinel placeholders for the
- *  obfuscated field/method names the received-instant download path reflects on. Rewritten at patch
- *  time (§11) by instantsDownloadPatch by matching each sentinel's text. */
+/** Anchors InstantsDownloadHook.names(), whose returned array holds the sentinel placeholders for
+ *  the obfuscated field/method names the received-instant download path reflects on. An array-return
+ *  method (not static fields) so R8 can't constant-fold the placeholders away before patch time.
+ *  Rewritten at patch time (§11) by instantsDownloadPatch by matching each sentinel's text. */
 internal object InstantsDownloadNamesFingerprint : Fingerprint(
-    definingClass = "Lapp/morphe/extension/instagram/patches/instants/InstantsDownloadHook;",
+    definingClass = "$INSTANTS_DESCRIPTOR/InstantsDownloadHook;",
     name = "names",
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.instants
+
+import app.morphe.patcher.Fingerprint
+
+/** Anchors InstantsDownloadHook.names(), whose const-strings are sentinel placeholders for the
+ *  obfuscated field/method names the received-instant download path reflects on. Rewritten at patch
+ *  time (§11) by instantsDownloadPatch by matching each sentinel's text. */
+internal object InstantsDownloadNamesFingerprint : Fingerprint(
+    definingClass = "Lapp/morphe/extension/instagram/patches/instants/InstantsDownloadHook;",
+    name = "names",
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/Fingerprints.kt
@@ -6,14 +6,28 @@
 
 package app.crimera.patches.instagram.misc.instants
 
-import app.crimera.patches.instagram.utils.Constants.INSTANTS_DESCRIPTOR
+import app.crimera.patches.instagram.entity.decoder.MEDIA_CLASS_NAME
 import app.morphe.patcher.Fingerprint
 
-/** Anchors InstantsDownloadHook.names(), whose returned array holds the sentinel placeholders for
- *  the obfuscated field/method names the received-instant download path reflects on. An array-return
- *  method (not static fields) so R8 can't constant-fold the placeholders away before patch time.
- *  Rewritten at patch time (§11) by instantsDownloadPatch by matching each sentinel's text. */
-internal object InstantsDownloadNamesFingerprint : Fingerprint(
-    definingClass = "$INSTANTS_DESCRIPTOR/InstantsDownloadHook;",
-    name = "names",
+/** Instants are "quicksnap" internally, and this repository keeps its real name through R8. */
+internal const val QUICK_SNAP_REPOSITORY_CLASS =
+    "Lcom/instagram/quicksnap/data/repository/QuickSnapRepository;"
+
+/**
+ * Types the quicksnap classes touch. Pinned by instantsDownloadPatch before the fingerprint below
+ * resolves, since a Media-carrying item on its own is not unique to instants.
+ */
+internal var quickSnapTypes: Set<String> = emptySet()
+
+/**
+ * The app's per-instant item, built from that instant's Media. Hooking its constructor catches every
+ * instant as it is created and hands the Media straight to the extension.
+ */
+internal object InstantItemConstructorFingerprint : Fingerprint(
+    name = "<init>",
+    custom = { methodDef, classDef ->
+        classDef.type in quickSnapTypes &&
+            methodDef.parameters.firstOrNull()?.type == MEDIA_CLASS_NAME &&
+            classDef.fields.any { it.type == MEDIA_CLASS_NAME }
+    },
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
@@ -6,78 +6,28 @@
 
 package app.crimera.patches.instagram.misc.instants
 
-import app.crimera.patches.instagram.entity.decoder.MEDIA_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.INSTANTS_DESCRIPTOR
 import app.crimera.patches.instagram.utils.enableSettings
-import app.crimera.utils.changeStringAt
-import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.BytecodePatchContext
-import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
-import app.morphe.util.registersUsed
-import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.Method
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.ClassDef
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 
 private const val INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR = "$INSTANTS_DESCRIPTOR/InstantsDownloadHook;"
 
-/** The obfuscated names InstantsDownloadHook's pull path reflects on, recovered from the target dex. */
-private data class DownloadNames(
-    val vmStateField: String,
-    val stateItemMethod: String,
-    val itemMediaField: String,
-)
-
-/** Rewrites the InstantsDownloadHook placeholder field whose seed *value* is [placeholder]. Matches
- *  on sentinel text, not index. A missing/duplicated sentinel is a hook/resolver desync — our bug —
- *  so it throws rather than degrading. */
-context(patchContext: BytecodePatchContext)
-private fun Fingerprint.replacePlaceholder(
-    placeholder: String,
-    value: String,
-) {
-    val hits =
-        method.instructions
-            .filter { it.opcode == Opcode.CONST_STRING }
-            .withIndex()
-            .filter { (_, insn) -> (insn as ReferenceInstruction).reference.toString() == placeholder }
-
-    if (hits.size != 1) {
-        throw PatchException(
-            "InstantsDownloadHook: expected exactly one \"$placeholder\" placeholder, " +
-                "found ${hits.size}. The hook's placeholder fields and instantsDownloadPatch are out of sync.",
-        )
-    }
-
-    changeStringAt(hits.single().index, value)
-}
-
 /**
- * "Save Instants": passively captures each view-once Instant (quicksnap) as it's viewed, recording
- * its CDN links into a local store so they can be re-viewed and downloaded afterwards from the
- * "Saved Instants" screen (see InstantsDownloadHook / InstantsVaultActivity). Instants change on tap
- * and vanish after viewing, so capture-on-view is more reliable than a per-instant button.
+ * "Save Instants": records each view-once Instant so it can be re-viewed and downloaded afterwards.
  *
- * Anchor: the viewer ViewModel's current-item handler — a static `(vm)V` method that reads
- * `vm.<stateField>.getValue().<itemMethod>()` and the resulting item's User, and carries the literal
- * "-100" sentinel-id check (verified via baksmali against stock v435; see
- * piko-re/re-notes/instants-download-viewer.md). From that one method the whole
- * VM → state → item → Media chain is recovered, and the resolved VM's methods are where the capture
- * hook is injected.
- *
- * Installs all-or-nothing: unless every obfuscated name resolves, no hook, capture or toggle ships.
- * An Instagram-side miss disables only this feature, never the session. No last-known-good fallback —
- * obfuscated names rotate on every R8 run.
+ * The hook goes on the constructor of the app's per-instant item, which takes that instant's Media
+ * as its first argument — so every instant is caught as it is built, and the hook is handed the
+ * Media rather than having to reach for it.
  */
 @Suppress("unused")
 val instantsDownloadPatch =
@@ -89,169 +39,50 @@ val instantsDownloadPatch =
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
-            // Step 1: recover the pull path + its injection method up front — resolution gates the
-            // whole feature. Any miss installs nothing and returns.
-            val (names, handler) =
-                runCatching { resolveDownloadNames() }.getOrElse { error ->
-                    println(
-                        "[piko] Download Instants: DISABLED for this build — could not resolve the " +
-                            "quicksnap viewer flow: ${error.message}",
-                    )
-                    return@execute
-                }
-
-            // Steps 2-4: install the capture hook, bake the names, then expose the toggle. Order
-            // matters — the marker is written last and enableSettings runs only after it, so any
-            // failure leaves the marker unset (capture no-ops) and the toggle never appears.
             runCatching {
-                // Inject the capture hook into every non-static instance method of the viewer VM
-                // (p0 = this). The anchor handler (A05) fires only on certain interactions, so —
-                // like the camera feature does for its VM — cover all instance methods; whichever
-                // runs while the viewer is on screen captures the current instant. Anchored on the
-                // resolved VM class only (§11). Also inject the static handler itself (p0 = the VM
-                // parameter) so a first-frame handler call is covered too.
-                handler.addInstruction(
+                quickSnapTypes = quickSnapReferencedTypes()
+
+                // p0 is the item being constructed, p1 its Media.
+                InstantItemConstructorFingerprint.method.addInstruction(
                     0,
-                    "invoke-static {p0}, $INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR->noteViewerVm(Ljava/lang/Object;)V",
+                    "invoke-static {p1}, $INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR->noteInstantMedia(Ljava/lang/Object;)V",
                 )
-
-                val vmType = handler.definingClass
-                val stashed =
-                    mutableClassDefBy { it.type == vmType }.methods.filter { m ->
-                        !AccessFlags.STATIC.isSet(m.accessFlags) &&
-                            m.name != "<init>" &&
-                            m.implementation != null
-                    }.count { m ->
-                        runCatching {
-                            m.addInstruction(
-                                0,
-                                "invoke-static {p0}, $INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR->noteViewerVm(Ljava/lang/Object;)V",
-                            )
-                        }.isSuccess
-                    }
-
-                if (stashed == 0) {
-                    throw PatchException(
-                        "viewer ViewModel: could not stash the live VM in any instance method.",
-                    )
-                }
-
-                InstantsDownloadNamesFingerprint.apply {
-                    replacePlaceholder("piko.instants.dl.vmStateField", names.vmStateField)
-                    replacePlaceholder("piko.instants.dl.stateItemMethod", names.stateItemMethod)
-                    replacePlaceholder("piko.instants.dl.itemMediaField", names.itemMediaField)
-
-                    // Commit point — must stay last.
-                    replacePlaceholder("piko.instants.dl.marker", "1")
-                }
-
                 enableSettings("instantsDownload")
             }.onFailure { error ->
                 println(
-                    "[piko] Download Instants: DISABLED for this build — hook installation failed: " +
-                        "${error.message}",
+                    "[piko] Save Instants: DISABLED for this build — could not resolve the " +
+                        "quicksnap item: ${error.message}",
                 )
             }
         }
     }
 
-/** True for the viewer VM's current-item handler: a static `(Self)V` method carrying the literal
- *  "-100" id check and a no-arg `getValue()` call. Tight enough to match only that one method. */
-private fun isViewerHandler(
-    classType: String,
-    m: Method,
-): Boolean {
-    if (!AccessFlags.STATIC.isSet(m.accessFlags)) return false
-    if (m.returnType != "V") return false
-    val params = m.parameterTypes
-    if (params.size != 1 || params[0].toString() != classType) return false
-    val insns = m.implementation?.instructions?.toList() ?: return false
-
-    val hasMarker =
-        insns.any {
-            it.opcode == Opcode.CONST_STRING &&
-                (it as ReferenceInstruction).reference.toString() == "-100"
+private fun ClassDef.referencedTypes(): Sequence<String> =
+    methods
+        .asSequence()
+        .flatMap { it.implementation?.instructions?.asSequence() ?: emptySequence() }
+        .mapNotNull { (it as? ReferenceInstruction)?.reference }
+        .flatMap { reference ->
+            when (reference) {
+                is TypeReference -> sequenceOf(reference.type)
+                is FieldReference -> sequenceOf(reference.definingClass, reference.type)
+                is MethodReference ->
+                    sequenceOf(reference.definingClass, reference.returnType) +
+                        reference.parameterTypes.asSequence().map { it.toString() }
+                else -> emptySequence()
+            }
         }
-    if (!hasMarker) return false
 
-    return insns.any {
-        it.opcode == Opcode.INVOKE_INTERFACE &&
-            ((it as ReferenceInstruction).reference as? MethodReference)?.let { r ->
-                r.name == "getValue" && r.parameterTypes.isEmpty()
-            } == true
-    }
-}
-
-/**
- * Recovers the obfuscated names the download path needs, from the target dex only, plus the method to
- * inject the live-VM capture hook into.
- *
- * From the anchor handler we read: the VM state field (the iget feeding getValue), the state's
- * item-getter (the no-arg object invoke on the getValue result), and the item's Media field. Register
- * dataflow is verified at each step, so R8 reordering doesn't mislead us. Throws on any miss.
- */
+/** Types touched by the classes built with a quicksnap repository — the feature's own corner. */
 context(patchContext: BytecodePatchContext)
-private fun resolveDownloadNames(): Pair<DownloadNames, MutableMethod> {
-    val vmClass =
-        patchContext.mutableClassDefBy { cd -> cd.methods.any { isViewerHandler(cd.type, it) } }
-    val handler = vmClass.methods.first { isViewerHandler(vmClass.type, it) }
-    val insns = handler.instructions.toList()
-
-    fun destReg(i: Int) = (insns[i] as OneRegisterInstruction).registerA
-
-    // getValue() call on the state-flow field's value.
-    val getValueIdx =
-        insns.indices.first { i ->
-            insns[i].opcode == Opcode.INVOKE_INTERFACE &&
-                ((insns[i] as ReferenceInstruction).reference as? MethodReference)?.let {
-                    it.name == "getValue" && it.parameterTypes.isEmpty()
-                } == true
-        }
-    val stateHolderReg = insns[getValueIdx].registersUsed.first()
-
-    // VM state field = the nearest preceding iget-object that wrote the getValue receiver, defined on
-    // the VM itself.
-    val vmStateField =
-        (getValueIdx - 1 downTo 0).firstNotNullOfOrNull { i ->
-            if (!insns[i].opcode.name.startsWith("iget-object", ignoreCase = true)) return@firstNotNullOfOrNull null
-            if (destReg(i) != stateHolderReg) return@firstNotNullOfOrNull null
-            val fr = (insns[i] as ReferenceInstruction).reference as FieldReference
-            if (fr.definingClass != vmClass.type) return@firstNotNullOfOrNull null
-            fr.name
-        } ?: throw PatchException("no VM field feeds the viewer state getValue() call.")
-
-    // The getValue result register, then the no-arg object-returning invoke on it = the item getter.
-    val stateResultReg =
-        (getValueIdx + 1 until insns.size).firstOrNull { insns[it].opcode == Opcode.MOVE_RESULT_OBJECT }
-            ?.let { destReg(it) }
-            ?: throw PatchException("viewer state getValue() result is never captured.")
-
-    val itemGetter =
-        (getValueIdx + 1 until insns.size).firstNotNullOfOrNull { i ->
-            if (insns[i].opcode != Opcode.INVOKE_VIRTUAL) return@firstNotNullOfOrNull null
-            if (insns[i].registersUsed.firstOrNull() != stateResultReg) return@firstNotNullOfOrNull null
-            val mr = (insns[i] as ReferenceInstruction).reference as MethodReference
-            if (mr.parameterTypes.isNotEmpty() || !mr.returnType.startsWith("L")) return@firstNotNullOfOrNull null
-            mr
-        } ?: throw PatchException("no no-arg item getter called on the viewer state.")
-
-    val itemType = itemGetter.returnType
-
-    // Media field on the item — must be unambiguous, or we'd read the wrong one.
-    val mediaFields =
-        patchContext.mutableClassDefBy { it.type == itemType }.fields.filter { it.type == MEDIA_CLASS_NAME }
-    val itemMediaField =
-        when (mediaFields.size) {
-            1 -> mediaFields.single().name
-            else -> throw PatchException(
-                "expected exactly one $MEDIA_CLASS_NAME field on the viewer item ($itemType), " +
-                    "found ${mediaFields.size}.",
-            )
-        }
-
-    return DownloadNames(
-        vmStateField = vmStateField,
-        stateItemMethod = itemGetter.name,
-        itemMediaField = itemMediaField,
-    ) to handler
+private fun quickSnapReferencedTypes(): Set<String> {
+    val types = mutableSetOf<String>()
+    patchContext.classDefForEach { classDef ->
+        val usesRepository =
+            classDef.methods.any { method ->
+                method.parameterTypes.any { it.toString() == QUICK_SNAP_REPOSITORY_CLASS }
+            }
+        if (usesRepository) types += classDef.referencedTypes()
+    }
+    return types
 }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
@@ -6,6 +6,8 @@
 
 package app.crimera.patches.instagram.misc.instants
 
+import app.crimera.patches.instagram.entity.decoder.MEDIA_CLASS_NAME
+import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.INSTANTS_DESCRIPTOR
@@ -28,7 +30,6 @@ import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 private const val INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR = "$INSTANTS_DESCRIPTOR/InstantsDownloadHook;"
-private const val MEDIA_TYPE = "Lcom/instagram/feed/media/Media;"
 
 /** The obfuscated names InstantsDownloadHook's pull path reflects on, recovered from the target dex. */
 private data class DownloadNames(
@@ -37,8 +38,8 @@ private data class DownloadNames(
     val itemMediaField: String,
 )
 
-/** Rewrites the InstantsDownloadHook.names() placeholder whose *value* is [placeholder]. Matches on
- *  sentinel text, not index. A missing/duplicated sentinel is a names()/resolver desync — our bug —
+/** Rewrites the InstantsDownloadHook placeholder field whose seed *value* is [placeholder]. Matches
+ *  on sentinel text, not index. A missing/duplicated sentinel is a hook/resolver desync — our bug —
  *  so it throws rather than degrading. */
 context(patchContext: BytecodePatchContext)
 private fun Fingerprint.replacePlaceholder(
@@ -53,8 +54,8 @@ private fun Fingerprint.replacePlaceholder(
 
     if (hits.size != 1) {
         throw PatchException(
-            "InstantsDownloadHook.names(): expected exactly one \"$placeholder\" placeholder, " +
-                "found ${hits.size}. names() and instantsDownloadPatch are out of sync.",
+            "InstantsDownloadHook: expected exactly one \"$placeholder\" placeholder, " +
+                "found ${hits.size}. The hook's placeholder fields and instantsDownloadPatch are out of sync.",
         )
     }
 
@@ -84,7 +85,7 @@ val instantsDownloadPatch =
         name = "Save Instants",
         description = "Captures view-once Instants as you view them so you can re-view and download them later.",
     ) {
-        dependsOn(settingsPatch, instantsDownloadResourcePatch)
+        dependsOn(settingsPatch, instantsDownloadResourcePatch, decoderEntity)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
@@ -238,12 +239,12 @@ private fun resolveDownloadNames(): Pair<DownloadNames, MutableMethod> {
 
     // Media field on the item — must be unambiguous, or we'd read the wrong one.
     val mediaFields =
-        patchContext.mutableClassDefBy { it.type == itemType }.fields.filter { it.type == MEDIA_TYPE }
+        patchContext.mutableClassDefBy { it.type == itemType }.fields.filter { it.type == MEDIA_CLASS_NAME }
     val itemMediaField =
         when (mediaFields.size) {
             1 -> mediaFields.single().name
             else -> throw PatchException(
-                "expected exactly one $MEDIA_TYPE field on the viewer item ($itemType), " +
+                "expected exactly one $MEDIA_CLASS_NAME field on the viewer item ($itemType), " +
                     "found ${mediaFields.size}.",
             )
         }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadPatch.kt
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.instants
+
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.INSTANTS_DESCRIPTOR
+import app.crimera.patches.instagram.utils.enableSettings
+import app.crimera.utils.changeStringAt
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR = "$INSTANTS_DESCRIPTOR/InstantsDownloadHook;"
+private const val MEDIA_TYPE = "Lcom/instagram/feed/media/Media;"
+
+/** The obfuscated names InstantsDownloadHook's pull path reflects on, recovered from the target dex. */
+private data class DownloadNames(
+    val vmStateField: String,
+    val stateItemMethod: String,
+    val itemMediaField: String,
+)
+
+/** Rewrites the InstantsDownloadHook.names() placeholder whose *value* is [placeholder]. Matches on
+ *  sentinel text, not index. A missing/duplicated sentinel is a names()/resolver desync — our bug —
+ *  so it throws rather than degrading. */
+context(patchContext: BytecodePatchContext)
+private fun Fingerprint.replacePlaceholder(
+    placeholder: String,
+    value: String,
+) {
+    val hits =
+        method.instructions
+            .filter { it.opcode == Opcode.CONST_STRING }
+            .withIndex()
+            .filter { (_, insn) -> (insn as ReferenceInstruction).reference.toString() == placeholder }
+
+    if (hits.size != 1) {
+        throw PatchException(
+            "InstantsDownloadHook.names(): expected exactly one \"$placeholder\" placeholder, " +
+                "found ${hits.size}. names() and instantsDownloadPatch are out of sync.",
+        )
+    }
+
+    changeStringAt(hits.single().index, value)
+}
+
+/**
+ * "Save Instants": passively captures each view-once Instant (quicksnap) as it's viewed, recording
+ * its CDN links into a local store so they can be re-viewed and downloaded afterwards from the
+ * "Saved Instants" screen (see InstantsDownloadHook / InstantsVaultActivity). Instants change on tap
+ * and vanish after viewing, so capture-on-view is more reliable than a per-instant button.
+ *
+ * Anchor: the viewer ViewModel's current-item handler — a static `(vm)V` method that reads
+ * `vm.<stateField>.getValue().<itemMethod>()` and the resulting item's User, and carries the literal
+ * "-100" sentinel-id check (verified via baksmali against stock v435; see
+ * piko-re/re-notes/instants-download-viewer.md). From that one method the whole
+ * VM → state → item → Media chain is recovered, and the resolved VM's methods are where the capture
+ * hook is injected.
+ *
+ * Installs all-or-nothing: unless every obfuscated name resolves, no hook, capture or toggle ships.
+ * An Instagram-side miss disables only this feature, never the session. No last-known-good fallback —
+ * obfuscated names rotate on every R8 run.
+ */
+@Suppress("unused")
+val instantsDownloadPatch =
+    bytecodePatch(
+        name = "Save Instants",
+        description = "Captures view-once Instants as you view them so you can re-view and download them later.",
+    ) {
+        dependsOn(settingsPatch, instantsDownloadResourcePatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            // Step 1: recover the pull path + its injection method up front — resolution gates the
+            // whole feature. Any miss installs nothing and returns.
+            val (names, handler) =
+                runCatching { resolveDownloadNames() }.getOrElse { error ->
+                    println(
+                        "[piko] Download Instants: DISABLED for this build — could not resolve the " +
+                            "quicksnap viewer flow: ${error.message}",
+                    )
+                    return@execute
+                }
+
+            // Steps 2-4: install the capture hook, bake the names, then expose the toggle. Order
+            // matters — the marker is written last and enableSettings runs only after it, so any
+            // failure leaves the marker unset (capture no-ops) and the toggle never appears.
+            runCatching {
+                // Inject the capture hook into every non-static instance method of the viewer VM
+                // (p0 = this). The anchor handler (A05) fires only on certain interactions, so —
+                // like the camera feature does for its VM — cover all instance methods; whichever
+                // runs while the viewer is on screen captures the current instant. Anchored on the
+                // resolved VM class only (§11). Also inject the static handler itself (p0 = the VM
+                // parameter) so a first-frame handler call is covered too.
+                handler.addInstruction(
+                    0,
+                    "invoke-static {p0}, $INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR->noteViewerVm(Ljava/lang/Object;)V",
+                )
+
+                val vmType = handler.definingClass
+                val stashed =
+                    mutableClassDefBy { it.type == vmType }.methods.filter { m ->
+                        !AccessFlags.STATIC.isSet(m.accessFlags) &&
+                            m.name != "<init>" &&
+                            m.implementation != null
+                    }.count { m ->
+                        runCatching {
+                            m.addInstruction(
+                                0,
+                                "invoke-static {p0}, $INSTANTS_DOWNLOAD_HOOK_DESCRIPTOR->noteViewerVm(Ljava/lang/Object;)V",
+                            )
+                        }.isSuccess
+                    }
+
+                if (stashed == 0) {
+                    throw PatchException(
+                        "viewer ViewModel: could not stash the live VM in any instance method.",
+                    )
+                }
+
+                InstantsDownloadNamesFingerprint.apply {
+                    replacePlaceholder("piko.instants.dl.vmStateField", names.vmStateField)
+                    replacePlaceholder("piko.instants.dl.stateItemMethod", names.stateItemMethod)
+                    replacePlaceholder("piko.instants.dl.itemMediaField", names.itemMediaField)
+
+                    // Commit point — must stay last.
+                    replacePlaceholder("piko.instants.dl.marker", "1")
+                }
+
+                enableSettings("instantsDownload")
+            }.onFailure { error ->
+                println(
+                    "[piko] Download Instants: DISABLED for this build — hook installation failed: " +
+                        "${error.message}",
+                )
+            }
+        }
+    }
+
+/** True for the viewer VM's current-item handler: a static `(Self)V` method carrying the literal
+ *  "-100" id check and a no-arg `getValue()` call. Tight enough to match only that one method. */
+private fun isViewerHandler(
+    classType: String,
+    m: Method,
+): Boolean {
+    if (!AccessFlags.STATIC.isSet(m.accessFlags)) return false
+    if (m.returnType != "V") return false
+    val params = m.parameterTypes
+    if (params.size != 1 || params[0].toString() != classType) return false
+    val insns = m.implementation?.instructions?.toList() ?: return false
+
+    val hasMarker =
+        insns.any {
+            it.opcode == Opcode.CONST_STRING &&
+                (it as ReferenceInstruction).reference.toString() == "-100"
+        }
+    if (!hasMarker) return false
+
+    return insns.any {
+        it.opcode == Opcode.INVOKE_INTERFACE &&
+            ((it as ReferenceInstruction).reference as? MethodReference)?.let { r ->
+                r.name == "getValue" && r.parameterTypes.isEmpty()
+            } == true
+    }
+}
+
+/**
+ * Recovers the obfuscated names the download path needs, from the target dex only, plus the method to
+ * inject the live-VM capture hook into.
+ *
+ * From the anchor handler we read: the VM state field (the iget feeding getValue), the state's
+ * item-getter (the no-arg object invoke on the getValue result), and the item's Media field. Register
+ * dataflow is verified at each step, so R8 reordering doesn't mislead us. Throws on any miss.
+ */
+context(patchContext: BytecodePatchContext)
+private fun resolveDownloadNames(): Pair<DownloadNames, MutableMethod> {
+    val vmClass =
+        patchContext.mutableClassDefBy { cd -> cd.methods.any { isViewerHandler(cd.type, it) } }
+    val handler = vmClass.methods.first { isViewerHandler(vmClass.type, it) }
+    val insns = handler.instructions.toList()
+
+    fun destReg(i: Int) = (insns[i] as OneRegisterInstruction).registerA
+
+    // getValue() call on the state-flow field's value.
+    val getValueIdx =
+        insns.indices.first { i ->
+            insns[i].opcode == Opcode.INVOKE_INTERFACE &&
+                ((insns[i] as ReferenceInstruction).reference as? MethodReference)?.let {
+                    it.name == "getValue" && it.parameterTypes.isEmpty()
+                } == true
+        }
+    val stateHolderReg = insns[getValueIdx].registersUsed.first()
+
+    // VM state field = the nearest preceding iget-object that wrote the getValue receiver, defined on
+    // the VM itself.
+    val vmStateField =
+        (getValueIdx - 1 downTo 0).firstNotNullOfOrNull { i ->
+            if (!insns[i].opcode.name.startsWith("iget-object", ignoreCase = true)) return@firstNotNullOfOrNull null
+            if (destReg(i) != stateHolderReg) return@firstNotNullOfOrNull null
+            val fr = (insns[i] as ReferenceInstruction).reference as FieldReference
+            if (fr.definingClass != vmClass.type) return@firstNotNullOfOrNull null
+            fr.name
+        } ?: throw PatchException("no VM field feeds the viewer state getValue() call.")
+
+    // The getValue result register, then the no-arg object-returning invoke on it = the item getter.
+    val stateResultReg =
+        (getValueIdx + 1 until insns.size).firstOrNull { insns[it].opcode == Opcode.MOVE_RESULT_OBJECT }
+            ?.let { destReg(it) }
+            ?: throw PatchException("viewer state getValue() result is never captured.")
+
+    val itemGetter =
+        (getValueIdx + 1 until insns.size).firstNotNullOfOrNull { i ->
+            if (insns[i].opcode != Opcode.INVOKE_VIRTUAL) return@firstNotNullOfOrNull null
+            if (insns[i].registersUsed.firstOrNull() != stateResultReg) return@firstNotNullOfOrNull null
+            val mr = (insns[i] as ReferenceInstruction).reference as MethodReference
+            if (mr.parameterTypes.isNotEmpty() || !mr.returnType.startsWith("L")) return@firstNotNullOfOrNull null
+            mr
+        } ?: throw PatchException("no no-arg item getter called on the viewer state.")
+
+    val itemType = itemGetter.returnType
+
+    // Media field on the item — must be unambiguous, or we'd read the wrong one.
+    val mediaFields =
+        patchContext.mutableClassDefBy { it.type == itemType }.fields.filter { it.type == MEDIA_TYPE }
+    val itemMediaField =
+        when (mediaFields.size) {
+            1 -> mediaFields.single().name
+            else -> throw PatchException(
+                "expected exactly one $MEDIA_TYPE field on the viewer item ($itemType), " +
+                    "found ${mediaFields.size}.",
+            )
+        }
+
+    return DownloadNames(
+        vmStateField = vmStateField,
+        stateItemMethod = itemGetter.name,
+        itemMediaField = itemMediaField,
+    ) to handler
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadResourcePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/instants/InstantsDownloadResourcePatch.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.instants
+
+import app.morphe.patcher.patch.resourcePatch
+import org.w3c.dom.Element
+
+/** Registers the "Saved Instants" viewer Activity for the Save Instants feature. Kept out of the
+ *  shared settings resource patch so it only ships when the feature is applied. Uses a plain
+ *  platform theme — the app's Theme.Instagram.Splash breaks plain widget construction. */
+val instantsDownloadResourcePatch =
+    resourcePatch {
+        finalize {
+            document("AndroidManifest.xml").use { document ->
+                val application = document.getElementsByTagName("application").item(0) as Element
+
+                val activity = document.createElement("activity")
+                activity.setAttribute("android:name", "app.morphe.extension.instagram.patches.instants.InstantsVaultActivity")
+                activity.setAttribute("android:theme", "@android:style/Theme.DeviceDefault.NoActionBar")
+                activity.setAttribute("android:exported", "false")
+                application.appendChild(activity)
+            }
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -68,4 +68,5 @@ object Constants {
     const val LOAD_FLAGS_DESCRIPTOR = "invoke-static {}, $HOOK_FLAGS_DESCRIPTOR->%s()V"
 
     const val COMMENT_BUTTON_EXTENSION_CLASS = "${PATCHES_DESCRIPTOR}/comment"
+    const val INSTANTS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/instants"
 }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -321,4 +321,19 @@
     <string name="piko_filter_story_minimum_item_count_desc">Stories having less than x items will be hidden (default 1)</string>
     <string name="piko_filter_story_maximum_item_count">Maximum story items</string>
     <string name="piko_filter_story_maximum_item_count_desc">Stories having more than x items will be hidden (default 9999)</string>
+
+    <!-- Save Instants -->
+    <string name="piko_instants_download">Save Instants</string>
+    <string name="piko_instants_download_desc">Capture view-once Instants as you view them, so you can re-view and download them later from “View saved Instants”.</string>
+    <string name="piko_view_saved_instants">View saved Instants</string>
+    <string name="piko_instants_vault_empty">No saved Instants yet. Open some Instants with capture enabled and they\'ll appear here.</string>
+    <string name="piko_media_not_available">Media link not available.</string>
+    <string name="piko_media_photo">Photo</string>
+    <string name="piko_media_video">Video</string>
+    <string name="piko_media_unknown">Unknown</string>
+    <string name="piko_delete_saved_confirm">Remove this saved Instant?</string>
+    <string name="piko_delete">Delete</string>
+    <string name="piko_clear_all">Clear all</string>
+    <string name="piko_clear_all_confirm">Remove all saved Instants?</string>
+    <string name="piko_instants_title">Instants</string>
 </resources>

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -327,13 +327,15 @@
     <string name="piko_instants_download_desc">Capture view-once Instants as you view them, so you can re-view and download them later from “View saved Instants”.</string>
     <string name="piko_view_saved_instants">View saved Instants</string>
     <string name="piko_instants_vault_empty">No saved Instants yet. Open some Instants with capture enabled and they\'ll appear here.</string>
-    <string name="piko_media_not_available">Media link not available.</string>
-    <string name="piko_media_photo">Photo</string>
-    <string name="piko_media_video">Video</string>
-    <string name="piko_media_unknown">Unknown</string>
-    <string name="piko_delete_saved_confirm">Remove this saved Instant?</string>
+    <string name="piko_instants_link_unavailable">Media link not available.</string>
+    <string name="piko_instants_unknown_user">Unknown</string>
+    <string name="piko_instants_delete_confirm">Remove this saved Instant?</string>
+    <string name="piko_instants_clear_all">Clear all</string>
+    <string name="piko_instants_clear_all_confirm">Remove all saved Instants?</string>
     <string name="piko_delete">Delete</string>
-    <string name="piko_clear_all">Clear all</string>
-    <string name="piko_clear_all_confirm">Remove all saved Instants?</string>
     <string name="piko_instants_title">Instants</string>
+    <string name="piko_search_username">Search by username</string>
+    <string name="piko_instants_no_matches">No saved Instants from that user.</string>
+    <string name="piko_instants_unavailable">Unavailable</string>
+    <string name="piko_saved_on">Saved on</string>
 </resources>


### PR DESCRIPTION
Adds a "Save Instants" patch that passively captures view-once Instants as you view them. Each instant's CDN links are recorded into a local vault (PikoInstantsDb), and a new "Saved Instants" screen (InstantsVaultActivity) lets you browse them grouped by sender, tap to download/open/copy, or long-press to delete.
The obfuscated VM → state → item → Media chain is resolved at patch time from the target dex using a -100 sentinel anchor — no hardcoded obfuscated names.
We added the cdn url at capture time, to be honst idk how many days cdn links survive .  open for reviews and suggestions..

Closes #1202, #1139, #1454