### PR TITLE
fix(instagram): patch GRAY_1600 to fix Compose surfaces staying gray in AMOLED mode

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.opcode
+import app.morphe.patcher.patch.bytecodePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+
+// Thanks to instafel (https://github.com/mamiiblt/instafel) - GRAY_1600 is a
+// compiled constant in BasePrismColorsV2's <clinit>, not a color resource, so
+// the colors.xml overrides in ThemePatch.kt don't reach it. It's the
+// prism-black tone newer Compose screens use, so without this patch they stay
+// dark gray instead of pure black in AMOLED mode.
+private const val PRISM_COLORS_V2_CLASS = "Lcom/instagram/compose/core/theme/BasePrismColorsV2;"
+private const val GRAY_1600_FIELD_NAME = "GRAY_1600"
+private const val PURE_BLACK_LITERAL = "0xff000000L"
+
+// Matches the const-wide that feeds GRAY_1600's sput-wide directly: a
+// shl-long/2addr sits in between (packing the ARGB value into Compose's
+// internal 64-bit color representation), so MatchAfterWithin(1) allows for
+// exactly that one unmatched instruction and no more - this is what pins the
+// const-wide to the one immediately preceding GRAY_1600 specifically, instead
+// of matching the first const-wide in the method.
+internal object ComposePrismBlackFingerprint : Fingerprint(
+    definingClass = PRISM_COLORS_V2_CLASS,
+    name = "<clinit>",
+    filters = listOf(
+        opcode(Opcode.CONST_WIDE),
+        fieldAccess(
+            definingClass = PRISM_COLORS_V2_CLASS,
+            name = GRAY_1600_FIELD_NAME,
+            opcode = Opcode.SPUT_WIDE,
+            location = InstructionLocation.MatchAfterWithin(1),
+        ),
+    ),
+)
+
+internal val composePrismBlackPatch =
+    bytecodePatch(
+        name = "Fix Compose prism black",
+        description = "Rewrites the GRAY_1600 constant in BasePrismColorsV2 so newer " +
+            "Compose-based screens render true black instead of Instagram's stock dark " +
+            "gray prism tone. Required for the AMOLED theme option in the Theme patch " +
+            "to look correct on those screens.",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            val constWideMatch = ComposePrismBlackFingerprint.instructionMatches[0]
+            val register = (constWideMatch.instruction as OneRegisterInstruction).registerA
+
+            ComposePrismBlackFingerprint.method.replaceInstruction(
+                constWideMatch.index,
+                "const-wide v$register, $PURE_BLACK_LITERAL",
+            )
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
@@ -47,7 +47,6 @@ internal object ComposePrismBlackFingerprint : Fingerprint(
 
 internal val composePrismBlackPatch =
     bytecodePatch(
-        name = "Fix Compose prism black",
         description = "Rewrites the GRAY_1600 constant in BasePrismColorsV2 so newer " +
             "Compose-based screens render true black instead of Instagram's stock dark " +
             "gray prism tone. Required for the AMOLED theme option in the Theme patch " +

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -7,19 +7,10 @@
 package app.crimera.patches.instagram.misc.theme
 
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
-import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
-import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.ResourcePatchContext
-import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.util.findElementByAttributeValueOrThrow
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
-import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
-import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.FileWriter
@@ -47,62 +38,13 @@ val themePatch =
         )
 
         
-        dependsOn(
-            bytecodePatch {
-                compatibleWith(COMPATIBILITY_INSTAGRAM)
-
-                execute { patchGray1600() }
-            }
-        )
+        dependsOn(composePrismBlackPatch)
 
         execute {
             forceWhiteOnMediaChrome()
             if (amoled == true) applyAmoledTheme() else applyMaterialYouTheme()
         }
     }
-
-// Thanks to instafel (https://github.com/mamiiblt/instafel) - GRAY_1600 is a
-// compiled constant in BasePrismColorsV2's <clinit>, not a color resource, so
-// the colors.xml overrides above don't reach it. It's the prism-black tone
-// newer Compose screens use, so without this patch they stay dark gray
-// instead of pure black in AMOLED mode.
-private const val PRISM_COLORS_V2_CLASS = "Lcom/instagram/compose/core/theme/BasePrismColorsV2;"
-private const val GRAY_1600_FIELD_NAME = "GRAY_1600"
-private const val PURE_BLACK_LITERAL = "0xff000000L"
-
-internal object BasePrismColorsV2ClinitFingerprint : Fingerprint(
-    custom = { method, classDef ->
-        classDef.type == PRISM_COLORS_V2_CLASS && method.name == "<clinit>"
-    },
-)
-
-context(context: BytecodePatchContext)
-private fun patchGray1600(): Boolean {
-    BasePrismColorsV2ClinitFingerprint.method.apply {
-        val sputIndex = instructions.indexOfFirst { instruction ->
-            instruction.opcode == Opcode.SPUT_WIDE &&
-                (instruction as? ReferenceInstruction)?.reference
-                    ?.let { it as? FieldReference }
-                    ?.let { it.definingClass == PRISM_COLORS_V2_CLASS && it.name == GRAY_1600_FIELD_NAME } == true
-        }
-
-        if (sputIndex == -1) return false
-
-        for (index in sputIndex - 1 downTo 0) {
-            val instruction = instructions[index]
-
-            if (instruction.opcode == Opcode.CONST_WIDE) {
-                val register = (instruction as OneRegisterInstruction).registerA
-                replaceInstruction(index, "const-wide v$register, $PURE_BLACK_LITERAL")
-                return true
-            }
-
-            if (instruction.opcode == Opcode.SPUT_WIDE) break
-        }
-    }
-
-    return false
-}
 
 // On-media chrome — the feed post header (username / subtitle / follow / ⋯ menu),
 // "Watch again" and similar labels drawn over photos/video — resolves through

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -7,10 +7,19 @@
 package app.crimera.patches.instagram.misc.theme
 
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.ResourcePatchContext
+import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.patcher.patch.booleanOption
 import app.morphe.util.findElementByAttributeValueOrThrow
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 import java.io.FileWriter
@@ -37,11 +46,63 @@ val themePatch =
                 "colours in both modes.",
         )
 
