### PR TITLE
fix(Twitter): "Change app icon" is broken on recent X versions

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/AppIconManager.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/AppIconManager.java
@@ -20,13 +20,12 @@ public class AppIconManager {
 
     private static final String PREF_NAME = Settings.SHARED_PREF_NAME;
     private static final String KEY_SELECTED_ICON = "selected_app_icon";
-    private static final String defComponentName = "com.twitter.android.StartActivity";
 
     private final Context context;
     private final PackageManager pm;
     private final SharedPreferences prefs;
 
-    public AppIconManager(Context context) {
+    public AppIconManager() {
         this.context = Utils.getContext();
         this.pm = this.context.getPackageManager();
         this.prefs = this.context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE);
@@ -73,15 +72,9 @@ public class AppIconManager {
     // Enable ONE icon, disable all others
     // ---------------------------------------------------------------------------------------------
     public void applyIcon(String componentName) {
-        String prevComponentName = getSavedIcon();
         saveSelectedIcon(componentName);
-        // If the icon is "default" remove all icons. This is a measure taken in case multiple icons are created.
-        if (componentName.equals(defComponentName)) {
-            disableAllIcons();
-        }
-        else{
-            disableIcon(prevComponentName);
-        }
+        // Always disable all icons. This is a measure taken in case multiple icons are enabled.
+        disableAllIcons();
         pm.setComponentEnabledSetting(
                 new ComponentName(context, componentName),
                 PackageManager.COMPONENT_ENABLED_STATE_ENABLED,

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/IconSelectorFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/customise/appIcon/IconSelectorFragment.java
@@ -14,30 +14,29 @@ import java.util.List;
 
 import app.morphe.extension.shared.ResourceType;
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.Utils;
 
+@SuppressWarnings("deprecation")
 public class IconSelectorFragment extends Fragment {
 
     private AppIconManager iconManager;
-    private List<RowItem> rows;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
 
-        iconManager = new AppIconManager(getActivity());
+        iconManager = new AppIconManager();
 
         View root = inflater.inflate(ResourceUtils.getIdentifier(ResourceType.LAYOUT, "fragment_icon_selector"), container, false);
         ListView listView = root.findViewById(ResourceUtils.getIdentifier(ResourceType.ID, "icon_listview"));
 
         // Build all rows using the new builder class
         IconListBuilder builder = new IconListBuilder();
-        rows = builder.buildRows();
+        List<RowItem> rows = builder.buildRows();
 
         IconListAdapter adapter = new IconListAdapter(
                 getActivity(),
                 rows,
                 iconManager.getSavedIcon(),
-                componentName -> iconManager.applyIcon(componentName)
+                iconManager::applyIcon
         );
 
         listView.setAdapter(adapter);

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/appicon/AppIconResourcePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/appicon/AppIconResourcePatch.kt
@@ -99,6 +99,12 @@ val appIconResourcePatch =
                         // Add meta-data elements
                         activityAlias.appendChild(
                             document.createElement("meta-data").apply {
+                                setAttribute("android:name", "exclude_from_shutdown")
+                                setAttribute("android:value", "true")
+                            },
+                        )
+                        activityAlias.appendChild(
+                            document.createElement("meta-data").apply {
                                 setAttribute("android:name", "appFamilies")
                                 setAttribute("android:value", "twitter")
                             },

--- a/patches/src/main/resources/twitter/settings/layout/icon_item.xml
+++ b/patches/src/main/resources/twitter/settings/layout/icon_item.xml
@@ -22,6 +22,5 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:textSize="16sp"
-            android:textColor="#FFFFFF" />
+            android:textSize="16sp" />
 </LinearLayout>


### PR DESCRIPTION
The "Change app icon" feature was broken on recent versions of X.
The selected icon was reset upon the next launch, and all icons were displayed in the drawer.

This PR fixes this issue by adding `<meta-data android:name="exclude_from_shutdown" android:value="true"/>` to piko's `<activity-alias>` elements.

Starting with a certain version, X added this `exclude_from_shutdown` metadata to all their activity aliases.
Upon checking the APK I have on hand, I found that this was not present in v11.38.0 but had already been added by v11.64.0.
It is likely that this feature was broken in the version between these two.
Due to missing this metadata, X had disabled the piko's activity aliases.

<details>

<summary>The mechanism behind this issue</summary>

- You choose any app icon
- App icon changed
- X disables it at next launch due to missing "exclude_from_shutdown"
- Now, all activity aliases are disabled!
  - In the app info, "Open app" menu is missing because there is no main activity
- When you press home launcher icon, it somehow tries to launch `android.app.AppDetailsActivity`.
- App crashes by`java.lang.RuntimeException: Unable to instantiate activity ComponentInfo{com.twitter.android/android.app.AppDetailsActivity}: java.lang.RuntimeException: Couldn't call constructor`
- After this crash, X attempts to recover from this corrupted state
- X enables all X's activity aliases (not piko's) for recovery
- So the app drawer is filled with many X icons

</details>

Also includes fixes for:

- Icon names are invisible on light mode
- When you change app icon for the first time, the app always crashes because it tries to disable a component `""` (empty string)
  - `java.lang.IllegalArgumentException: Component class  does not exist in com.twitter.android`
- When you change app icon for the second time, always a duplicated icon is created
  - `saveSelectedIcon` succeeds at the first time, but icon didn't changed actually
  - Therefore, the saved icon and the actual active icon do not match, preventing the previous icon from being properly disabled