### PR TITLE
fix(Instagram): Restore and sync ghost action bar icons

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -13,7 +13,9 @@ import android.content.Context;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import java.util.Collections;
 import java.util.Set;
+import java.util.WeakHashMap;
 
 import app.morphe.extension.instagram.utils.Pref;
 import app.morphe.extension.instagram.settings.SettingsStatus;
@@ -31,6 +33,14 @@ import com.instagram.common.session.UserSession;
 
 public class ActionBarPatch {
 
+    private static final Set<ImageView> GHOST_MODE_ICONS = Collections.newSetFromMap(new WeakHashMap<>());
+
+    private static void updateGhostModeIcons(boolean enabled) {
+        String icon = enabled ? UI.DRAWABLE_EYE_STROKE_ICON : UI.DRAWABLE_EYE_ICON;
+        for (ImageView imageView : GHOST_MODE_ICONS) {
+            UI.setThemedIcon(imageView, icon);
+        }
+    }
 
     private static void ghostModeToggle(ViewGroup viewGroup) throws Exception {
         if(SettingsStatus.ghostSection()){
@@ -38,14 +48,14 @@ public class ActionBarPatch {
 
             String iconStr = ghostModeToggle ? UI.DRAWABLE_EYE_STROKE_ICON:UI.DRAWABLE_EYE_ICON;
             ImageView imageView = UI.addImageViewToViewGroup(viewGroup, iconStr, null);
+            GHOST_MODE_ICONS.add(imageView);
             imageView.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     try {
                         boolean ghostModeToggle= !Pref.getTurnOnAllGhostModes();
-                        String iconStr = ghostModeToggle ? UI.DRAWABLE_EYE_STROKE_ICON:UI.DRAWABLE_EYE_ICON;
                         Pref.setTurnOnAllGhostModes(ghostModeToggle);
-                        UI.setThemedIcon(imageView,iconStr);
+                        updateGhostModeIcons(ghostModeToggle);
 
                         String toastStr = ghostModeToggle ? str("piko_ghost_modes_on") : str("piko_ghost_modes_default");
                         Utils.showToastShort(toastStr);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -78,7 +78,7 @@ public class Settings {
 
     public static final StringSetting ACTION_BAR_MAIN_FEED = new StringSetting("action_bar_main_feed", "");
     public static final StringSetting ACTION_BAR_USER_PROFILE = new StringSetting("action_bar_user_profile", "");
-    public static final StringSetting ACTION_BAR_CHAT = new StringSetting("action_bar_chat", "");
+    public static final StringSetting ACTION_BAR_CHAT = new StringSetting("action_bar_chat_buttons", "");
     public static final StringSetting ACTION_BAR_INBOX = new StringSetting("action_bar_inbox", "");
 
     public static final BooleanSetting ENABLE_MARK_CHAT_AS_READ = new BooleanSetting("enable_mark_chat_as_read", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/MultiSelectListPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/MultiSelectListPref.java
@@ -59,7 +59,7 @@ public class MultiSelectListPref extends MultiSelectListPreference {
         }
         else if (key == Settings.ACTION_BAR_CHAT.key) {
             entries = ResourceUtils.getStringArray("piko_array_action_bar_chat");
-            entriesValues = ResourceUtils.getStringArray("piko_array_action_bar_user_profile_val");
+            entriesValues = ResourceUtils.getStringArray("piko_array_action_bar_chat_val");
         }
         else if (key == Settings.ACTION_BAR_INBOX.key) {
             entries = ResourceUtils.getStringArray("piko_array_action_bar_inbox");

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -7,7 +7,6 @@
 
 package app.morphe.extension.instagram.utils;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import app.morphe.extension.instagram.settings.Settings;
@@ -295,12 +294,7 @@ public class Pref {
     }
 
     public static Set<String> chatActionBarButtons() {
-        Set<String> buttons = new HashSet<>(SharedPref.getSetPref(Settings.ACTION_BAR_CHAT));
-        if (buttons.remove(Constants.AB_PROFILE_INFO_ICON)) {
-            buttons.add(Constants.AB_GHOST_MODE_ICON);
-            SharedPref.setSetPref(Settings.ACTION_BAR_CHAT.key, buttons);
-        }
-        return buttons;
+        return SharedPref.getSetPref(Settings.ACTION_BAR_CHAT);
     }
 
     public static Set<String> inboxActionBarButtons() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -7,6 +7,7 @@
 
 package app.morphe.extension.instagram.utils;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import app.morphe.extension.instagram.settings.Settings;
@@ -294,7 +295,12 @@ public class Pref {
     }
 
     public static Set<String> chatActionBarButtons() {
-        return SharedPref.getSetPref(Settings.ACTION_BAR_CHAT);
+        Set<String> buttons = new HashSet<>(SharedPref.getSetPref(Settings.ACTION_BAR_CHAT));
+        if (buttons.remove(Constants.AB_PROFILE_INFO_ICON)) {
+            buttons.add(Constants.AB_GHOST_MODE_ICON);
+            SharedPref.setSetPref(Settings.ACTION_BAR_CHAT.key, buttons);
+        }
+        return buttons;
     }
 
     public static Set<String> inboxActionBarButtons() {


### PR DESCRIPTION
The chat action bar used the user profile value array, causing the ghost icon selection to be saved as the profile info icon. existing ghost icons also only refreshed on the action bar where they were tapped. use the chat-specific value array, migrate the invalid saved chat value, and keep existing ghost icons synchronized across home tab, inbox tab, profile tab, and chat tab.

## Testing
- `.\gradlew.bat :extensions:instagram:compileDebugJavaWithJavac :extensions:instagram:compileReleaseJavaWithJavac`
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26

Closes #1480 