### PR TITLE
fix(twitter): show sensitive media #1572

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
@@ -20,7 +20,7 @@ import app.morphe.extension.crimera.PikoUtils;
 public class TimelineEntry {
     public static final boolean hideAds;
     private static final boolean hideWTF,hideCTS,hideCTJ,hideDetailedPosts,hideRBMK,hidePinnedPosts,hidePremiumPrompt,showSensitiveMedia,hideTopPeopleSearch,hideTodaysNews;
-    private static final Field mediaVisibility;
+    private static Field mediaVisibility;
 
     static {
         hideAds = (Pref.hideAds() && SettingsStatus.hideAds);
@@ -34,7 +34,6 @@ public class TimelineEntry {
         showSensitiveMedia = Pref.showSensitiveMedia();
         hideTopPeopleSearch = (Pref.hideTopPeopleSearch() && SettingsStatus.hideTopPeopleSearch);
         hideTodaysNews = (Pref.hideTodaysNews() && SettingsStatus.hideTodaysNews);
-        mediaVisibility = getFieldMediaVisibility();
     }
 
     private static boolean isEntryIdRemove(String entryId) {
@@ -105,9 +104,13 @@ public class TimelineEntry {
         }
         return jsonTimelineModuleItem;
     }
-    public static JsonTweetWithVisibilityResults sensitiveMedia(JsonTweetWithVisibilityResults jsonTweetWithVisibilityResults) {
+    public static JsonTweetWithVisibilityResults sensitiveMedia(JsonTweetWithVisibilityResults jsonTweetWithVisibilityResults, String fieldName) {
         try {
-            if (showSensitiveMedia && mediaVisibility != null) {
+            if (showSensitiveMedia) {
+                if (mediaVisibility == null) {
+                    mediaVisibility = jsonTweetWithVisibilityResults.getClass().getDeclaredField(fieldName);
+                    mediaVisibility.setAccessible(true);
+                }
                 mediaVisibility.set(jsonTweetWithVisibilityResults, null);
             }
         } catch (Exception unused) {
@@ -149,16 +152,6 @@ public class TimelineEntry {
         }
 
         return videoEnities;
-    }
-    private static final Field getFieldMediaVisibility() {
-        Field[] fields = JsonTweetWithVisibilityResults.class.getDeclaredFields();
-
-        for (Field field : fields) {
-            if (field.getType().getName().indexOf("model.mediavisibility") != -1) {
-                return field;
-            }
-        }
-        return null;
     }
 //end
 }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
@@ -6,12 +6,13 @@
 
 package app.morphe.extension.twitter.patches;
 
+import com.twitter.model.json.core.JsonTweetWithVisibilityResults;
 import com.twitter.model.json.timeline.urt.JsonTimelineEntry;
-import com.twitter.model.json.core.JsonSensitiveMediaWarning;
 import com.twitter.model.json.timeline.urt.JsonTimelineModuleItem;
 import app.morphe.extension.twitter.Pref;
 import app.morphe.extension.twitter.settings.SettingsStatus;
 import app.morphe.extension.twitter.entity.Video;
+import java.lang.reflect.Field;
 import java.util.List;
 import java.util.ArrayList;
 import app.morphe.extension.crimera.PikoUtils;
@@ -19,6 +20,8 @@ import app.morphe.extension.crimera.PikoUtils;
 public class TimelineEntry {
     public static final boolean hideAds;
     private static final boolean hideWTF,hideCTS,hideCTJ,hideDetailedPosts,hideRBMK,hidePinnedPosts,hidePremiumPrompt,showSensitiveMedia,hideTopPeopleSearch,hideTodaysNews;
+    private static final Field mediaVisibility;
+
     static {
         hideAds = (Pref.hideAds() && SettingsStatus.hideAds);
         hideWTF = (Pref.hideWTF() && SettingsStatus.hideWTF);
@@ -31,6 +34,7 @@ public class TimelineEntry {
         showSensitiveMedia = Pref.showSensitiveMedia();
         hideTopPeopleSearch = (Pref.hideTopPeopleSearch() && SettingsStatus.hideTopPeopleSearch);
         hideTodaysNews = (Pref.hideTodaysNews() && SettingsStatus.hideTodaysNews);
+        mediaVisibility = getFieldMediaVisibility();
     }
 
     private static boolean isEntryIdRemove(String entryId) {
@@ -101,17 +105,15 @@ public class TimelineEntry {
         }
         return jsonTimelineModuleItem;
     }
-    public static JsonSensitiveMediaWarning sensitiveMedia(JsonSensitiveMediaWarning jsonSensitiveMediaWarning) {
+    public static JsonTweetWithVisibilityResults sensitiveMedia(JsonTweetWithVisibilityResults jsonTweetWithVisibilityResults) {
         try {
-            if(showSensitiveMedia){
-                jsonSensitiveMediaWarning.a = false;
-                jsonSensitiveMediaWarning.b = false;
-                jsonSensitiveMediaWarning.c = false;
+            if (showSensitiveMedia && mediaVisibility != null) {
+                mediaVisibility.set(jsonTweetWithVisibilityResults, null);
             }
         } catch (Exception unused) {
 
         }
-        return jsonSensitiveMediaWarning;
+        return jsonTweetWithVisibilityResults;
     }
     public static boolean hidePromotedTrend(Object data) {
         if (data != null && hideAds) {
@@ -136,7 +138,7 @@ public class TimelineEntry {
                     maxVideoObject = vidObj;
                 }
                 if (maxVideoObject != null) {
-                    ArrayList result = new ArrayList();
+                    ArrayList<Object> result = new ArrayList<>();
                     result.add(maxVideoObject);
                     return result;
                 }
@@ -148,6 +150,15 @@ public class TimelineEntry {
 
         return videoEnities;
     }
+    private static final Field getFieldMediaVisibility() {
+        Field[] fields = JsonTweetWithVisibilityResults.class.getDeclaredFields();
 
+        for (Field field : fields) {
+            if (field.getType().getName().indexOf("model.mediavisibility") != -1) {
+                return field;
+            }
+        }
+        return null;
+    }
 //end
 }

--- a/extensions/twitter/stub/src/main/java/com/twitter/model/json/core/JsonTweetWithVisibilityResults.java
+++ b/extensions/twitter/stub/src/main/java/com/twitter/model/json/core/JsonTweetWithVisibilityResults.java
@@ -1,0 +1,4 @@
+package com.twitter.model.json.core;
+
+public class JsonTweetWithVisibilityResults {
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -19,7 +19,7 @@ import com.android.tools.smali.dexlib2.Opcode
 // Credits to @Cradlesofashes
 
 private object sensitiveMediaSettingsPatchFingerprint : Fingerprint(
-    definingClass = "Lcom/twitter/model/json/core/JsonSensitiveMediaWarning\$\$JsonObjectMapper;",
+    definingClass = "Lcom/twitter/model/json/core/JsonTweetWithVisibilityResults\$\$JsonObjectMapper;",
     name = "parse",
     returnType = "Ljava/lang/Object",
 )
@@ -43,7 +43,7 @@ val sensitiveMediaPatch =
             methods.addInstructions(
                 returnObj,
                 """
-                invoke-static {p1}, $TIMELINE_ENTRY_DESCRIPTOR;->sensitiveMedia(Lcom/twitter/model/json/core/JsonSensitiveMediaWarning;)Lcom/twitter/model/json/core/JsonSensitiveMediaWarning;
+                invoke-static {p1}, $TIMELINE_ENTRY_DESCRIPTOR;->sensitiveMedia(Lcom/twitter/model/json/core/JsonTweetWithVisibilityResults;)Lcom/twitter/model/json/core/JsonTweetWithVisibilityResults;
                 move-result-object p1
                 """.trimIndent(),
             )

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -15,6 +15,8 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.value.ArrayEncodedValue
+import com.android.tools.smali.dexlib2.iface.value.StringEncodedValue
 
 // Credits to @Cradlesofashes
 
@@ -40,10 +42,29 @@ val sensitiveMediaPatch =
 
             val returnObj = instructions.last { it.opcode == Opcode.RETURN_OBJECT }.location.index
 
+            val jsonClass = classDefBy {
+                it.type == "Lcom/tweet/model/json/core/JsonTestWithVisibilityResults;"
+            }!!
+
+            val mediaVisibilityField = jsonClass.fields.first { field ->
+                field.annotations.any { annotation ->
+                    annotation.type.endsWith("JsonField;") &&
+                    annotation.elements.any { element ->
+                        element.name == "name" &&
+                        (element.value as? ArrayEncodedValue)?.value?.any {
+                            (it as? StringEncodedValue)?.value == "media_visibility_results"
+                        } == true
+                    }
+                }
+            }
+
+            val fieldName = mediaVisibilityField.name
+
             methods.addInstructions(
                 returnObj,
                 """
-                invoke-static {p1}, $TIMELINE_ENTRY_DESCRIPTOR;->sensitiveMedia(Lcom/twitter/model/json/core/JsonTweetWithVisibilityResults;)Lcom/twitter/model/json/core/JsonTweetWithVisibilityResults;
+                const-string v0, "$fieldName"
+                invoke-static {p1, v0}, $TIMELINE_ENTRY_DESCRIPTOR;->sensitiveMedia(Lcom/twitter/model/json/core/JsonTestWithVisibilityResults;Ljava/lang/String;)Lcom/twitter/model/json/core/JsonTestWithVisibilityResults;
                 move-result-object p1
                 """.trimIndent(),
             )


### PR DESCRIPTION
Fix the issue "show sensitive media" in #1572, for "Remove premium upsell" there is already a fix in 3.9.0-dev.1

I hope this version is good for @swakwork 

However I don't like it, Java Reflection is slow, I tried to optimize it as much as possible.
