### PR TITLE
build: compile against SDK 36

### DIFF
--- a/extensions/instagram/stub/build.gradle.kts
+++ b/extensions/instagram/stub/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "app.morphe.extension.instagram"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26

--- a/extensions/shared/library/build.gradle.kts
+++ b/extensions/shared/library/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "app.morphe.extension.shared"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 28

--- a/extensions/twitter/stub/build.gradle.kts
+++ b/extensions/twitter/stub/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 android {
     namespace = "app.morphe.extension.twitter"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
### Problem

A clean clone does not build. `:extensions:shared:library:checkReleaseAarMetadata` fails before any source is compiled:

```
> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > An issue was found when checking AAR metadata:

       1.  Dependency 'app.morphe:morphe-extensions-library:1.5.0' requires libraries and applications that
           depend on it to compile against version 36 or later of the
           Android APIs.

           :extensions:shared:library is currently compiled against android-34.

           Recommended action: Update this project to use a newer compileSdk
           of at least 36, for example 36.
```

The three extension modules pin `compileSdk = 34`, while the Morphe extensions library resolved by `app.morphe.patches` 1.3.3 now requires 36.

### Change

`compileSdk = 36` in `extensions/shared/library`, `extensions/instagram/stub` and `extensions/twitter/stub`.

Only `compileSdk` moves. `targetSdk` and `minSdk` are untouched, so runtime behaviour and device support are unchanged — `compileSdk` only governs which APIs may be compiled against.

### Verification

`./gradlew :patches:buildAndroid` succeeds with the bump and produces the `.mpp`; without it the build stops at the metadata check above. Tested on Linux arm64, JDK 17 (same version as the release workflow), Android SDK platform 36 + build-tools 36.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)