### PR TITLE
fix(instagram): pass current carousel index to reel overflow buttons

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
@@ -53,9 +53,9 @@ public class AddReelButton {
         }
     }
 
-    private static void addDownloadButton(Context context, Object helperObject, Object mediaObject){
+    private static void addDownloadButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_DOWNLOAD_ICON;
-        ReelButton reelButton = new DownloadButton(context,mediaObject);
+        ReelButton reelButton = new DownloadButton(context, mediaObject, currentMediaIndex);
         String DOWNLOAD_BUTTON_TEXT = str("piko_download_options");
         if(Pref.enableDirectDownload()){
             DOWNLOAD_BUTTON_TEXT = str("piko_category_download_media");
@@ -66,9 +66,9 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    private static void addInfoButton(Context context, Object helperObject, Object mediaObject){
+    private static void addInfoButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_BLUB_ICON;
-        ReelButton reelButton = new InfoButton(context,mediaObject);
+        ReelButton reelButton = new InfoButton(context, mediaObject, currentMediaIndex);
         String buttonText = str("piko_more_options");
 
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon,reelButton,buttonText);
@@ -76,7 +76,7 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    private static void addDebugButton(Context context, Object helperObject, Object mediaObject) {
+    private static void addDebugButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex) {
         String icon = UI.DRAWABLE_DEBUG_ICON;
         ReelButton reelButton = new DebugButton(context, mediaObject);
         String buttonText = str("piko_debug");
@@ -84,12 +84,11 @@ public class AddReelButton {
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon, reelButton, buttonText);
 
         AddReelButton.addReelButton(context, reelOverflowButton, helperObject);
-
     }
 
-    private static void addExternalDownloadButton(Context context, Object helperObject, Object mediaObject){
+    private static void addExternalDownloadButton(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         String icon = UI.DRAWABLE_DOWNLOAD_ICON;
-        ReelButton reelButton = new ExternalDownloadButton(context,mediaObject);
+        ReelButton reelButton = new ExternalDownloadButton(context, mediaObject, currentMediaIndex);
         String buttonText = str("piko_download_with_external_downloader");
 
         ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon,reelButton,buttonText);
@@ -97,18 +96,19 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
-    public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject){
+    // Called from hook — passes the real current carousel index.
+    public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject, int currentMediaIndex){
         if(Pref.pikoDebug()){
-            AddReelButton.addDebugButton(context, helperObject, mediaObject);
+            AddReelButton.addDebugButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.enableDownload()){
-            AddReelButton.addDownloadButton(context, helperObject, mediaObject);
+            AddReelButton.addDownloadButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.downloadWithExternalDownloader()){
-            AddReelButton.addExternalDownloadButton(context, helperObject, mediaObject);
+            AddReelButton.addExternalDownloadButton(context, helperObject, mediaObject, currentMediaIndex);
         }
         if(Pref.moreOptionsOnPost()){
-            AddReelButton.addInfoButton(context, helperObject, mediaObject);
+            AddReelButton.addInfoButton(context, helperObject, mediaObject, currentMediaIndex);
         }
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DebugButton.java
@@ -14,7 +14,7 @@ import app.morphe.extension.instagram.entity.MediaData;
 
 public class DebugButton extends ReelButton {
     public DebugButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+        super(context, mediaObject, 0);
     }
 
     @Override

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/DownloadButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 
 public class DownloadButton extends ReelButton {
-    public DownloadButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public DownloadButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        DownloadUtils.downloadPost(this.context, null, this.mediaObject, 0);
+        DownloadUtils.downloadPost(this.context, null, this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ExternalDownloadButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
 
 public class ExternalDownloadButton extends ReelButton {
-    public ExternalDownloadButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public ExternalDownloadButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        DownloadUtils.externalDownloader(this.mediaObject,0);
+        DownloadUtils.externalDownloader(this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/InfoButton.java
@@ -12,12 +12,12 @@ import android.content.Context;
 import app.morphe.extension.instagram.patches.feed.MoreOptionsOnPostPatch;
 
 public class InfoButton extends ReelButton {
-    public InfoButton(Context context, Object mediaObject) {
-        super(context, mediaObject);
+    public InfoButton(Context context, Object mediaObject, int currentMediaIndex) {
+        super(context, mediaObject, currentMediaIndex);
     }
 
     @Override
     public void onClick(View view) {
-        MoreOptionsOnPostPatch.postMoreOptions(this.context, null, this.mediaObject, 0);
+        MoreOptionsOnPostPatch.postMoreOptions(this.context, null, this.mediaObject, this.currentMediaIndex);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/ReelButton.java
@@ -13,10 +13,12 @@ import android.content.Context;
 public abstract class ReelButton implements View.OnClickListener {
     public final Context context;
     public final Object mediaObject;
+    public final int currentMediaIndex;
 
-    public ReelButton(Context context, Object mediaObject) {
+    public ReelButton(Context context, Object mediaObject, int currentMediaIndex) {
         this.context = context;
         this.mediaObject = mediaObject;
+        this.currentMediaIndex = currentMediaIndex;
     }
 
     // Every subclass will be forced to implement its own specific click logic

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/overflowMenuButton/reels/HookReelOverflowMenuButton.kt
@@ -6,6 +6,9 @@
 
 package app.crimera.patches.instagram.misc.overflowMenuButton.reels
 
+import app.crimera.patches.instagram.entity.decoder.CURRENT_MEDIA_FIELD
+import app.crimera.patches.instagram.entity.decoder.MEDIA_ADD_INFO_CLASS_NAME
+import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.misc.download.AddReelButtonFingerprint
 import app.crimera.patches.instagram.utils.Constants.ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
@@ -22,15 +25,18 @@ val hookReelOverflowMenuButton =
     bytecodePatch(
         description = "This patch hooks reel overflow button list adder",
     ) {
-        dependsOn(reelsOverflowMenuButtonEntity)
+        dependsOn(reelsOverflowMenuButtonEntity, decoderEntity)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
         execute {
             AddReelButtonFingerprint.method.apply {
                 val classDef = AddReelButtonFingerprint.classDef
-                val className = classDef.type
                 val classFields = classDef.fields
 
                 val appActivityField = classFields.first { it.type == FRAGMENT_ACTIVITY }
+
+                // Find the field that holds the MEDIA_ADD_INFO object on the reel controller.
+                // This is the same class used by the feed hook to get CURRENT_MEDIA_FIELD.
+                val mediaExtraDataField = classFields.firstOrNull { it.type == MEDIA_ADD_INFO_CLASS_NAME }
 
                 val selfClassRegister = instructions[indexOfFirstInstruction(Opcode.MOVE_OBJECT_FROM16)].registersUsed[0]
                 val buttonAdderInstanceRegister = instructions[indexOfFirstInstruction(Opcode.NEW_INSTANCE)].registersUsed[0]
@@ -39,15 +45,36 @@ val hookReelOverflowMenuButton =
                 val mediaObjectFromParameterIndex = indexOfFirstInstruction(sPutIndex, Opcode.MOVE_OBJECT_FROM16)
                 val mediaObjectRegister = instructions[mediaObjectFromParameterIndex].registersUsed[0]
 
+                // freeRegisterOne is used for scratch — it's set by CONST_4 after our injection
+                // point so it's safe to clobber before that instruction runs.
                 val freeRegisterOne = instructions[indexOfFirstInstruction(mediaObjectFromParameterIndex, Opcode.CONST_4)].registersUsed[0]
 
-                addInstructions(
-                    mediaObjectFromParameterIndex + 1,
-                    """
-                    iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
-                    invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;)V
-                    """.trimIndent(),
-                )
+                if (mediaExtraDataField != null) {
+                    // Safe two-register pattern: identical to how the feed onClick hook reads
+                    // CURRENT_MEDIA_FIELD.
+                    // Safe order:
+                    //   iget-object freeRegisterOne, selfClassRegister, mediaExtraDataField  <- read extra-data obj (selfClassRegister still intact)
+                    //   iget        freeRegisterOne, freeRegisterOne,   CURRENT_MEDIA_FIELD  <- overwrite with int (extra-data obj no longer needed)
+                    //   iget-object selfClassRegister, selfClassRegister, appActivityField   <- now clobber selfClassRegister with context
+                    //   invoke-static {selfClassRegister, buttonAdderInstanceRegister, mediaObjectRegister, freeRegisterOne}
+                    addInstructions(
+                        mediaObjectFromParameterIndex + 1,
+                        """
+                        iget-object v$freeRegisterOne, v$selfClassRegister, $mediaExtraDataField
+                        iget v$freeRegisterOne, v$freeRegisterOne, $CURRENT_MEDIA_FIELD
+                        iget-object v$selfClassRegister, v$selfClassRegister, $appActivityField
+                        invoke-static {v$selfClassRegister,v$buttonAdderInstanceRegister,v$mediaObjectRegister,v$freeRegisterOne},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;I)V
+                        """.trimIndent(),
+                    )
+                } else {
+                    addInstructions(
+                        mediaObjectFromParameterIndex + 1,
+                        """
+                        iget-object v$freeRegisterOne, v$selfClassRegister, $appActivityField
+                        invoke-static {v$freeRegisterOne,v$buttonAdderInstanceRegister,v$mediaObjectRegister},$ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS->includeCustomReelOverflowButtons(Landroid/content/Context;Ljava/lang/Object;Ljava/lang/Object;)V
+                        """.trimIndent(),
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
## Problem

When a reel post contains multiple images (carousel/slideshow), tapping the download button or any other overflow menu button (external downloader, more options) always operated on **slide 1**, regardless of which slide the user was currently viewing. The index was hardcoded to `0` in all `ReelButton` subclasses.

## Root Cause

The reel overflow button hook (`ClipsOrganicMediaItemViewMoreOptionsController`) did not pass the current carousel position to the extension. No index was read from the controller at hook time.

## Fix

The hook now reads `CURRENT_MEDIA_FIELD` from `MEDIA_ADD_INFO_CLASS_NAME` on the controller class — the same field and pattern already used by the feed onClick hook (`HookOverflowMenuButtonOnClickPatch`).

A safe three-instruction register sequence is used to avoid clobbering live registers (which caused a previous crash):

```
iget-object freeReg, self, mediaExtraDataField    ← read extra-data obj (self still intact)
iget        freeReg, freeReg, CURRENT_MEDIA_FIELD ← read int index (safe reuse of freeReg)
iget-object self,    self,    appActivityField    ← clobber self LAST, after all reads done
```

Falls back to index `0` via a 3-arg overload if `mediaExtraDataField` is not found on the controller class.

`hookReelOverflowMenuButton` now depends on `decoderEntity` to ensure `CURRENT_MEDIA_FIELD` and `MEDIA_ADD_INFO_CLASS_NAME` are resolved before the hook runs.

## Testing

Confirmed on a real device — downloading from slide 3 of a carousel reel correctly downloads slide 3. Single-video reels and the reel overflow bottom sheet are unaffected.

## Note

The consent popup fix (#1574, #1563) is handled separately in PR #1585 which introduces a dedicated `Disable onboarding permission prompts` patch.

Closes #1562
