### PR TITLE
fix(instagram): handle null comment media and user data when saving comment media

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/CommentData.java
@@ -42,18 +42,25 @@ public class CommentData extends Entity implements GifMediaInterface {
     }
 
     public MediaData getImageMedia() throws Exception {
-        Entity imageDataEntity = super.getFieldAsEntity("fieldName");
-        if (imageDataEntity != null) {
-            Object mediaObj = imageDataEntity.getField("fieldName2");
-            if (mediaObj != null) {
-                return new MediaData(mediaObj);
+        try {
+            Entity imageDataEntity = super.getFieldAsEntity("fieldName");
+            if (imageDataEntity != null) {
+                Object mediaObj = imageDataEntity.getField("fieldName2");
+                if (mediaObj != null) {
+                    return new MediaData(mediaObj);
+                }
             }
+        } catch (Exception ignored) {
         }
         return null;
     }
 
     private Object getGifMedia() throws Exception {
-        return super.getField("fieldName");
+        try {
+            return super.getField("fieldName");
+        } catch (Exception ignored) {
+            return null;
+        }
     }
 
     public boolean hasGifMedia() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
@@ -78,6 +78,7 @@ public class HandleCommentButton {
                 return true;
 
             } else if (button.equals(SaveMediaButton.A00)) {
+                try {
                     CommentData commentData = new CommentData(commentObject);
 
                     Context context = (Context) Utils.getActivity();
@@ -89,15 +90,20 @@ public class HandleCommentButton {
                         MediaData imageData = commentData.getImageMedia();
                         UserData userData = commentData.getCommentUserData();
 
-                        String userName = (userData != null) ? userData.getUsername() : "comment_"+LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+                        String userName = (userData != null && userData.getUsername() != null) ? userData.getUsername() : "comment_" + System.currentTimeMillis();
                         String mediaLink = imageData.getMediaLink();
                         String fileName = userName + "_" + imageData.getDownloadFilename(MediaType.ANY);
 
                         String subFolder = DownloadUtils.getSubfolderName(userName);
 
                         DownloadUtils.downloadMediaUrl(context, mediaLink, subFolder, fileName);
+                    } else {
+                        PikoUtils.toast(str("piko_comment_copied_failed"));
                     }
-                
+                } catch (Exception ex) {
+                    PikoUtils.logger(ex);
+                    PikoUtils.toast(str("piko_comment_copied_failed"));
+                }
                 return true;
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel = true
 org.gradle.caching = true
 kotlin.code.style = official
 android.useAndroidX = true
-version = 3.9.0-dev.2
+version = 3.9.0-dev.3


### PR DESCRIPTION
### Summary
Fixes potential NullPointerExceptions and reflection failure crashes when attempting to save comment media on comments where user details or media metadata are missing or unparseable.

### Changes
- Wrapped getImageMedia() and getGifMedia() field getters in CommentData.java with try-catch blocks to safely return 
ull when field reflection fails.
- Added null safety checks for userData and userData.getUsername() in HandleCommentButton.java with fallback timestamp naming.
- Wrapped comment media download handler in exception handling with toast feedback.