### PR TITLE
fix(Instagram): Download max res 4K media

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -252,38 +252,16 @@ public class MediaData extends Entity {
 
     public String getVideoLink() throws Exception {
         List<VideoData> videoDataList = this.getVideoVariants();
-        if(videoDataList != null && !videoDataList.isEmpty()){
-            VideoData highestResolutionVideo = videoDataList.get(0);
-            long highestPixelCount = (long) highestResolutionVideo.getWidth() * highestResolutionVideo.getHeight();
-
-            for (VideoData videoData : videoDataList) {
-                long pixelCount = (long) videoData.getWidth() * videoData.getHeight();
-                if (pixelCount > highestPixelCount) {
-                    highestResolutionVideo = videoData;
-                    highestPixelCount = pixelCount;
-                }
-            }
-
-            return highestResolutionVideo.getUrl();
+        if(videoDataList!=null){
+            return videoDataList.get(0).getUrl();
         }
         return null;
     }
     
     public String getImageLink() throws Exception {
         List<ImageData> imageDataList = this.getImageVariants();
-        if(imageDataList != null && !imageDataList.isEmpty()){
-            ImageData highestResolutionImage = imageDataList.get(0);
-            long highestPixelCount = (long) highestResolutionImage.getWidth() * highestResolutionImage.getHeight();
-
-            for (ImageData imageData : imageDataList) {
-                long pixelCount = (long) imageData.getWidth() * imageData.getHeight();
-                if (pixelCount > highestPixelCount) {
-                    highestResolutionImage = imageData;
-                    highestPixelCount = pixelCount;
-                }
-            }
-
-            return highestResolutionImage.getUrl();
+        if(imageDataList!=null){
+            return imageDataList.get(0).getUrl();
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -260,8 +260,19 @@ public class MediaData extends Entity {
     
     public String getImageLink() throws Exception {
         List<ImageData> imageDataList = this.getImageVariants();
-        if(imageDataList!=null){
-            return imageDataList.get(0).getUrl();
+        if(imageDataList != null && !imageDataList.isEmpty()){
+            ImageData highestResolutionImage = imageDataList.get(0);
+            long highestPixelCount = (long) highestResolutionImage.getWidth() * highestResolutionImage.getHeight();
+
+            for (ImageData imageData : imageDataList) {
+                long pixelCount = (long) imageData.getWidth() * imageData.getHeight();
+                if (pixelCount > highestPixelCount) {
+                    highestResolutionImage = imageData;
+                    highestPixelCount = pixelCount;
+                }
+            }
+
+            return highestResolutionImage.getUrl();
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -252,8 +252,19 @@ public class MediaData extends Entity {
 
     public String getVideoLink() throws Exception {
         List<VideoData> videoDataList = this.getVideoVariants();
-        if(videoDataList!=null){
-            return videoDataList.get(0).getUrl();
+        if(videoDataList != null && !videoDataList.isEmpty()){
+            VideoData highestResolutionVideo = videoDataList.get(0);
+            long highestPixelCount = (long) highestResolutionVideo.getWidth() * highestResolutionVideo.getHeight();
+
+            for (VideoData videoData : videoDataList) {
+                long pixelCount = (long) videoData.getWidth() * videoData.getHeight();
+                if (pixelCount > highestPixelCount) {
+                    highestResolutionVideo = videoData;
+                    highestPixelCount = pixelCount;
+                }
+            }
+
+            return highestResolutionVideo.getUrl();
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -208,9 +208,7 @@ public class Pref {
     }
 
     public static Integer improveImageViewing(Integer defaultSize) {
-        return enableDownload() || SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING)
-                ? MAX_IMAGE_SIZE
-                : defaultSize;
+        return SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING) ? MAX_IMAGE_SIZE : defaultSize;
     }
 
     public static boolean enableDownload() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -17,6 +17,7 @@ import app.morphe.extension.crimera.SharedPref;
 
 @SuppressWarnings("unused")
 public class Pref {
+    private static final int MAX_IMAGE_SIZE = 4096;
     public static boolean SHOULD_MARK_CHAT_AS_READ;
     static {
         SHOULD_MARK_CHAT_AS_READ = false;
@@ -203,11 +204,13 @@ public class Pref {
     }
 
     public static int improveImageViewing(int defaultSize) {
-        return SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING) ? 2048 : defaultSize;
+        return SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING) ? MAX_IMAGE_SIZE : defaultSize;
     }
 
     public static Integer improveImageViewing(Integer defaultSize) {
-        return SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING) ? 2048 : defaultSize;
+        return enableDownload() || SharedPref.getBooleanPref(Settings.IMPROVE_IMAGE_VIEWING)
+                ? MAX_IMAGE_SIZE
+                : defaultSize;
     }
 
     public static boolean enableDownload() {


### PR DESCRIPTION
## Improvements
- Fix Instagram downloads selecting a lower-quality image or video when the first returned variant is not the highest resolution.
- Request image metadata up to 4096px whenever media downloading is enabled, while keeping high-resolution in-app viewing independently controlled by its existing setting.
- Select image and video variants by pixel count, including individual and “Download all media” actions.
- Safely handle empty variant lists instead of attempting to access the first entry.

## 📦 Others
- Verified with `:extensions:instagram:compileDebugJavaWithJavac` and IDE lint checks.