### PR TITLE
feat(Instagram): New patch to block onboarding permission prompts

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
@@ -24,6 +24,11 @@ public class HookFlags {
         BOOL_FLAGS.put("56295", false); //ig_device_permission_consent
     }
 
+    private static void onboardingPermissionPromptFlags() {
+        BOOL_FLAGS.put("56295", false); //ig_device_permission_consent
+        BOOL_FLAGS.put("77866", false); //ig4a_d0_retention
+    }
+
     private static void simpleOverflowMenuFlags() {
         BOOL_FLAGS.put("104772", false); //ig_ini
         BOOL_FLAGS.put("117613::0", true); //ig_overflow_menu_icon::use_more_lines_icon

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
@@ -20,10 +20,6 @@ public class HookFlags {
     private static Map<String, Boolean> BOOL_FLAGS = new HashMap<>();
     private static DeveloperOptions developerOptions = new DeveloperOptions();
 
-    private static void contactPermissionConsentFlags() {
-        BOOL_FLAGS.put("56295", false); //ig_device_permission_consent
-    }
-
     private static void onboardingPermissionPromptFlags() {
         BOOL_FLAGS.put("56295", false); //ig_device_permission_consent
         BOOL_FLAGS.put("77866", false); //ig4a_d0_retention

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -34,6 +34,7 @@ public class Links {
     private static final boolean DISABLE_DISCOVER_PEOPLE;
     private static final boolean DISABLE_ADS;
     private static final boolean DISABLE_HIGHLIGHTS;
+    private static final boolean DISABLE_ONBOARDING_PERMISSION_PROMPTS;
     private static final List<String> META_PACKAGES;
 
     static {
@@ -44,6 +45,7 @@ public class Links {
         DISABLE_COMMENTS = Pref.disableComments() && SettingsStatus.disableComments;
         DISABLE_DISCOVER_PEOPLE = Pref.disableDiscoverPeople() && SettingsStatus.disableDiscoverPeople;
         DISABLE_ADS = Pref.disableAds() && SettingsStatus.disableAds;
+        DISABLE_ONBOARDING_PERMISSION_PROMPTS = SettingsStatus.disableOnboardingPermissionPrompts;
 
         META_PACKAGES = Arrays.asList(
                 "com.instagram.android",      // Instagram
@@ -96,6 +98,9 @@ public class Links {
                         || host.contains("graph.facebook.com")
                         || path.contains("/logging_client_events")) {
                     shouldBlockUri = DISABLE_ANALYTICS;
+                } else if (path.contains("/consent/existing_user_flow/")
+                        || path.contains("/consent/new_user_flow/")) {
+                    shouldBlockUri = DISABLE_ONBOARDING_PERMISSION_PROMPTS;
                 } else if (path.contains("/api/v2/media/seen/")) {
                     shouldBlockUri = Pref.viewStoriesAnonymously();
                 } else if (path.contains("/heartbeat_and_get_viewer_count/")) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -140,6 +140,10 @@ public class SettingsStatus {
     public static void customiseStoryRingSize() { customiseStoryRingSize = true; }
     public static boolean disableAnalytics = false;
     public static void disableAnalytics() { disableAnalytics = true; }
+    public static boolean disableOnboardingPermissionPrompts = false;
+    public static void disableOnboardingPermissionPrompts() {
+        disableOnboardingPermissionPrompts = true;
+    }
     public static boolean disableDiscoverPeople = false;
     public static void disableDiscoverPeople() {
         disableDiscoverPeople = true;

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/misc/DisableAnalyticsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/misc/DisableAnalyticsPatch.kt
@@ -9,7 +9,6 @@ package app.crimera.patches.instagram.links.misc
 import app.crimera.patches.instagram.links.interceptUriPatch
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.crimera.patches.instagram.utils.addFlags
 import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
@@ -23,9 +22,6 @@ val disableAnalyticsPatch =
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
-
-            addFlags("contactPermissionConsentFlags")
-
             enableSettings("disableAnalytics")
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.onboarding
+
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.addFlags
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val disableOnboardingPermissionPromptsPatch =
+    bytecodePatch(
+        name = "Disable onboarding permission prompts",
+        description = "Prevents contacts and location permission onboarding prompts from appearing on launch.",
+        default = true,
+    ) {
+        dependsOn(settingsPatch)
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            addFlags("onboardingPermissionPromptFlags")
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
@@ -6,9 +6,11 @@
 
 package app.crimera.patches.instagram.misc.onboarding
 
+import app.crimera.patches.instagram.links.interceptUriPatch
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.addFlags
+import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
@@ -18,10 +20,11 @@ val disableOnboardingPermissionPromptsPatch =
         description = "Prevents contacts and location permission onboarding prompts from appearing on launch.",
         default = true,
     ) {
-        dependsOn(settingsPatch)
+        dependsOn(settingsPatch, interceptUriPatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
             addFlags("onboardingPermissionPromptFlags")
+            enableSettings("disableOnboardingPermissionPrompts")
         }
     }


### PR DESCRIPTION
## ✨ New Features
- Add a default-enabled `Disable onboarding permission prompts` patch for Instagram.
- Suppress launch-time contacts and location onboarding screens by disabling the `ig_device_permission_consent` and `ig4a_d0_retention` Mobile Config flows.
- Preserve Android permission state, allowing users to grant contacts or location access later when intentionally using related features.

## 📦 Others
- Reuse the existing Mobile Config flag hook and settings patch infrastructure without introducing additional fingerprints.
- Verified by compiling the Instagram extension and Kotlin patches and building the complete MPP bundle.

## 🖼️ Example prompts this patch blocks

<img width="1520" height="1683" alt="Prompt" src="https://github.com/user-attachments/assets/6adb54e6-403a-46ba-8595-db11a32cfc4b" />
