### PR TITLE
fix(instagram): carousel download uses current slide index + fix consent popup on launch

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -96,6 +96,17 @@ public class Links {
                         || host.contains("graph.facebook.com")
                         || path.contains("/logging_client_events")) {
                     shouldBlockUri = DISABLE_ANALYTICS;
+                } else if (DISABLE_ANALYTICS && (
+                        path.contains("/api/v1/consent/existing_user_flow/")
+                        || path.contains("/api/v1/consent/new_user_flow/")
+                        || path.contains("/consent/existing_user_flow/")
+                        || path.contains("/consent/new_user_flow/"))) {
+                    // When analytics is disabled, also block consent re-check endpoints.
+                    // These are called on every launch to determine if setup dialogs
+                    // (location, contacts, notifications) need to be shown again.
+                    // Blocking them prevents the "Set up on new device" location popup
+                    // from appearing on every app open when Disable Analytics is enabled.
+                    shouldBlockUri = true;
                 } else if (path.contains("/api/v2/media/seen/")) {
                     shouldBlockUri = Pref.viewStoriesAnonymously();
                 } else if (path.contains("/heartbeat_and_get_viewer_count/")) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
@@ -84,7 +84,6 @@ public class AddReelButton {
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon, reelButton, buttonText);
 
         AddReelButton.addReelButton(context, reelOverflowButton, helperObject);
-
     }
 
     private static void addExternalDownloadButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
@@ -97,6 +96,8 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
+    // Called from hook when MEDIA_ADD_INFO_CLASS_NAME field is found on the reel controller —
+    // passes the real current carousel index.
     public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         if(Pref.pikoDebug()){
             AddReelButton.addDebugButton(context, helperObject, mediaObject, currentMediaIndex);
@@ -110,6 +111,11 @@ public class AddReelButton {
         if(Pref.moreOptionsOnPost()){
             AddReelButton.addInfoButton(context, helperObject, mediaObject, currentMediaIndex);
         }
+    }
+
+    // Fallback: called when MEDIA_ADD_INFO_CLASS_NAME field is not found — index defaults to 0.
+    public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject){
+        includeCustomReelOverflowButtons(context, helperObject, mediaObject, 0);
     }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
@@ -53,9 +53,9 @@ public class AddReelButton {
         }
     }
 
