### PR TITLE
feat(Instagram): Add `Disable swipe to create` patch

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -47,6 +47,7 @@ public class Settings {
     public static final BooleanSetting COMMENT_SAVE_MEDIA_BUTTON = new BooleanSetting("comment_save_media_button", true);
     public static final BooleanSetting HIDE_GROUP_CREATION_BUTTON_ON_SHARESHEET = new BooleanSetting("hide_group_creation_button_on_sharesheet", true);
     public static final BooleanSetting DISABLE_REELS_SCROLLING = new BooleanSetting("disable_reels_scrolling", false);
+    public static final BooleanSetting DISABLE_SWIPE_TO_CREATE = new BooleanSetting("disable_swipe_to_create", false);
     public static final BooleanSetting REMOVE_EMPTY_BOTTOM_SPACE = new BooleanSetting("remove_empty_bottom_space", true);
     public static final BooleanSetting DISABLE_TYPING_STATUS = new BooleanSetting("disable_typing_status", false);
     public static final BooleanSetting HIDE_NOTES_TRAY = new BooleanSetting("hide_notes_tray", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -119,12 +119,16 @@ public class SettingsStatus {
     public static void disableReelsScrolling() {
         disableReelsScrolling = true;
     }
+    public static boolean disableSwipeToCreate = false;
+    public static void disableSwipeToCreate() {
+        disableSwipeToCreate = true;
+    }
     public static boolean disableDoubleTapLike = false;
     public static void disableDoubleTapLike() {
         disableDoubleTapLike = true;
     }
     public static boolean distractionFreeSection() {
-        return (disableDoubleTapLike || hideNotesTray || disableHighlights || disableStories || disableExplore || disableComments || hideStoriesTray || limitFollowingFeed || hideGroupCreationOnSharesheet || disableReelsScrolling);
+        return (disableDoubleTapLike || hideNotesTray || disableHighlights || disableStories || disableExplore || disableComments || hideStoriesTray || limitFollowingFeed || hideGroupCreationOnSharesheet || disableReelsScrolling || disableSwipeToCreate);
     }
 
     //Misc section.
@@ -250,6 +254,7 @@ public class SettingsStatus {
         FLAGS.put(str("piko_disable_explore"),SettingsStatus.disableExplore);
         FLAGS.put(str("piko_disable_highlights"),SettingsStatus.disableHighlights);
         FLAGS.put(str("piko_disable_stories"),SettingsStatus.disableStories);
+        FLAGS.put(str("piko_disable_swipe_to_create"), SettingsStatus.disableSwipeToCreate);
 
         FLAGS.put(str("piko_view_dm_anonymously"),SettingsStatus.viewDmAnonymously);
         FLAGS.put(str("piko_view_live_anonymously"),SettingsStatus.disableScreenshotDetection);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -381,6 +381,15 @@ public class ScreenBuilder {
                             str("piko_disable_reels_scrolling"),
                             str("piko_disable_reels_scrolling_desc"),
                             Settings.DISABLE_REELS_SCROLLING
+                )
+            );
+        }
+        if (SettingsStatus.disableSwipeToCreate) {
+            addPreference(
+                    helper.switchPreference(
+                            str("piko_disable_swipe_to_create"),
+                            str("piko_disable_swipe_to_create_desc"),
+                            Settings.DISABLE_SWIPE_TO_CREATE
                     )
             );
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -142,6 +142,10 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.DISABLE_REELS_SCROLLING) && SettingsStatus.disableReelsScrolling;
     }
 
+    public static boolean disableSwipeToCreate() {
+        return SharedPref.getBooleanPref(Settings.DISABLE_SWIPE_TO_CREATE) && SettingsStatus.disableSwipeToCreate;
+    }
+
     public static boolean makeEphemeralMediaPermanent() {
         return SharedPref.getBooleanPref(Settings.UNLIMITED_REPLAYS) && SettingsStatus.unlimitedReplaysOnEphemeralMedia;
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/DisableSwipeToCreatePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/DisableSwipeToCreatePatch.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.distractionFree
+
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.PREF_CALL_DESCRIPTOR
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.OpcodesFilter
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.getReference
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val SWIPE_NAVIGATION_CONTAINER_CLASS =
+    "Lcom/instagram/ui/swipenavigation/container/SwipeNavigationContainer;"
+
+private const val POSITION_CONFIG_CLASS =
+    "Lcom/instagram/ui/swipenavigation/container/PositionConfig;"
+
+private object SetInternalPositionFingerprint : Fingerprint(
+    name = "setInternalPosition",
+    definingClass = SWIPE_NAVIGATION_CONTAINER_CLASS,
+    parameters = listOf(POSITION_CONFIG_CLASS),
+    returnType = "V",
+    filters =
+        OpcodesFilter.opcodesToFilters(
+            Opcode.IGET,
+            Opcode.INVOKE_DIRECT,
+            Opcode.MOVE_RESULT,
+            Opcode.IGET_BOOLEAN,
+            Opcode.INVOKE_DIRECT,
+        ),
+)
+
+private object SpringVelocityFingerprint : Fingerprint(
+    definingClass = SWIPE_NAVIGATION_CONTAINER_CLASS,
+    parameters = listOf("Landroid/view/MotionEvent;", "F", "J"),
+    returnType = "V",
+    filters =
+        OpcodesFilter.opcodesToFilters(
+            Opcode.IGET_BOOLEAN,
+            Opcode.IF_EQZ,
+            Opcode.NEG_FLOAT,
+            Opcode.INVOKE_DIRECT,
+            Opcode.MOVE_RESULT_OBJECT,
+            Opcode.FLOAT_TO_DOUBLE,
+            Opcode.INVOKE_VIRTUAL,
+        ),
+)
+
+@Suppress("unused")
+val disableSwipeToCreatePatch =
+    bytecodePatch(
+        name = "Disable swipe to create",
+        description = "Prevents opening the creation screen by swiping right on the home tab.",
+    ) {
+        dependsOn(settingsPatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            val getSpringMethod =
+                SpringVelocityFingerprint.instructionMatches[3]
+                    .instruction
+                    .getReference<MethodReference>()
+                    ?.takeIf {
+                        it.definingClass == SWIPE_NAVIGATION_CONTAINER_CLASS &&
+                            it.name == "getSpring" &&
+                            it.parameterTypes.isEmpty()
+                    }
+                    ?: throw PatchException("Unable to find the swipe navigation spring getter")
+
+            val setSpringVelocityMethod =
+                SpringVelocityFingerprint.instructionMatches[6]
+                    .instruction
+                    .getReference<MethodReference>()
+                    ?.takeIf {
+                        it.definingClass == getSpringMethod.returnType &&
+                            it.parameterTypes.size == 1 &&
+                            it.parameterTypes[0] == "D" &&
+                            it.returnType == "V"
+                    }
+                    ?: throw PatchException("Unable to find the swipe navigation spring velocity setter")
+
+            SetInternalPositionFingerprint.method.apply {
+                val reasonField =
+                    getInstruction(0)
+                        .takeIf { it.opcode == Opcode.IGET_OBJECT }
+                        ?.getReference<FieldReference>()
+                        ?.takeIf {
+                            it.definingClass == POSITION_CONFIG_CLASS &&
+                                it.type == "Ljava/lang/String;"
+                        }
+                        ?: throw PatchException("Unable to find the swipe navigation reason field")
+
+                val positionInstructions =
+                    instructions.filter { instruction ->
+                        instruction.opcode == Opcode.IGET &&
+                            instruction.getReference<FieldReference>()?.let {
+                                it.definingClass == POSITION_CONFIG_CLASS && it.type == "F"
+                            } == true
+                    }
+
+                if (positionInstructions.size != 1) {
+                    throw PatchException("Expected exactly one swipe navigation position field")
+                }
+
+                val positionInstruction = positionInstructions.single()
+                val targetIndex = positionInstruction.location.index + 1
+                val positionRegister =
+                    (positionInstruction as? TwoRegisterInstruction)?.registerA
+                        ?: throw PatchException("Unable to find the swipe navigation position field")
+                val continueInstruction = getInstruction(targetIndex)
+
+                addInstructionsWithLabels(
+                    targetIndex,
+                    """
+                    $PREF_CALL_DESCRIPTOR->disableSwipeToCreate()Z
+                    move-result v1
+                    if-eqz v1, :piko_continue
+                    iget-object v1, p1, $reasonField
+                    const-string/jumbo v2, "swipe"
+                    invoke-virtual {v2, v1}, Ljava/lang/String;->equals(Ljava/lang/Object;)Z
+                    move-result v1
+                    if-eqz v1, :piko_continue
+                    const/4 v2, 0x0
+                    cmpl-float v1, v$positionRegister, v2
+                    if-gez v1, :piko_continue
+                    invoke-direct {p0}, $SWIPE_NAVIGATION_CONTAINER_CLASS->getClampedPosition()F
+                    move-result v1
+                    cmpl-float v1, v2, v1
+                    if-gtz v1, :piko_continue
+                    const/4 v$positionRegister, 0x0
+                    invoke-direct {p0}, $getSpringMethod
+                    move-result-object v1
+                    const-wide/16 v2, 0x0
+                    invoke-virtual {v1, v2, v3}, $setSpringVelocityMethod
+                    """.trimIndent(),
+                    ExternalLabel("piko_continue", continueInstruction),
+                )
+            }
+
+            enableSettings("disableSwipeToCreate")
+        }
+    }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -56,6 +56,8 @@
     <string name="piko_disable_reels_scrolling_desc">"Disables the endless scrolling behavior in Instagram Reels, preventing swiping to the next Reel.
 
 Note: On a clean install, the \'Tip\' animation may appear but will stop on its own after a few seconds."</string>
+    <string name="piko_disable_swipe_to_create">Disable swipe to create</string>
+    <string name="piko_disable_swipe_to_create_desc">Prevents opening the creation screen by swiping right on the home tab.</string>
     <string name="piko_hide_stories_tray">Hide stories tray</string>
     <string name="piko_hide_stories_tray_desc">Hide stories tray from main feed</string>
     <string name="piko_hide_notes_tray">Hide notes tray</string>


### PR DESCRIPTION
Adds a Distraction free setting that prevents opening the creation screen by swiping right on the home tab.

## Testing
- `.\gradlew.bat :patches:build --console=plain`
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4 
- Tested on Samsung Galaxy S26

Closes #1082 