+        
+        dependsOn(
+            bytecodePatch {
+                compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+                execute { patchGray1600() }
+            }
+        )
+
         execute {
             forceWhiteOnMediaChrome()
             if (amoled == true) applyAmoledTheme() else applyMaterialYouTheme()
         }
     }
+
+// Thanks to instafel (https://github.com/mamiiblt/instafel) - GRAY_1600 is a
+// compiled constant in BasePrismColorsV2's <clinit>, not a color resource, so
+// the colors.xml overrides above don't reach it. It's the prism-black tone
+// newer Compose screens use, so without this patch they stay dark gray
+// instead of pure black in AMOLED mode.
+private const val PRISM_COLORS_V2_CLASS = "Lcom/instagram/compose/core/theme/BasePrismColorsV2;"
+private const val GRAY_1600_FIELD_NAME = "GRAY_1600"
+private const val PURE_BLACK_LITERAL = "0xff000000L"
+
+internal object BasePrismColorsV2ClinitFingerprint : Fingerprint(
+    custom = { method, classDef ->
+        classDef.type == PRISM_COLORS_V2_CLASS && method.name == "<clinit>"
+    },
+)
+
+context(context: BytecodePatchContext)
+private fun patchGray1600(): Boolean {
+    BasePrismColorsV2ClinitFingerprint.method.apply {
+        val sputIndex = instructions.indexOfFirst { instruction ->
+            instruction.opcode == Opcode.SPUT_WIDE &&
+                (instruction as? ReferenceInstruction)?.reference
+                    ?.let { it as? FieldReference }
+                    ?.let { it.definingClass == PRISM_COLORS_V2_CLASS && it.name == GRAY_1600_FIELD_NAME } == true
+        }
+
+        if (sputIndex == -1) return false
+
+        for (index in sputIndex - 1 downTo 0) {
+            val instruction = instructions[index]
+
+            if (instruction.opcode == Opcode.CONST_WIDE) {
+                val register = (instruction as OneRegisterInstruction).registerA
+                replaceInstruction(index, "const-wide v$register, $PURE_BLACK_LITERAL")
+                return true
+            }
+
+            if (instruction.opcode == Opcode.SPUT_WIDE) break
+        }
+    }
+
+    return false
+}
 
 // On-media chrome — the feed post header (username / subtitle / follow / ⋯ menu),
 // "Watch again" and similar labels drawn over photos/video — resolves through

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -31,10 +31,7 @@ val themePatch =
             title = "Pure-black AMOLED theme",
             description = "By default this patch applies a Material You dynamic theme that " +
                 "follows your device's light/dark setting. Turn this on to override it " +
-                "with a pure-black AMOLED theme instead. " +
-                "Note: a few server-driven pages (notifications, DM inbox, " +
-                "About-this-account) and full-screen media/Reels keep Instagram's own " +
-                "colours in both modes.",
+                "with a pure-black AMOLED theme instead.",
         )
 
         
@@ -55,11 +52,35 @@ val themePatch =
 // attributes themselves straight to white, leaving the shared surface leaf intact.
 // On-media chrome sits over media (arbitrary/dark), so white is correct in every
 // theme. Guarded so a missing/undecoded styles.xml can never fail the build.