-    private static void addDownloadButton(Context context, Object helperObject, Object mediaObject){
+    private static void addDownloadButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_DOWNLOAD_ICON;
-        ReelButton reelButton = new DownloadButton(context,mediaObject);
+        ReelButton reelButton = new DownloadButton(context, mediaObject, currentMediaIndex);
         String DOWNLOAD_BUTTON_TEXT = str("piko_download_options");
         if(Pref.enableDirectDownload()){
             DOWNLOAD_BUTTON_TEXT = str("piko_category_download_media");
@@ -66,9 +66,9 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    private static void addInfoButton(Context context, Object helperObject, Object mediaObject){
+    private static void addInfoButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_BLUB_ICON;
-        ReelButton reelButton = new InfoButton(context,mediaObject);
+        ReelButton reelButton = new InfoButton(context, mediaObject, currentMediaIndex);
         String buttonText = str("piko_more_options");
 
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon,reelButton,buttonText);
@@ -76,9 +76,9 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    private static void addDebugButton(Context context, Object helperObject, Object mediaObject) {
+    private static void addDebugButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex) {
         String icon = UI.DRAWABLE_DEBUG_ICON;
-        ReelButton reelButton = new DebugButton(context, mediaObject);
+        ReelButton reelButton = new DebugButton(context, mediaObject, currentMediaIndex);
         String buttonText = str("piko_debug");
 
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon, reelButton, buttonText);
@@ -87,9 +87,9 @@ public class AddReelButton {
 
     }
 
-    private static void addExternalDownloadButton(Context context, Object helperObject, Object mediaObject){
+    private static void addExternalDownloadButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_DOWNLOAD_ICON;
-        ReelButton reelButton = new ExternalDownloadButton(context,mediaObject);
+        ReelButton reelButton = new ExternalDownloadButton(context, mediaObject, currentMediaIndex);
         String buttonText = str("piko_download_with_external_downloader");
 
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon,reelButton,buttonText);
@@ -97,18 +97,18 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject){
+    public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         if(Pref.pikoDebug()){
-            AddReelButton.addDebugButton(context, helperObject, mediaObject);
+            AddReelButton.addDebugButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.enableDownload()){
-            AddReelButton.addDownloadButton(context, helperObject, mediaObject);
+            AddReelButton.addDownloadButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.downloadWithExternalDownloader()){
-            AddReelButton.addExternalDownloadButton(context, helperObject, mediaObject);
+            AddReelButton.addExternalDownloadButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.moreOptionsOnPost()){
-            AddReelButton.addInfoButton(context, helperObject, mediaObject);
+            AddReelButton.addInfoButton(context, helperObject, mediaObject, currentMediaIndex);
         }
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
@@ -17,6 +17,10 @@ public class DebugButton extends ReelButton {
         super(context, mediaObject, currentMediaIndex);
     }
 
+    public DebugButton(Context context, Object mediaObject) {
+        super(context, mediaObject, 0);
+    }
+
     @Override
     public void onClick(View view) {
         ObjectBrowser.browseObject(this.context, new MediaData(this.mediaObject));

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
@@ -13,8 +13,8 @@ import app.morphe.extension.crimera.ObjectBrowser;
 import app.morphe.extension.instagram.entity.MediaData;
 
 public class DebugButton extends ReelButton {
-    public DebugButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public DebugButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 
 public class DownloadButton extends ReelButton {
-    public DownloadButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public DownloadButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        DownloadUtils.downloadPost(this.context, null, this.mediaObject, 0);
+        DownloadUtils.downloadPost(this.context, null, this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
@@ -16,6 +16,10 @@ public class DownloadButton extends ReelButton {
         super(context, mediaObject, currentMediaIndex);
     }
 
+    public DownloadButton(Context context, Object mediaObject) {
+        super(context, mediaObject, 0);
+    }
+
     @Override
     public void onClick(View view) {
         DownloadUtils.downloadPost(this.context, null, this.mediaObject, this.currentMediaIndex);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 
 public class ExternalDownloadButton extends ReelButton {
-    public ExternalDownloadButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public ExternalDownloadButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        DownloadUtils.externalDownloader(this.mediaObject,0);
+        DownloadUtils.externalDownloader(this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
@@ -16,6 +16,10 @@ public class ExternalDownloadButton extends ReelButton {
         super(context, mediaObject, currentMediaIndex);
     }
 
+    public ExternalDownloadButton(Context context, Object mediaObject) {
+        super(context, mediaObject, 0);
+    }
+
     @Override
     public void onClick(View view) {
         DownloadUtils.externalDownloader(this.mediaObject, this.currentMediaIndex);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.feed.MoreOptionsOnPostPatch;
 
 public class InfoButton extends ReelButton {
-    public InfoButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public InfoButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        MoreOptionsOnPostPatch.postMoreOptions(this.context, null, this.mediaObject, 0);
+        MoreOptionsOnPostPatch.postMoreOptions(this.context, null, this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
@@ -16,6 +16,10 @@ public class InfoButton extends ReelButton {
         super(context, mediaObject, currentMediaIndex);
     }
 
+    public InfoButton(Context context, Object mediaObject) {
+        super(context, mediaObject, 0);
+    }
+
     @Override
     public void onClick(View view) {
         MoreOptionsOnPostPatch.postMoreOptions(this.context, null, this.mediaObject, this.currentMediaIndex);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
@@ -13,10 +13,12 @@ import android.content.Context;
 public abstract class ReelButton implements View.OnClickListener {
     public final Context context;
     public final Object mediaObject;
+    public final int currentMediaIndex;
 
-    public ReelButton(Context context, Object mediaObject) {
+    public ReelButton(Context context, Object mediaObject, int currentMediaIndex) {
         this.context = context;
         this.mediaObject = mediaObject;
+        this.currentMediaIndex = currentMediaIndex;
     }
 
     // Every subclass will be forced to implement its own specific click logic

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
@@ -21,6 +21,10 @@ public abstract class ReelButton implements View.OnClickListener {
         this.currentMediaIndex = currentMediaIndex;
     }
 
+    public ReelButton(Context context, Object mediaObject) {
+        this(context, mediaObject, 0);
+    }
+
     // Every subclass will be forced to implement its own specific click logic
     @Override
     public abstract void onClick(View view);

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
@@ -6,6 +6,9 @@
 
 package app.crimera.patches.instagram.misc.overflowMenuButton.reels
 
+import app.crimera.patches.instagram.entity.decoder.CURRENT_MEDIA_FIELD
+import app.crimera.patches.instagram.entity.decoder.MEDIA_ADD_INFO_CLASS_NAME
+import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.misc.download.AddReelButtonFingerprint
 import app.crimera.patches.instagram.utils.Constants.ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
@@ -22,19 +25,18 @@ val hookReelOverflowMenuButton =
     bytecodePatch(
         description = "This patch hooks reel overflow button list adder",
     ) {
-        dependsOn(reelsOverflowMenuButtonEntity)
+        dependsOn(reelsOverflowMenuButtonEntity, decoderEntity)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
         execute {
             AddReelButtonFingerprint.method.apply {
                 val classDef = AddReelButtonFingerprint.classDef
-                val className = classDef.type
                 val classFields = classDef.fields
 
                 val appActivityField = classFields.first { it.type == FRAGMENT_ACTIVITY }
 
-                // Find the first int field on the controller class — this holds the current
-                // carousel/slideshow index that Instagram tracks for the viewed item.
-                val currentMediaIndexField = classFields.firstOrNull { it.type == "I" }
+                // Find the field that holds the MEDIA_ADD_INFO object on the reel controller.
+                // This is the same class used by the feed hook to get CURRENT_MEDIA_FIELD.
+                val mediaExtraDataField = classFields.firstOrNull { it.type == MEDIA_ADD_INFO_CLASS_NAME }
 
                 val selfClassRegister = instructions[indexOfFirstInstruction(Opcode.MOVE_OBJECT_FROM16)].registersUsed[0]
                 val buttonAdderInstanceRegister = instructions[indexOfFirstInstruction(Opcode.NEW_INSTANCE)].registersUsed[0]
@@ -43,25 +45,48 @@ val hookReelOverflowMenuButton =
                 val mediaObjectFromParameterIndex = indexOfFirstInstruction(sPutIndex, Opcode.MOVE_OBJECT_FROM16)
                 val mediaObjectRegister = instructions[mediaObjectFromParameterIndex].registersUsed[0]
 
+                // freeRegisterOne is used for scratch — it's set by CONST_4 after our injection
+                // point so it's safe to clobber before that instruction runs.
                 val freeRegisterOne = instructions[indexOfFirstInstruction(mediaObjectFromParameterIndex, Opcode.CONST_4)].registersUsed[0]
 
-                if (currentMediaIndexField != null) {
+                if (mediaExtraDataField != null) {
+                    // Safe two-register pattern: identical to how the feed onClick hook reads
+                    // CURRENT_MEDIA_FIELD.
+                    // - freeRegisterOne: scratch for the MEDIA_ADD_INFO object, then int index
+                    // - buttonAdderInstanceRegister: scratch for the Context (appActivity)
+                    //   (buttonAdderInstanceRegister was set by NEW_INSTANCE before our injection
+                    //    and is already live as helperObject — but we read it into the invoke
+                    //    AFTER we've finished using it as scratch here)
+                    // Step 1: read context into buttonAdderInstanceRegister
+                    // Step 2: read mediaExtraData object into freeRegisterOne
+                    // Step 3: read int index from that object, also into freeRegisterOne
+                    // Step 4: invoke with (context, helperObject=still in buttonAdderInstanceRegister, mediaObject, index)
+                    // Wait — buttonAdderInstanceRegister is the helperObject we need to pass.
+                    // We must NOT clobber it. Use selfClassRegister for context scratch instead,
+                    // reading it BEFORE we need selfClassRegister for the IGET chain.
+                    //
+                    // Safe order:
+                    //   iget-object freeRegisterOne, selfClassRegister, mediaExtraDataField  <- read extra-data obj (selfClassRegister still intact)
+                    //   iget        freeRegisterOne, freeRegisterOne,   CURRENT_MEDIA_FIELD  <- overwrite with int (extra-data obj no longer needed)
+                    //   iget-object selfClassRegister, selfClassRegister, appActivityField   <- now clobber selfClassRegister with context
+                    //   invoke-static {selfClassRegister, buttonAdderInstanceRegister, mediaObjectRegister, freeRegisterOne}
                     addInstructions(
                         mediaObjectFromParameterIndex + 1,
                         """
-                        iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
-                        iget v$selfClassRegister, v$selfClassRegister, $currentMediaIndexField
-                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$selfClassRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
+                        iget-object v$freeRegisterOne, v$selfClassRegister, $mediaExtraDataField
+                        iget v$freeRegisterOne, v$freeRegisterOne, $CURRENT_MEDIA_FIELD
+                        iget-object v$selfClassRegister, v$selfClassRegister, $appActivityField
+                        invoke-static {v$selfClassRegister,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$freeRegisterOne},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
                         """.trimIndent(),
                     )
                 } else {
-                    // Fallback: no int field found, pass 0 as the index.
+                    // Fallback: reel controller doesn't have MEDIA_ADD_INFO field.
+                    // Pass index 0 — safe, single-item reels are always index 0.
                     addInstructions(
                         mediaObjectFromParameterIndex + 1,
                         """
                         iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
-                        const/4 v$selfClassRegister, 0x0
-                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$selfClassRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
+                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;)V
                         """.trimIndent(),
                     )
                 }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
@@ -32,6 +32,10 @@ val hookReelOverflowMenuButton =
 
                 val appActivityField = classFields.first { it.type == FRAGMENT_ACTIVITY }
 
+                // Find the first int field on the controller class — this holds the current
+                // carousel/slideshow index that Instagram tracks for the viewed item.
+                val currentMediaIndexField = classFields.firstOrNull { it.type == "I" }
+
                 val selfClassRegister = instructions[indexOfFirstInstruction(Opcode.MOVE_OBJECT_FROM16)].registersUsed[0]
                 val buttonAdderInstanceRegister = instructions[indexOfFirstInstruction(Opcode.NEW_INSTANCE)].registersUsed[0]
 
@@ -41,13 +45,26 @@ val hookReelOverflowMenuButton =
 
                 val freeRegisterOne = instructions[indexOfFirstInstruction(mediaObjectFromParameterIndex, Opcode.CONST_4)].registersUsed[0]
 
-                addInstructions(
-                    mediaObjectFromParameterIndex + 1,
-                    """
-                    iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
-                    invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;)V
-                    """.trimIndent(),
-                )
+                if (currentMediaIndexField != null) {
+                    addInstructions(
+                        mediaObjectFromParameterIndex + 1,
+                        """
+                        iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
+                        iget v$selfClassRegister, v$selfClassRegister, $currentMediaIndexField
+                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$selfClassRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
+                        """.trimIndent(),
+                    )
+                } else {
+                    // Fallback: no int field found, pass 0 as the index.
+                    addInstructions(
+                        mediaObjectFromParameterIndex + 1,
+                        """
+                        iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
+                        const/4 v$selfClassRegister, 0x0
+                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$selfClassRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
+                        """.trimIndent(),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes three open issues related to Instagram carousel reel downloads and the consent popup on launch.

---

## Changes

### fix(instagram): pass current carousel index to reel overflow buttons

Closes #1562

**Problem:** When a reel post contains multiple images (carousel/slideshow), the download button and all other overflow menu buttons always operated on slide 1 (index hardcoded to `0`), regardless of which slide the user was currently viewing.

**Root cause:** The reel overflow button hook (`ClipsOrganicMediaItemViewMoreOptionsController`) did not pass the current carousel position to the extension. All `ReelButton` subclasses received position `0`.

**Fix:** The hook now reads `CURRENT_MEDIA_FIELD` from `MEDIA_ADD_INFO_CLASS_NAME` on the controller class — the same field and pattern already used by the feed onClick hook (`HookOverflowMenuButtonOnClickPatch`). A safe three-instruction sequence avoids clobbering live registers:

```
iget-object freeReg, self, mediaExtraDataField    <- read extra-data obj (self still intact)
iget        freeReg, freeReg, CURRENT_MEDIA_FIELD <- read int index (safe reuse)
iget-object self,    self,    appActivityField    <- clobber self LAST after all reads done
```

Falls back to index `0` via a 3-arg overload if `mediaExtraDataField` is not found on the controller class.

**Tested:** Confirmed on a real device — downloading from slide 3 of a carousel reel correctly downloads slide 3.

---

### fix(instagram): block consent re-check endpoints when analytics is disabled

Closes #1574
Closes #1563

**Problem:** With "Disable Analytics" enabled, Instagram called `/api/v1/consent/existing_user_flow/` and `/api/v1/consent/new_user_flow/` on every launch to determine whether device setup dialogs should be shown again. Since the analytics block prevented Instagram from recording that setup was already completed, the "Set up on new device" location/contact access popup appeared on every single launch.

The existing `ig_device_permission_consent` flag (`56295 = false`) suppresses the dialogs themselves, but the consent re-check HTTP calls still triggered the setup flow before the flag could take effect.

**Fix:** Explicitly block both consent re-check endpoint paths in `Links.interceptUri()` when `DISABLE_ANALYTICS` is `true`. This covers both the location services popup (#1574) and the contact access popup mentioned in review comments.

**Tested:** Neither the location nor contact access popup appears on launch with Disable Analytics enabled.
