### PR TITLE
fix(Instagram): Preserve settings fragment on recreation

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -67,12 +67,14 @@ public class SettingsActivity extends Activity {
         boolean isRootSettings = fragmentName == null || Constants.PIKO_FRAGMENT_SETTINGS.equals(fragmentName);
         createLayout(displayTitle, isRootSettings);
 
-        SettingsFragment fragment = new SettingsFragment();
-        if (getIntent() != null && getIntent().getExtras() != null) {
-            fragment.setArguments(getIntent().getExtras());
-        }
+        if (bundle == null) {
+            SettingsFragment fragment = new SettingsFragment();
+            if (getIntent() != null && getIntent().getExtras() != null) {
+                fragment.setArguments(getIntent().getExtras());
+            }
 
-        getFragmentManager().beginTransaction().replace(1001, fragment).commit();
+            getFragmentManager().beginTransaction().replace(1001, fragment).commit();
+        }
     }
 
     @SuppressLint("ResourceType")


### PR DESCRIPTION
While testing a new feature, I encountered `IllegalStateException: Content view not yet created` after switching to light mode. the same crash occurred again after rotating the piko settings screen to landscape. Android restores the existing `PreferenceFragment` when the activity is recreated, but `SettingsActivity` was replacing it with a new fragment. this change creates the fragment only for the initial activity instance, preventing the lifecycle conflict after theme and orientation changes.

## Testing
- `.\gradlew.bat :extensions:instagram:testDebugUnitTest :extensions:instagram:assembleDebug --rerun-tasks --console=plain --no-configuration-cache`
- `.\gradlew.bat clean :patches:buildAndroid --console=plain --no-configuration-cache`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.4
- Tested on Samsung Galaxy S26