### PR TITLE
fix(Instagram): Resolve bytecode verifier crashes

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -90,7 +90,6 @@ public class ActionBarPatch {
         }
     }
 
-    //TO-DO: Fix user profile action bar.
     public static void userProfileActionBarButton(ViewGroup viewGroup, UserSession userSession, Object userObject){
         try {
             if (viewGroup == null) {
@@ -102,10 +101,6 @@ public class ActionBarPatch {
             UserData userData = new UserData(userObject);
             Boolean isSelfProfile = userData.getUserId().equals(userSession.getUserId());
 
-            if(pref.contains(Constants.AB_SETTINGS_ICON) && isSelfProfile) {
-                UI.pikoSettingsGear(viewGroup);
-            }
-
             if(pref.contains(Constants.AB_GHOST_MODE_ICON) && isSelfProfile) {
                 ghostModeToggle(viewGroup);
             }
@@ -113,6 +108,10 @@ public class ActionBarPatch {
             if(pref.contains(Constants.AB_PROFILE_INFO_ICON)) {
                 Context context = viewGroup.getContext();
                 UI.addImageViewToViewGroup(viewGroup, UI.DRAWABLE_INFO_ICON, () -> ProfileMoreOption.moreOptionsDailogueBox(context, userData));
+            }
+
+            if(pref.contains(Constants.AB_SETTINGS_ICON) && isSelfProfile) {
+                UI.pikoSettingsGear(viewGroup);
             }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/userprofile/UserProfileButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/userprofile/UserProfileButton.java
@@ -40,9 +40,7 @@ public class UserProfileButton {
             ProfileInfo profileInfo = new ProfileInfo(object);
             Boolean isSelfProfile = profileInfo.isSelfProfile();
 
-//            if (!isSettingsInActionBar && isSelfProfile){
-            //TO-DO: Fix user profile action bar.
-            if (isSelfProfile){
+            if (!isSettingsInActionBar && isSelfProfile){
                 UI.pikoSettingsButton(viewGroup);
             }
             if(!userProfileABPref.contains(Constants.AB_PROFILE_INFO_ICON) && Pref.isMoreOptionsOnProfilePatched()){

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/inboxActionBarButton/InboxActionBarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/inboxActionBarButton/InboxActionBarButtonPatch.kt
@@ -40,7 +40,7 @@ val inboxActionBarButtonPatch =
                     if (typeRef == "Lcom/instagram/igds/components/actionbar/IgdsActionBar;") {
                         val viewGroupRegister = it.registersUsed[0]
                         addInstructions(
-                            it.location.index,
+                            it.location.index + 1,
                             """
                             invoke-static {v$viewGroupRegister}, $ACTIONBAR_DESCRIPTOR->inboxActionBarButton(Landroid/view/ViewGroup;)V
                             """.trimIndent(),

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/userProfileActionBarButton/UserProfileActionBarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/userProfileActionBarButton/UserProfileActionBarButtonPatch.kt
@@ -14,19 +14,56 @@ import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.USER_DETAIL_VIEW_MODEL_CLASS
 import app.crimera.patches.instagram.utils.Constants.USER_SESSION_CLASS
 import app.crimera.patches.instagram.utils.addFlags
-import app.crimera.utils.methodExtractor
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableField
 import app.morphe.patcher.util.smali.ExternalLabel
-import app.morphe.util.findFreeRegister
-import app.morphe.util.indexOfFirstInstruction
+import app.morphe.util.getFreeRegisterProvider
+import app.morphe.util.getReference
+import app.morphe.util.indexOfFirstInstructionOrThrow
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.Method
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val IG_LINEAR_LAYOUT_CLASS = "Lcom/instagram/common/ui/base/IgLinearLayout;"
+
+internal fun findProfileActionBarBuilderInvocation(
+    candidates: List<IndexedValue<MethodReference>>,
+    expectedParameterTypes: List<String>,
+    methodsInDefiningClass: (String) -> Iterable<Method>,
+): IndexedValue<MethodReference> {
+    val matchingCandidates =
+        candidates.filter { candidate ->
+            candidate.value.parameterTypes == expectedParameterTypes &&
+                candidate.value.returnType == "V"
+        }
+    val candidate =
+        matchingCandidates.singleOrNull()
+            ?: throw PatchException(
+                "Expected exactly one profile action bar builder invocation, found ${matchingCandidates.size}",
+            )
+    val reference = candidate.value
+    val matchingDefinitions =
+        methodsInDefiningClass(reference.definingClass).filter { method ->
+            method.definingClass == reference.definingClass &&
+                method.name == reference.name &&
+                method.parameterTypes == expectedParameterTypes &&
+                method.returnType == "V" &&
+                AccessFlags.STATIC.isSet(method.accessFlags)
+        }
+
+    if (matchingDefinitions.count() != 1) {
+        throw PatchException("Expected exactly one matching method in the profile action bar builder class")
+    }
+
+    return candidate
+}
 
 internal object ProfileActionBarRelatedFingerprint : Fingerprint(
     strings = listOf("notifications_entry_point_impression", "impression_cast_to_tv"),
@@ -54,59 +91,127 @@ val userProfileActionBarButtonPatch =
         dependsOn(decoderEntity)
 
         execute {
-
-            val actionBarRelatedClass: String
             val profileHeaderFieldInActionBarRelatedClass: MutableField
 
             ProfileActionBarRelatedFingerprint.apply {
-                actionBarRelatedClass = classDef.type
+                val matchingFields = classDef.fields.filter { it.type == ProfileHeaderRelatedFingerprint.classDef.type }
                 profileHeaderFieldInActionBarRelatedClass =
-                    classDef.fields.first { it.type == ProfileHeaderRelatedFingerprint.classDef.type }
+                    matchingFields.singleOrNull()
+                        ?: throw PatchException(
+                            "Expected exactly one profile header field in the action bar related class, found ${matchingFields.size}",
+                        )
             }
 
-            val userDetailViewModelFieldInProfileHeaderRelatedClass: MutableField =
-                ProfileHeaderRelatedFingerprint.classDef.fields.first {
+            val userDetailViewModelFields =
+                ProfileHeaderRelatedFingerprint.classDef.fields.filter {
                     it.type == USER_DETAIL_VIEW_MODEL_CLASS
                 }
+            val userDetailViewModelFieldInProfileHeaderRelatedClass: MutableField =
+                userDetailViewModelFields.singleOrNull()
+                    ?: throw PatchException(
+                        "Expected exactly one user detail view model field in the profile header class, found ${userDetailViewModelFields.size}",
+                    )
 
             val userDetailsClassFields = classDefBy { it.type == USER_DETAIL_VIEW_MODEL_CLASS }.fields
 
-            val userDataFieldInUserDetailClass = userDetailsClassFields.first { it.type == USER_MODEL_CLASS_NAME }
+            val userDataFields = userDetailsClassFields.filter { it.type == USER_MODEL_CLASS_NAME }
+            val userDataFieldInUserDetailClass =
+                userDataFields.singleOrNull()
+                    ?: throw PatchException(
+                        "Expected exactly one user model field in the user detail view model, found ${userDataFields.size}",
+                    )
 
             ProfileActionBarFingerprint.method.apply {
-                val actionBarRelatedObjectParameterRegister =
-                    parameters.indexOfFirst {
-                        it.type ==
-                            ProfileActionBarRelatedFingerprint.classDef.type
-                    } + 1
-                val userSessionParameterRegister = parameters.indexOfFirst { it.type == USER_SESSION_CLASS }
+                if (AccessFlags.STATIC.isSet(accessFlags)) {
+                    throw PatchException("Expected the profile action bar method to be an instance method")
+                }
 
-                val profileActionBarIconInjectMethodIndex = instructions.last { it.opcode == Opcode.INVOKE_STATIC_RANGE }.location.index
-                val layoutRegister = getInstruction(profileActionBarIconInjectMethodIndex - 1).registersUsed[0]
-                val nextReturnVoidIndex = indexOfFirstInstruction(profileActionBarIconInjectMethodIndex, Opcode.RETURN_VOID)
-                val freeRegister = 3
-                val freeRegister2 = 4
-                val freeRegister3 = 5
-                val CODE =
+                fun parameterRegister(type: String): Int {
+                    val matches = parameters.withIndex().filter { it.value.type == type }
+                    return matches.singleOrNull()?.index?.plus(1)
+                        ?: throw PatchException(
+                            "Expected exactly one $type parameter in the profile action bar method, found ${matches.size}",
+                        )
+                }
+
+                val actionBarRelatedObjectParameterRegister =
+                    parameterRegister(ProfileActionBarRelatedFingerprint.classDef.type)
+                val userSessionParameterRegister = parameterRegister(USER_SESSION_CLASS)
+
+                val expectedBuilderParameterTypes =
+                    listOf(
+                        "Landroid/app/Activity;",
+                        "Landroid/content/Context;",
+                        USER_SESSION_CLASS,
+                        IG_LINEAR_LAYOUT_CLASS,
+                        IG_LINEAR_LAYOUT_CLASS,
+                        ProfileActionBarRelatedFingerprint.classDef.type,
+                        "Ljava/util/List;",
+                        "Lkotlin/jvm/functions/Function1;",
+                    )
+                val profileActionBarBuilderInvocation =
+                    findProfileActionBarBuilderInvocation(
+                        candidates =
+                            instructions.mapIndexedNotNull { index, instruction ->
+                                if (instruction.opcode != Opcode.INVOKE_STATIC_RANGE) {
+                                    null
+                                } else {
+                                    instruction.getReference<MethodReference>()?.let { IndexedValue(index, it) }
+                                }
+                            },
+                        expectedParameterTypes = expectedBuilderParameterTypes,
+                        methodsInDefiningClass = { definingClass ->
+                            classDefBy { it.type == definingClass }.methods
+                        },
+                    )
+                val profileActionBarIconInjectMethodIndex = profileActionBarBuilderInvocation.index
+                val profileActionBarBuilderInstruction = getInstruction(profileActionBarIconInjectMethodIndex)
+                val profileActionBarBuilderReference = profileActionBarBuilderInvocation.value
+                val layoutParameterIndices =
+                    profileActionBarBuilderReference.parameterTypes.withIndex().filter {
+                        it.value == IG_LINEAR_LAYOUT_CLASS
+                    }
+                if (layoutParameterIndices.size != 2) {
+                    throw PatchException(
+                        "Expected two profile action bar layout parameters, found ${layoutParameterIndices.size}",
+                    )
+                }
+
+                val builderRegisters = profileActionBarBuilderInstruction.registersUsed
+                if (builderRegisters.size != profileActionBarBuilderReference.parameterTypes.size) {
+                    throw PatchException("Profile action bar builder register count does not match its parameters")
+                }
+                val layoutRegister = builderRegisters[layoutParameterIndices.last().index]
+                val nextReturnVoidIndex =
+                    indexOfFirstInstructionOrThrow(profileActionBarIconInjectMethodIndex, Opcode.RETURN_VOID)
+                val freeRegisterProvider =
+                    getFreeRegisterProvider(
+                        index = profileActionBarIconInjectMethodIndex + 1,
+                        numberOfFreeRegistersNeeded = 3,
+                        layoutRegister,
+                    )
+                val userObjectRegister = freeRegisterProvider.getFreeRegister()
+                val userSessionRegister = freeRegisterProvider.getFreeRegister()
+                val layoutCopyRegister = freeRegisterProvider.getFreeRegister()
+                val code =
                     """
-                    move-object/from16 v$freeRegister, p$actionBarRelatedObjectParameterRegister
-                            if-eqz v$actionBarRelatedObjectParameterRegister, :piko
-                            iget-object v$freeRegister, v$actionBarRelatedObjectParameterRegister, $profileHeaderFieldInActionBarRelatedClass
-                            
-                            if-eqz v$freeRegister, :piko
-                            iget-object v$freeRegister,v$freeRegister, $userDetailViewModelFieldInProfileHeaderRelatedClass
-                            
-                            if-eqz v$freeRegister, :piko
-                            iget-object v$freeRegister,v$freeRegister, $userDataFieldInUserDetailClass
-                            move-object/from16 v$freeRegister2, p$userSessionParameterRegister
-                            move-object/from16 v$freeRegister3, v$layoutRegister
-                            invoke-static {v$freeRegister3, v$freeRegister2, v$freeRegister}, $ACTIONBAR_DESCRIPTOR->userProfileActionBarButton(Landroid/view/ViewGroup;${USER_SESSION_CLASS}Ljava/lang/Object;)V
-                            return-void
+                    move-object/from16 v$userObjectRegister, p$actionBarRelatedObjectParameterRegister
+                    if-eqz v$userObjectRegister, :piko
+                    iget-object v$userObjectRegister, v$userObjectRegister, $profileHeaderFieldInActionBarRelatedClass
+
+                    if-eqz v$userObjectRegister, :piko
+                    iget-object v$userObjectRegister, v$userObjectRegister, $userDetailViewModelFieldInProfileHeaderRelatedClass
+
+                    if-eqz v$userObjectRegister, :piko
+                    iget-object v$userObjectRegister, v$userObjectRegister, $userDataFieldInUserDetailClass
+                    move-object/from16 v$userSessionRegister, p$userSessionParameterRegister
+                    move-object/from16 v$layoutCopyRegister, v$layoutRegister
+                    invoke-static {v$layoutCopyRegister, v$userSessionRegister, v$userObjectRegister}, $ACTIONBAR_DESCRIPTOR->userProfileActionBarButton(Landroid/view/ViewGroup;${USER_SESSION_CLASS}Ljava/lang/Object;)V
                     """.trimIndent()
 
                 addInstructionsWithLabels(
                     profileActionBarIconInjectMethodIndex + 1,
-                    CODE,
+                    code,
                     ExternalLabel("piko", getInstruction(nextReturnVoidIndex)),
                 )
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/userProfile/ProfileMoreOptionsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/userProfile/ProfileMoreOptionsPatch.kt
@@ -18,7 +18,7 @@ val profileMoreOptionsPatch =
         name = "More options on profile",
         description = "Adds a new button to handle user related data like copy handle, download profile picture etc",
     ) {
-        dependsOn(settingsPatch, userProfileButtonPatch)
+        dependsOn(settingsPatch, userProfileButtonPatch, userProfileActionBarButtonPatch)
 
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 


### PR DESCRIPTION
Fixes multiple issues occurring in instagram 439.0.0.37.89 patched with piko 3.9.0-dev.1. the inbox crash occurred because the action bar hook ran before `CHECK_CAST` established the register as an `IgdsActionBar`, causing the verifier to reject a `View` passed as a `ViewGroup`. the profile crash occurred because the friendship status patch skipped a required integer initialization, leaving a register typed as a `String` where an integer was expected. moves the inbox hook after the required type conversion and preserves the integer initialization before bypassing the internal badge checks. restores the profile action bar hook after instagram's action bar builder and validates the target method, required fields, parameters, and registers before injection. the profile action bar dependency and settings fallback behavior are also restored.

## Testing
- `.\gradlew.bat :patches:check --rerun-tasks --console=plain`
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain`
- Tested on Instagram 439.0.0.37.89 with Piko 3.9.0-dev.1
- Tested on Samsung Galaxy S26

Closes #1592 , #1601