### PR TITLE
fix(Instagram): Fix app crash on comment media download and support 

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
@@ -42,20 +42,29 @@ public class CommentData extends Entity implements GifMediaInterface {
     }
 
     public MediaData getImageMedia() throws Exception {
-        Entity imageDataEntity = super.getFieldAsEntity("fieldName");
-        Object mediaObj = imageDataEntity.getField("fieldName2");
-        if(mediaObj!=null){
-            return new MediaData(mediaObj);
+        try {
+            Entity imageDataEntity = super.getFieldAsEntity("fieldName");
+            if (imageDataEntity != null) {
+                Object mediaObj = imageDataEntity.getField("fieldName2");
+                if (mediaObj != null) {
+                    return new MediaData(mediaObj);
+                }
+            }
+        } catch (Exception ignored) {
         }
         return null;
     }
 
     private Object getGifMedia() throws Exception {
-        return super.getField("fieldName");
+        try {
+            return super.getField("fieldName");
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     public boolean hasGifMedia() throws Exception {
-        return this.getGifMedia()!=null;
+        return this.getGifMedia() != null;
     }
 
     private String getGifObjectField(String fieldName) throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
@@ -42,25 +42,18 @@ public class CommentData extends Entity implements GifMediaInterface {
     }
 
     public MediaData getImageMedia() throws Exception {
-        try {
-            Entity imageDataEntity = super.getFieldAsEntity("fieldName");
-            if (imageDataEntity != null) {
-                Object mediaObj = imageDataEntity.getField("fieldName2");
-                if (mediaObj != null) {
-                    return new MediaData(mediaObj);
-                }
+        Entity imageDataEntity = super.getFieldAsEntity("fieldName");
+        if (imageDataEntity != null) {
+            Object mediaObj = imageDataEntity.getField("fieldName2");
+            if (mediaObj != null) {
+                return new MediaData(mediaObj);
             }
-        } catch (Exception ignored) {
         }
         return null;
     }
 
     private Object getGifMedia() throws Exception {
-        try {
-            return super.getField("fieldName");
-        } catch (Exception ignored) {
-            return null;
-        }
+        return super.getField("fieldName");
     }
 
     public boolean hasGifMedia() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
@@ -74,31 +74,33 @@ public class HandleCommentButton {
                 return true;
 
             } else if (button.equals(SaveMediaButton.A00)) {
-                CommentData commentData = new CommentData(commentObject);
+                try {
+                    CommentData commentData = new CommentData(commentObject);
 
-                Context context = (Context) Utils.getActivity();
-                if(commentData.hasGifMedia()) {
-                    String gifUrl = commentData.getGifUrl();
-                    String fileName = commentData.getGifDownloadName();
-                    DownloadUtils.downloadMediaUrl(context, gifUrl, Constants.DEFAULT_GIF_FOLDER, fileName);
-                    return true;
+                    Context context = (Context) Utils.getActivity();
+                    if (commentData.hasGifMedia()) {
+                        String gifUrl = commentData.getGifUrl();
+                        String fileName = commentData.getGifDownloadName();
+                        DownloadUtils.downloadMediaUrl(context, gifUrl, Constants.DEFAULT_GIF_FOLDER, fileName);
+                    } else if (commentData.hasImageMedia()) {
+                        MediaData imageData = commentData.getImageMedia();
+                        UserData userData = commentData.getCommentUserData();
 
-                } else if (commentData.hasImageMedia()) {
-                    MediaData imageData = commentData.getImageMedia();
-                    UserData userData = commentData.getCommentUserData();
+                        String userName = (userData != null) ? userData.getUsername() : "comment";
+                        String mediaLink = imageData.getMediaLink();
+                        String fileName = userName + "_" + imageData.getDownloadFilename(MediaType.ANY);
 
-                    String userName = userData.getUsername();
-                    String mediaLink = imageData.getMediaLink();
-                    String fileName = userName+"_"+imageData.getDownloadFilename(MediaType.IMAGE);
+                        String subFolder = DownloadUtils.getSubfolderName(userName);
 
-                    String subFolder = DownloadUtils.getSubfolderName(userName);
-
-                    DownloadUtils.downloadMediaUrl(context, mediaLink, subFolder, fileName);
-                    return true;
-
+                        DownloadUtils.downloadMediaUrl(context, mediaLink, subFolder, fileName);
+                    } else {
+                        PikoUtils.toast(str("piko_comment_copied_failed"));
+                    }
+                } catch (Exception ex) {
+                    PikoUtils.logger(ex);
+                    PikoUtils.toast(str("piko_comment_copied_failed"));
                 }
-
-                return false;
+                return true;
             }
 
             return false;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
@@ -50,6 +50,8 @@ public class HandleCommentButton {
         }
     }
 
+    // return true = Piko button clicked no need to check Instagram's buttons.
+    // return false = Piko button not clicked, check Instagram's buttons.
     public static boolean checkOnCommentButtonClick(Object button, List list) {
         try {
             if (list.isEmpty()) return false;
@@ -74,7 +76,6 @@ public class HandleCommentButton {
                 return true;
 
             } else if (button.equals(SaveMediaButton.A00)) {
-                try {
                     CommentData commentData = new CommentData(commentObject);
 
                     Context context = (Context) Utils.getActivity();
@@ -93,23 +94,18 @@ public class HandleCommentButton {
                         String subFolder = DownloadUtils.getSubfolderName(userName);
 
                         DownloadUtils.downloadMediaUrl(context, mediaLink, subFolder, fileName);
-                    } else {
-                        PikoUtils.toast(str("piko_comment_copied_failed"));
                     }
-                } catch (Exception ex) {
-                    PikoUtils.logger(ex);
-                    PikoUtils.toast(str("piko_comment_copied_failed"));
-                }
+                
                 return true;
             }
 
-            return false;
-
         } catch (Exception e) {
             PikoUtils.logger(e);
-            return false;
-
+            PikoUtils.toast(e.getMessage());
+            // If exception happens, we need not check Instagram's button.
+            return true;
         }
+        return false;
     }
 
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
@@ -11,6 +11,8 @@ import static app.morphe.extension.instagram.utils.IgStr.str;
 
 import java.util.List;
 import android.content.Context;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
@@ -87,7 +89,7 @@ public class HandleCommentButton {
                         MediaData imageData = commentData.getImageMedia();
                         UserData userData = commentData.getCommentUserData();
 
-                        String userName = (userData != null) ? userData.getUsername() : "comment";
+                        String userName = (userData != null) ? userData.getUsername() : "comment_"+LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
                         String mediaLink = imageData.getMediaLink();
                         String fileName = userName + "_" + imageData.getDownloadFilename(MediaType.ANY);
 


### PR DESCRIPTION
### Summary
- Prevents `kotlin.NoWhenBranchMatchedException` app crash by consuming `SaveMediaButton.A00` click events in comment section.
- Updates download filename format to `MediaType.ANY` to support `.mp4` video downloads as well as `.jpg` images.
- Adds null-safety for `UserData` and try-catch handling during media extraction.
