### PR TITLE
fix(instagram): inject inboxActionBarButton after CHECK_CAST to fix VerifyError on 439

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/inboxActionBarButton/InboxActionBarButtonPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/actionBar/inboxActionBarButton/InboxActionBarButtonPatch.kt
@@ -10,11 +10,9 @@ import app.crimera.patches.instagram.utils.Constants.ACTIONBAR_DESCRIPTOR
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.utils.getReference
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.string
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
 import app.morphe.util.getReference
 import app.morphe.util.registersUsed
@@ -35,12 +33,16 @@ val inboxActionBarButtonPatch =
         execute {
 
             InboxActionBarBuilderFingerprint.method.apply {
+                // Inject AFTER the CHECK_CAST so the register is already typed as
+                // IgdsActionBar (a ViewGroup subtype) by the verifier. Injecting before
+                // the cast leaves the register typed as raw View, which causes a
+                // VerifyError on X.08PF (DirectInboxFragment) at runtime.
                 instructions.filter { it.opcode == Opcode.CHECK_CAST }.firstOrNull {
-                    val typeRef = it.getReference<TypeReference>()!!.type
+                    val typeRef = it.getReference<TypeReference>()?.type
                     if (typeRef == "Lcom/instagram/igds/components/actionbar/IgdsActionBar;") {
                         val viewGroupRegister = it.registersUsed[0]
-                        addInstructions(
-                            it.location.index,
+                        addInstruction(
+                            it.location.index + 1,
                             """
                             invoke-static {v$viewGroupRegister}, $ACTIONBAR_DESCRIPTOR->inboxActionBarButton(Landroid/view/ViewGroup;)V
                             """.trimIndent(),


### PR DESCRIPTION
## Problem

On Instagram **439.0.0.37.89** (Android 16 / SDK 36), the app crashes immediately when navigating to Direct Inbox:

\\\
java.lang.VerifyError: Verifier rejected class X.08PF:
  android.view.View X.08PF.onCreateView(...) failed to verify:
  register v9 has type Reference: android.view.View
  but expected Reference: android.view.ViewGroup
\\\

## Root cause

\InboxActionBarButtonPatch\ injects the \inboxActionBarButton\ call at \it.location.index\ — **before** the \CHECK_CAST to IgdsActionBar\ executes. At that point the register still holds the raw \ndroid.view.View\ returned by \LayoutInflater.inflate()\.

The DEX verifier (ART, SDK 36) sees that register being passed where a \ViewGroup\ is declared, and rejects the entire \X.08PF\ (DirectInboxFragment) class.

## Fix

Inject at \index + 1\ (after the cast), so the register is already typed as \IgdsActionBar\ — a \ViewGroup\ subclass — when the verifier inspects it.

This is exactly the same pattern \ChatActionBarButtonPatch\ already uses (with an explicit comment explaining why).

## Tested on
- Instagram \439.0.0.37.89\ / Android 16 / SDK 36 (iQOO device)