### PR TITLE
fix(Twitter): Apply custom sharing domain to copied links

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
@@ -20,6 +20,7 @@ import app.morphe.util.findFreeRegister
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.BuilderOffsetInstruction
 import java.util.logging.Logger
 
 internal object NewShareSheetLinkFingerprint : Fingerprint(
@@ -97,12 +98,14 @@ val handleModernShareSheetLinks =
 
                 NewShareSheetLinkFingerprint2.method.apply {
                     val firstGoto = indexOfFirstInstruction(Opcode.GOTO)
+                    val linkMergeIndex = getInstruction<BuilderOffsetInstruction>(firstGoto).target.location.index
+                    val linkMergeInstruction = instructions[linkMergeIndex]
 
                     val shareSheetWInstruction = instructions[indexOfFirstInstruction(firstGoto, Opcode.IGET_OBJECT)]
                     val shareSheetWRegister = shareSheetWInstruction.registersUsed[1]
 
-                    val dummyRegister = getInstruction(firstGoto - 2).registersUsed[0]
-                    val linkRegister = getInstruction(firstGoto - 1).registersUsed[0]
+                    val linkRegister = linkMergeInstruction.registersUsed[0]
+                    val dummyRegister = findFreeRegister(linkMergeIndex + 1, listOf(linkRegister, shareSheetWRegister))
 
                     val injectCode =
                         callStatement
@@ -110,7 +113,7 @@ val handleModernShareSheetLinks =
                             .replace(dummy2, linkRegister.toString())
 
                     addInstructions(
-                        firstGoto,
+                        linkMergeIndex + 1,
                         """
                         iget-object v$dummyRegister, v$shareSheetWRegister, $contextualPostField
                         $injectCode

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/handlemodernsharesheetlinks/HandleModernShareSheetLinks.kt
@@ -98,12 +98,12 @@ val handleModernShareSheetLinks =
 
                 NewShareSheetLinkFingerprint2.method.apply {
                     val firstGoto = indexOfFirstInstruction(Opcode.GOTO)
-                    val linkMergeIndex = getInstruction<BuilderOffsetInstruction>(firstGoto).target.location.index
-                    val linkMergeInstruction = instructions[linkMergeIndex]
 
                     val shareSheetWInstruction = instructions[indexOfFirstInstruction(firstGoto, Opcode.IGET_OBJECT)]
                     val shareSheetWRegister = shareSheetWInstruction.registersUsed[1]
 
+                    val linkMergeIndex = getInstruction<BuilderOffsetInstruction>(firstGoto).target.location.index
+                    val linkMergeInstruction = getInstruction(linkMergeIndex)
                     val linkRegister = linkMergeInstruction.registersUsed[0]
                     val dummyRegister = findFreeRegister(linkMergeIndex + 1, listOf(linkRegister, shareSheetWRegister))
 


### PR DESCRIPTION
When the native share menu is disabled, copied post links bypass the custom sharing domain hook and keep using x.com. apply the hook after the share link branches converge so copied links use the configured custom domain regardless of the native share menu setting.

## Testing
- `.\gradlew.bat :patches:check --console=plain`
- Tested on Twitter v12.7.1-release.0 with Piko v3.8.0-dev.5
- Tested on Samsung Galaxy S26