### PR TITLE
fix(Instagram): Match Piko settings background to Amoled theme patch

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -11,6 +11,7 @@ import static app.morphe.extension.instagram.utils.IgStr.str;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
@@ -59,6 +60,10 @@ public class UI {
         int attrId = ResourceUtils.getAttrIdentifier(attrName);
         boolean resolved = context.getTheme().resolveAttribute(attrId, typedValue, true);
         return context.getColor(typedValue.resourceId);
+    }
+
+    public static boolean isDarkMode() {
+        return Color.luminance(getThemedColour("igds_color_primary_background")) < 0.5;
     }
 
     public static void setThemedIcon(ImageView imageView, String drawableAttr) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -32,6 +32,7 @@ import java.util.function.Supplier;
 
 import app.morphe.extension.crimera.downloader.StorageUtils;
 import app.morphe.extension.instagram.constants.Constants;
+import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.settings.preference.Helper;
 import app.morphe.extension.instagram.settings.preference.ScreenBuilder;
 import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
@@ -210,13 +211,13 @@ public class SettingsActivity extends Activity {
         getWindow().setNavigationBarColor(InstagramPreferenceStyle.backgroundColor());
 
         int flags = getWindow().getDecorView().getSystemUiVisibility();
-//        if (InstagramPreferenceStyle.isDark(this)) {
-//            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-//            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-//        } else {
-//            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
-//            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
-//        }
+        if (UI.isDarkMode()) {
+            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            flags &= ~View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        } else {
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR;
+            flags |= View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR;
+        }
         getWindow().getDecorView().setSystemUiVisibility(flags);
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -8,7 +8,6 @@ package app.morphe.extension.instagram.settings.preference.widgets;
 
 import android.animation.ValueAnimator;
 import android.content.Context;
-import android.content.res.Configuration;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -51,7 +50,11 @@ public final class InstagramPreferenceStyle {
     }
 
     public static int backgroundColor() {
-        return UI.getThemedColour("igds_color_primary_background");
+        int primaryBackground = UI.getThemedColour("igds_color_primary_background");
+
+        return UI.isDarkMode()
+                ? ResourceUtils.getColor("igds_prism_black", primaryBackground)
+                : primaryBackground;
     }
 
     public static int pressedBackgroundColor() {


### PR DESCRIPTION
The piko settings screen uses a pure black background in dark mode even when the Amoled theme patch is not applied. use Instagram's `igds_prism_black` resource for the dark mode background instead. this keeps the standard `#0c1014` background without the Amoled theme patch and switches it to pure black only when the patch is applied.

## Testing
- `.\gradlew.bat :extensions:instagram:compileDebugJavaWithJavac --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26