### PR TITLE
fix(Instagram): Match piko settings highlight to theme

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -58,7 +58,13 @@ public final class InstagramPreferenceStyle {
     }
 
     public static int pressedBackgroundColor() {
-        return UI.getThemedColour("igds_color_secondary_background");
+        int secondaryBackground = UI.getThemedColour("igds_color_secondary_background");
+
+        if (!UI.isDarkMode() || backgroundColor() == Color.BLACK) {
+            return secondaryBackground;
+        }
+
+        return ResourceUtils.getColor("igds_prism_gray_09", secondaryBackground);
     }
 
     public static int primaryTextColor() {


### PR DESCRIPTION
[#1543](https://github.com/crimera/piko/pull/1543) changed the piko settings background to Instagram's blue-tinted `igds_prism_black` in standard dark mode, but the pressed highlight continued using the neutral `igds_color_secondary_background`. this palette mismatch makes the highlight look brown when the Amoled theme patch is not applied. use `igds_prism_gray_09` for the pressed highlight in standard dark mode.

## Testing
- `.\gradlew.bat :patches:test --console=plain`
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.8.0-dev.5
- Tested on Samsung Galaxy S26