+// muteIconPrimaryColor: same on-media conflict as the igds_* attrs above,
+// just under IG's own naming (not bds_/igds_). Two style blocks define it
+// with fixed mid-greys (grey_14/grey_15) that had adequate contrast against
+// the original audio-bar pill background — but igds_prism_gray_08 (that pill's
+// background) is remapped to piko_dynamic_prism_black below, so the icon
+// needs to be forced white too, like the rest of on-media chrome.
 private val onMediaChromeAttrs =
     setOf(
         "igds_color_primary_text_on_media",
         "igds_color_icon_on_media",
         "igds_color_primary_button_on_media",
+        "muteIconPrimaryColor",
+    )
+
+// SmartCapture (the Stories/Reels camera UI) has its own on-media attribute
+// namespace (sc_*) that ALSO conflicts through abc_decor_view_status_guard_light
+// in some style blocks (e.g. IgSmartCaptureTheme, SmartCapture) - same underlying
+// bug as onMediaChromeAttrs above. Unlike those igds_* attrs (always bds_white
+// wherever they appear), these sc_* names are reused with genuinely different,
+// intentional values elsewhere (e.g. SmartCapture.Selfie.Ig.Dark deliberately
+// uses a darker sc_fds_gray_90 for that one selfie sub-mode), so this can't be a
+// blanket by-name replace like onMediaChromeAttrs - it has to match by the
+// CURRENT value instead, only touching the specific instances that still point
+// at the conflicted background resource.
+private val onMediaAttrsPointingAtGuardLight =
+    setOf(
+        "sc_primary_icon_on_media",
+        "sc_primary_text_on_media",
+        "sc_always_white",
     )
 
 private fun ResourcePatchContext.forceWhiteOnMediaChrome() {
@@ -73,7 +94,14 @@ private fun ResourcePatchContext.forceWhiteOnMediaChrome() {
                 val items = document.getElementsByTagName("item")
                 for (index in 0 until items.length) {
                     val item = items.item(index) as? Element ?: continue
-                    if (onMediaChromeAttrs.contains(item.getAttribute("name"))) {
+                    val name = item.getAttribute("name")
+
+                    if (onMediaChromeAttrs.contains(name)) {
+                        item.textContent = "@color/bds_white"
+                    } else if (
+                        onMediaAttrsPointingAtGuardLight.contains(name) &&
+                        item.textContent == "@color/abc_decor_view_status_guard_light"
+                    ) {
                         item.textContent = "@color/bds_white"
                     }
                 }
@@ -450,7 +478,13 @@ private val materialYouSurfaceBaselineMappings =
         "igds_prism_gray_09_alpha_95" to "@color/piko_dynamic_prism_black",
         "igds_prism_gray_10_alpha_95" to "@color/piko_dynamic_prism_black",
         "bds_grey_9_95_transparent" to "@color/piko_dynamic_prism_black",
-        "bds_grey_10_80_transparent" to "@color/piko_dynamic_prism_black",
+        // bds_grey_10_80_transparent is intentionally EXCLUDED from this flatten:
+        // it's shared with igds_secondary_button_on_media (the reel "watch again"
+        // pill and similar on-media buttons), which needs to stay translucent over
+        // arbitrary media. Flattening it turned that pill into a solid opaque black
+        // block instead of a translucent overlay. igds_creation_menu_background,
+        // the other consumer of this literal, already gets its own direct override
+        // above, so it's unaffected by leaving this literal alone.
         "bds_grey_10_90_transparent" to "@color/piko_dynamic_prism_black",
         // LIGHT-mode counterparts of the dark surface leaves above (all confirmed
         // present in the 435.x resource table). In light mode Instagram resolves the


### PR DESCRIPTION
AMOLED theme only overrode colors.xml, but newer Compose screens read
their dark surface color from GRAY_1600, a compiled constant inside
BasePrismColorsV2's <clinit> - not a resource, so those overrides never
reached it, leaving some screens dark gray instead of black.

Added a bytecode patch that finds BasePrismColorsV2's <clinit> via a
Fingerprint and rewrites the constant to pure black (0xff000000L).
Wired into the Theme patch via dependsOn.

Credit: instafel (https://github.com/mamiiblt/instafel) for identifying
GRAY_1600 as the missing piece.

<img width="400" alt="..." src="https://github.com/user-attachments/assets/1c7ec42d-4190-459d-86ca-0079e787e9e9" /> <img width="400" alt="..." src="https://github.com/user-attachments/assets/0a310bf4-2ecc-4c6e-8933-240da1f6a4b0" />


