### PR TITLE
feat(Instagram): Add material you and amoled theme controls

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -10,6 +10,10 @@ import app.morphe.extension.crimera.settings.StringSetting;
 
 public class Settings {
     public static final BooleanSetting PIKO_DEBUG = new BooleanSetting("piko_debug", false);
+    public static final BooleanSetting MATERIAL_YOU_THEME = new BooleanSetting("material_you_theme", false);
+    public static final BooleanSetting AMOLED_THEME = new BooleanSetting("amoled_theme", false);
+    public static final StringSetting INSTAGRAM_THEME_MODE =
+            new StringSetting("instagram_theme_mode", "-1");
     // It should be true always. It will be handled upon opening the piko settings for the first time.
     public static final BooleanSetting FIRST_TIME_PIKO = new BooleanSetting("first_time_piko", true);
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -27,6 +27,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import app.morphe.extension.instagram.constants.UI;
+import app.morphe.extension.instagram.theme.MaterialYouTheme;
 import app.morphe.extension.shared.ResourceUtils;
 
 public final class InstagramPreferenceStyle {
@@ -49,16 +50,7 @@ public final class InstagramPreferenceStyle {
         );
     }
 
-    /**
-     * Native list / multi-select / edit-text preference dialogs build from
-     * getContext()'s platform alertDialogTheme. The settings activity is registered
-     * with a fixed dark DeviceDefault theme, so without this the dialogs are always
-     * dark. Wrapping the preference's context in a matching DeviceDefault theme makes
-     * them follow Instagram's resolved in-app theme, via {@link UI#isDarkMode()} (the
-     * luminance of the themed background), rather than the device's night setting — so
-     * the dialog matches IG even when the device and IG themes disagree. This only
-     * selects a platform DIALOG theme; it sets no app colour.
-     */
+    /** Matches platform preference dialogs to Instagram's resolved theme. */
     public static Context dialogContext(Context context) {
         int themeRes = UI.isDarkMode()
                 ? android.R.style.Theme_DeviceDefault
@@ -512,8 +504,15 @@ public final class InstagramPreferenceStyle {
 
             boolean enabled = isEnabled();
 
-            int onTrack = UI.getThemedColour("igds_color_primary_button");
-            int onThumb = backgroundColor();
+            boolean materialYouEnabled = MaterialYouTheme.isMaterialYouEnabled();
+            int instagramOnTrack = UI.getThemedColour("igds_color_primary_button");
+            int instagramOnThumb = backgroundColor();
+            int onTrack = materialYouEnabled
+                    ? ResourceUtils.getColor("material_selected_track", instagramOnTrack)
+                    : instagramOnTrack;
+            int onThumb = materialYouEnabled
+                    ? ResourceUtils.getColor("checkbox_image_tint", instagramOnThumb)
+                    : instagramOnThumb;
 
             int offTrack = ResourceUtils.getColor("material_unselected_track", pressedBackgroundColor());
             int offThumb = ResourceUtils.getColor("checkbox_unchecked_enabled", secondaryTextColor());
@@ -612,10 +611,8 @@ public final class InstagramPreferenceStyle {
             paint.setColor(thumbColor);
             canvas.drawCircle(cx, cy, thumbRadius, paint);
 
-            // Checkmark on the thumb when enabled, drawn in the accent colour so it
-            // reads against the surface-coloured thumb. Fades in with colorProgress.
             if (enabled && colorProgress > 0f) {
-                int checkColor = UI.getThemedColour("igds_color_primary_button");
+                int checkColor = onTrack;
                 paint.setStyle(Paint.Style.STROKE);
                 paint.setStrokeWidth(dp(getContext(), 2));
                 paint.setStrokeCap(Paint.Cap.ROUND);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+package app.morphe.extension.instagram.theme;
+
+import android.app.UiModeManager;
+import android.content.res.Configuration;
+
+final class MaterialYouState {
+    private MaterialYouState() {
+    }
+
+    static ThemeMode resolveMode(boolean materialYouEnabled, boolean amoledEnabled) {
+        if (materialYouEnabled && amoledEnabled) {
+            return ThemeMode.AMOLED_MATERIAL_YOU;
+        }
+        if (materialYouEnabled) {
+            return ThemeMode.MATERIAL_YOU;
+        }
+        return amoledEnabled ? ThemeMode.AMOLED : ThemeMode.BASE;
+    }
+
+    static boolean hasMaterialYou(ThemeMode mode) {
+        return mode == ThemeMode.MATERIAL_YOU
+                || mode == ThemeMode.AMOLED_MATERIAL_YOU;
+    }
+
+    static boolean hasAmoled(ThemeMode mode) {
+        return mode == ThemeMode.AMOLED
+                || mode == ThemeMode.AMOLED_MATERIAL_YOU;
+    }
+
+    static int composePrismOverrideArgb(
+            ThemeMode mode,
+            int materialYouBackgroundArgb
+    ) {
+        return composeSurfaceOverrideArgb(mode, materialYouBackgroundArgb);
+    }
+
+    static int composeSurfaceOverrideArgb(
+            ThemeMode mode,
+            int materialYouBackgroundArgb
+    ) {
+        if (hasAmoled(mode)) {
+            return 0xff000000;
+        }
+        return hasMaterialYou(mode) ? materialYouBackgroundArgb : 0;
+    }
+
+    static long composeSearchRowBackground(
+            long nativePackedColor,
+            int overrideArgb
+    ) {
+        if (overrideArgb == 0 || overrideArgb == Integer.MIN_VALUE) {
+            return nativePackedColor;
+        }
+        return ((long) overrideArgb) << 32;
+    }
+
+    static boolean shouldRequestToggleChange(
+            boolean requestedEnabled,
+            boolean currentEnabled
+    ) {
+        return requestedEnabled != currentEnabled;
+    }
+
+    static ThemeMode availableModeOrBase(
+            ThemeMode mode,
+            boolean materialYouAvailable,
+            boolean amoledAvailable
+    ) {
+        if (hasMaterialYou(mode) && !materialYouAvailable
+                || hasAmoled(mode) && !amoledAvailable) {
+            return ThemeMode.BASE;
+        }
+        return mode;
+    }
+
+    static ThemeMode availableModeOrFallback(
+            ThemeMode mode,
+            boolean materialYouAvailable,
+            boolean amoledAvailable,
+            boolean combinedAvailable
+    ) {
+        if (mode == ThemeMode.AMOLED_MATERIAL_YOU) {
+            if (materialYouAvailable && amoledAvailable && combinedAvailable) {
+                return mode;
+            }
+            if (amoledAvailable) {
+                return ThemeMode.AMOLED;
+            }
+            if (materialYouAvailable) {
+                return ThemeMode.MATERIAL_YOU;
+            }
+            return ThemeMode.BASE;
+        }
+        return availableModeOrBase(mode, materialYouAvailable, amoledAvailable);
+    }
+
+    static ThemeMode modeForMaterialYouToggle(boolean enabled, ThemeMode currentMode) {
+        return resolveMode(enabled, hasAmoled(currentMode));
+    }
+
+    static int targetNightMask(int nativeMode, int liveSystemNightMask) {
+        switch (nativeMode) {
+            case 1:
+                return Configuration.UI_MODE_NIGHT_NO;
+            case 2:
+                return Configuration.UI_MODE_NIGHT_YES;
+            case -1:
+                return liveSystemNightMask & Configuration.UI_MODE_NIGHT_MASK;
+            default:
+                throw new IllegalArgumentException("Unsupported native theme mode: " + nativeMode);
+        }
+    }
+
+    static boolean isEffectiveDark(int nativeMode, int liveSystemNightMask) {
+        return targetNightMask(nativeMode, liveSystemNightMask)
+                == Configuration.UI_MODE_NIGHT_YES;
+    }
+
+    static int sanitizeNativeThemeMode(int nativeMode) {
+        return nativeMode == -1 || nativeMode == 1 || nativeMode == 2
+                ? nativeMode
+                : -1;
+    }
+
+    static boolean shouldPersistNativeThemeBeforeAction(
+            boolean hasNativeMode,
+            boolean hasNativeAction
+    ) {
+        return hasNativeMode && !hasNativeAction;
+    }
+
+    static boolean shouldPersistNativeThemeAfterAction(
+            boolean hasNativeMode,
+            boolean hasNativeAction
+    ) {
+        return hasNativeMode && hasNativeAction;
+    }
+
+    static int resolveSystemNightMask(int systemNightMode, int resourceNightMask) {
+        switch (systemNightMode) {
+            case UiModeManager.MODE_NIGHT_NO:
+                return Configuration.UI_MODE_NIGHT_NO;
+            case UiModeManager.MODE_NIGHT_YES:
+                return Configuration.UI_MODE_NIGHT_YES;
+            default:
+                return resourceNightMask & Configuration.UI_MODE_NIGHT_MASK;
+        }
+    }
+
+    static int resolveCachedSystemNightMask(
+            int sdkInt,
+            int cachedNightMask,
+            int liveSystemNightMask
+    ) {
+        if (sdkInt < 31) {
+            return cachedNightMask;
+        }
+
+        int normalizedLiveMask =
+                liveSystemNightMask & Configuration.UI_MODE_NIGHT_MASK;
+        if (normalizedLiveMask == Configuration.UI_MODE_NIGHT_NO
+                || normalizedLiveMask == Configuration.UI_MODE_NIGHT_YES) {
+            return normalizedLiveMask;
+        }
+        return cachedNightMask;
+    }
+
+    static boolean shouldPikoRecreate(
+            ThemeMode previousMode,
+            ThemeMode requestedMode,
+            boolean hasNativeAction,
+            int currentNightMask,
+            int targetNightMask
+    ) {
+        boolean overlayChanged = previousMode != requestedMode;
+        boolean nativeConfigurationWillChange =
+                hasNativeAction && currentNightMask != targetNightMask;
+        return overlayChanged && !nativeConfigurationWillChange;
+    }
+
+    static Integer nativeModeForLegacySelection(
+            int checkedId,
+            int lightId,
+            int darkId,
+            int systemId
+    ) {
+        if (checkedId == lightId) {
+            return 1;
+        }
+        if (checkedId == darkId) {
+            return 2;
+        }
+        if (checkedId == systemId) {
+            return -1;
+        }
+        return null;
+    }
+
+    static Integer nativeModeForLegacySelectionId(
+            String selectedId,
+            int packedIds
+    ) {
+        if (selectedId == null) {
+            return null;
+        }
+
+        final int parsedId;
+        try {
+            parsedId = Integer.parseInt(selectedId);
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+
+        return nativeModeForLegacySelection(
+                parsedId,
+                unpackLegacyRadioId(packedIds, 1),
+                unpackLegacyRadioId(packedIds, 2),
+                unpackLegacyRadioId(packedIds, 3)
+        );
+    }
+
+    static int unpackLegacyRadioId(int packedIds, int byteIndex) {
+        if (byteIndex < 0 || byteIndex > 3) {
+            throw new IllegalArgumentException("Legacy theme radio byte index must be 0..3");
+        }
+        return (packedIds >>> (byteIndex * 8)) & 0xff;
+    }
+
+    static ThemeMode modeForAmoledToggle(boolean enabled, ThemeMode currentMode) {
+        return resolveMode(hasMaterialYou(currentMode), enabled);
+    }
+
+    static ThemeMode modeForNativeThemeSelection(ThemeMode currentMode) {
+        return resolveMode(hasMaterialYou(currentMode), false);
+    }
+
+    static boolean shouldSelectNativeDark(
+            boolean nativeDarkSelected,
+            boolean amoledEnabled
+    ) {
+        return nativeDarkSelected && !amoledEnabled;
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -1,0 +1,734 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+package app.morphe.extension.instagram.theme;
+
+import android.app.Activity;
+import android.app.Application;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Looper;
+import android.widget.CompoundButton;
+import android.widget.RadioGroup;
+
+import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.instagram.settings.Settings;
+import app.morphe.extension.instagram.utils.IgStr;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ResourceType;
+import app.morphe.extension.shared.ResourceUtils;
+import app.morphe.extension.shared.Utils;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import kotlin.Unit;
+import kotlin.jvm.functions.Function0;
+import kotlin.jvm.functions.Function1;
+
+public final class MaterialYouTheme {
+    private static final int NATIVE_THEME_DARK = 2;
+    private static boolean initializationFailureLogged;
+    private static boolean lifecycleCallbacksRegistered;
+    private static final ActivityThemeGeneration ACTIVITY_GENERATIONS =
+            new ActivityThemeGeneration();
+    private static int themeTransitionDepth;
+    private static Activity themeTransitionActivity;
+    private static boolean themeTransitionOverlayChanged;
+    private static boolean themeTransitionPikoRecreate;
+    private static int lastComposePrismOverrideArgb = Integer.MIN_VALUE;
+    private static int lastComposeSurfaceOverrideArgb = Integer.MIN_VALUE;
+
+    private static final Function1<Boolean, Unit> MATERIAL_YOU_TOGGLE_CALLBACK = value -> {
+        requestMaterialYouChange(Utils.getActivity(), Boolean.TRUE.equals(value));
+        return Unit.INSTANCE;
+    };
+
+    private static final CompoundButton.OnCheckedChangeListener LEGACY_MATERIAL_YOU_TOGGLE_LISTENER =
+            (buttonView, isChecked) -> {
+                if (!MaterialYouState.shouldRequestToggleChange(
+                        isChecked,
+                        isMaterialYouEnabled()
+                )) {
+                    return;
+                }
+                requestMaterialYouChange(
+                        getActivity(buttonView.getContext()),
+                        isChecked
+                );
+            };
+
+    private static final Application.ActivityLifecycleCallbacks ACTIVITY_CALLBACKS =
+            new Application.ActivityLifecycleCallbacks() {
+        @Override
+        public void onActivityPreCreated(Activity activity, Bundle savedInstanceState) {
+            applyToActivity(activity);
+        }
+
+        @Override
+        public void onActivityCreated(Activity activity, Bundle savedInstanceState) {
+        }
+
+        @Override
+        public void onActivityStarted(Activity activity) {
+        }
+
+        @Override
+        public void onActivityResumed(Activity activity) {
+            boolean stale = ACTIVITY_GENERATIONS.claimStale(activity);
+            if (stale) {
+                activity.recreate();
+                return;
+            }
+        }
+
+        @Override
+        public void onActivityPaused(Activity activity) {
+        }
+
+        @Override
+        public void onActivityStopped(Activity activity) {
+        }
+
+        @Override
+        public void onActivitySaveInstanceState(Activity activity, Bundle outState) {
+        }
+
+        @Override
+        public void onActivityDestroyed(Activity activity) {
+            ACTIVITY_GENERATIONS.remove(activity);
+        }
+    };
+
+    private MaterialYouTheme() {
+    }
+
+    public static void initialize(Context context) {
+        if (Build.VERSION.SDK_INT < 31) {
+            return;
+        }
+
+        try {
+            Context applicationContext = context.getApplicationContext();
+            if (applicationContext == null) {
+                applicationContext = context;
+            }
+            MaterialYouThemeAPI31.initialize(applicationContext);
+            ThemeMode mode = availableModeOrFallback(currentMode());
+            // The first activity must refresh colors after attaching its overlay.
+            lastComposePrismOverrideArgb = Integer.MIN_VALUE;
+            lastComposeSurfaceOverrideArgb =
+                    MaterialYouState.composeSurfaceOverrideArgb(mode, 0);
+            registerActivityCallbacks(applicationContext);
+        } catch (Exception exception) {
+            logInitializationFailureOnce(exception);
+        }
+    }
+
+    public static void applyToActivity(Activity activity) {
+        if (Build.VERSION.SDK_INT < 31
+                || activity == null
+                || Looper.myLooper() != Looper.getMainLooper()) {
+            return;
+        }
+
+        ThemeMode persistedMode = currentMode();
+        ThemeMode mode = availableModeOrFallback(persistedMode);
+        int nativeMode = currentInstagramThemeMode();
+        int systemNightMask = getSystemUiMode();
+        boolean instagramDark = MaterialYouState.isEffectiveDark(
+                nativeMode,
+                systemNightMask
+        );
+        boolean resourcesApplied =
+                MaterialYouThemeAPI31.setResourcesMode(activity, mode, instagramDark);
+        // Compose caches must be refreshed independently of the resource overlay.
+        applyComposePrismMode(activity, mode);
+        if (resourcesApplied) {
+            if (mode != persistedMode) {
+                persistMode(mode);
+            }
+            ACTIVITY_GENERATIONS.recordCreated(activity);
+        }
+    }
+
+    public static int getSystemUiMode() {
+        return Build.VERSION.SDK_INT >= 31
+                ? MaterialYouThemeAPI31.getSystemNightMask()
+                : Configuration.UI_MODE_NIGHT_UNDEFINED;
+    }
+
+    public static int resolveSystemUiModeCache(int cachedNightMask) {
+        int liveSystemNightMask = getSystemUiMode();
+        return MaterialYouState.resolveCachedSystemNightMask(
+                Build.VERSION.SDK_INT,
+                cachedNightMask,
+                liveSystemNightMask
+        );
+    }
+
+    public static boolean isMaterialYouAvailable() {
+        return Build.VERSION.SDK_INT >= 31 && MaterialYouThemeAPI31.isReady(ThemeMode.MATERIAL_YOU);
+    }
+
+    public static boolean isAmoledAvailable() {
+        return Build.VERSION.SDK_INT >= 31 && MaterialYouThemeAPI31.isReady(ThemeMode.AMOLED);
+    }
+
+    public static boolean isMaterialYouEnabled() {
+        return isMaterialYouAvailable()
+                && MaterialYouState.hasMaterialYou(availableModeOrFallback(currentMode()));
+    }
+
+    public static boolean isAmoledEnabled() {
+        return isAmoledAvailable()
+                && MaterialYouState.hasAmoled(availableModeOrFallback(currentMode()));
+    }
+
+    public static Function1<Boolean, Unit> getMaterialYouToggleCallback() {
+        return MATERIAL_YOU_TOGGLE_CALLBACK;
+    }
+
+    public static CompoundButton.OnCheckedChangeListener getLegacyMaterialYouToggleListener() {
+        return LEGACY_MATERIAL_YOU_TOGGLE_LISTENER;
+    }
+
+    public static Function1<Integer, Unit> wrapNativeThemeCallback(
+            Function1<Integer, Unit> callback
+    ) {
+        if (!isAmoledAvailable() || callback instanceof NativeThemeCallback) {
+            return callback;
+        }
+        return new NativeThemeCallback(callback);
+    }
+
+    public static void observeComposeNativeThemeMode(int nativeMode) {
+        int observedMode = MaterialYouState.sanitizeNativeThemeMode(nativeMode);
+        if (currentInstagramThemeMode() != observedMode) {
+            persistInstagramThemeMode(observedMode);
+        }
+    }
+
+    public static Function0<Unit> getAmoledRadioCallback(
+            Function1<Integer, Unit> callback
+    ) {
+        Function1<Integer, Unit> nativeCallback = unwrapNativeThemeCallback(callback);
+        return () -> {
+            ThemeMode targetMode = MaterialYouState.modeForAmoledToggle(
+                    true,
+                    currentModeForRequest()
+            );
+            requestNativeThemeChange(
+                    Utils.getActivity(),
+                    targetMode,
+                    NATIVE_THEME_DARK,
+                    () -> nativeCallback.invoke(NATIVE_THEME_DARK)
+            );
+            return Unit.INSTANCE;
+        };
+    }
+
+    public static RadioGroup.OnCheckedChangeListener wrapLegacyNativeThemeListener(
+            RadioGroup.OnCheckedChangeListener listener,
+            int packedIds
+    ) {
+        if (!isAmoledAvailable()) {
+            return listener;
+        }
+        return new LegacyNativeThemeController(
+                listener,
+                MaterialYouState.unpackLegacyRadioId(packedIds, 0),
+                MaterialYouState.unpackLegacyRadioId(packedIds, 1),
+                MaterialYouState.unpackLegacyRadioId(packedIds, 2),
+                MaterialYouState.unpackLegacyRadioId(packedIds, 3)
+        );
+    }
+
+    public static String getLegacySelectedRadioId(String nativeId, int packedIds) {
+        String amoledId = Integer.toString(
+                MaterialYouState.unpackLegacyRadioId(packedIds, 0)
+        );
+        Integer observedNativeMode =
+                MaterialYouState.nativeModeForLegacySelectionId(nativeId, packedIds);
+        if (observedNativeMode != null
+                && currentInstagramThemeMode() != observedNativeMode) {
+            Activity activity = Utils.getActivity();
+            if (Build.VERSION.SDK_INT >= 31
+                    && activity != null
+                    && Looper.myLooper() == Looper.getMainLooper()) {
+                requestNativeThemeChange(
+                        activity,
+                        currentModeForRequest(),
+                        observedNativeMode,
+                        null
+                );
+            } else {
+                persistInstagramThemeMode(observedNativeMode);
+            }
+        }
+        return isAmoledEnabled() ? amoledId : nativeId;
+    }
+
+    public static String getLegacyRadioTitle(
+            String itemId,
+            String amoledId,
+            String nativeTitle
+    ) {
+        return resolveLegacyRadioTitle(
+                itemId,
+                amoledId,
+                nativeTitle,
+                getAmoledTitle()
+        );
+    }
+
+    public static String getAmoledTitle() {
+        return "AMOLED";
+    }
+
+    public static String resolveLegacyRadioTitle(
+            String itemId,
+            String amoledId,
+            String nativeTitle,
+            String amoledTitle
+    ) {
+        if (itemId != null && itemId.equals(amoledId) && amoledTitle != null) {
+            return amoledTitle;
+        }
+        return nativeTitle;
+    }
+
+    public static boolean shouldSelectNativeDark(boolean nativeDarkSelected) {
+        return MaterialYouState.shouldSelectNativeDark(
+                nativeDarkSelected,
+                isAmoledEnabled()
+        );
+    }
+
+    public static boolean isAvailable() {
+        return isMaterialYouAvailable();
+    }
+
+    public static boolean isEnabled() {
+        return isMaterialYouEnabled();
+    }
+
+    public static Function1<Boolean, Unit> getToggleCallback() {
+        return getMaterialYouToggleCallback();
+    }
+
+    public static CompoundButton.OnCheckedChangeListener getLegacyToggleListener() {
+        return getLegacyMaterialYouToggleListener();
+    }
+
+    private static void requestMaterialYouChange(Activity activity, boolean enabled) {
+        requestNativeThemeChange(
+                activity,
+                MaterialYouState.modeForMaterialYouToggle(
+                        enabled,
+                        currentModeForRequest()
+                ),
+                null,
+                null
+        );
+    }
+
+    private static void requestNativeThemeChange(
+            Activity activity,
+            ThemeMode mode,
+            Integer nativeMode,
+            Runnable nativeAction
+    ) {
+        if (Build.VERSION.SDK_INT < 31
+                || activity == null
+                || Looper.myLooper() != Looper.getMainLooper()) {
+            return;
+        }
+
+        applyMode(
+                activity,
+                availableModeOrFallback(mode),
+                nativeMode,
+                nativeAction
+        );
+    }
+
+    private static ThemeMode availableModeOrFallback(ThemeMode mode) {
+        return MaterialYouState.availableModeOrFallback(
+                mode,
+                isMaterialYouAvailable(),
+                isAmoledAvailable(),
+                MaterialYouThemeAPI31.isReady(ThemeMode.AMOLED_MATERIAL_YOU)
+        );
+    }
+
+    private static void applyMode(
+            Activity activity,
+            ThemeMode requestedMode,
+            Integer nativeMode,
+            Runnable nativeAction
+    ) {
+        ThemeMode previousMode = availableModeOrFallback(currentMode());
+        int previousNativeMode = currentInstagramThemeMode();
+        int requestedNativeMode = nativeMode == null
+                ? previousNativeMode
+                : MaterialYouState.sanitizeNativeThemeMode(nativeMode);
+        int systemNightMask = getSystemUiMode();
+        boolean previousInstagramDark = MaterialYouState.isEffectiveDark(
+                previousNativeMode,
+                systemNightMask
+        );
+        boolean requestedInstagramDark = MaterialYouState.isEffectiveDark(
+                requestedNativeMode,
+                systemNightMask
+        );
+        int currentNightMask = activity.getResources().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK;
+        int targetNightMask = MaterialYouState.targetNightMask(
+                requestedNativeMode,
+                systemNightMask
+        );
+        boolean overlayChanged = previousMode != requestedMode
+                || previousInstagramDark != requestedInstagramDark;
+        boolean pikoRecreate = MaterialYouState.shouldPikoRecreate(
+                previousMode,
+                requestedMode,
+                nativeAction != null,
+                currentNightMask,
+                targetNightMask
+        );
+        if (!MaterialYouThemeAPI31.setResourcesMode(
+                activity,
+                requestedMode,
+                requestedInstagramDark
+        )) {
+            MaterialYouThemeAPI31.setResourcesMode(
+                    activity,
+                    previousMode,
+                    previousInstagramDark
+            );
+            persistMode(previousMode);
+            return;
+        }
+
+        if (previousMode != requestedMode && !persistMode(requestedMode)) {
+            MaterialYouThemeAPI31.setResourcesMode(
+                    activity,
+                    previousMode,
+                    previousInstagramDark
+            );
+            persistMode(previousMode);
+            return;
+        }
+
+        if (MaterialYouState.shouldPersistNativeThemeBeforeAction(
+                nativeMode != null,
+                nativeAction != null
+        ) && !persistInstagramThemeMode(requestedNativeMode)) {
+            MaterialYouThemeAPI31.setResourcesMode(
+                    activity,
+                    previousMode,
+                    previousInstagramDark
+            );
+            persistMode(previousMode);
+            persistInstagramThemeMode(previousNativeMode);
+            return;
+        }
+
+        applyComposePrismMode(activity, requestedMode);
+        runThemeTransition(
+                activity,
+                nativeAction,
+                pikoRecreate,
+                overlayChanged
+        );
+        if (MaterialYouState.shouldPersistNativeThemeAfterAction(
+                nativeMode != null,
+                nativeAction != null
+        )) {
+            persistInstagramThemeMode(requestedNativeMode);
+        }
+    }
+
+    private static void applyComposePrismMode(Context context, ThemeMode mode) {
+        int materialYouBackgroundArgb = 0;
+        if (MaterialYouState.hasMaterialYou(mode)) {
+            int resourceId = ResourceUtils.getIdentifier(
+                    context,
+                    ResourceType.COLOR,
+                    "igds_primary_background"
+            );
+            if (resourceId != 0) {
+                try {
+                    materialYouBackgroundArgb = context.getColor(resourceId);
+                } catch (Resources.NotFoundException ignored) {
+                }
+            }
+        }
+
+        int overrideArgb = MaterialYouState.composePrismOverrideArgb(
+                mode,
+                materialYouBackgroundArgb
+        );
+        boolean changed = overrideArgb != lastComposePrismOverrideArgb;
+        applyComposePrismColor(overrideArgb, changed);
+        lastComposePrismOverrideArgb = overrideArgb;
+        lastComposeSurfaceOverrideArgb =
+                MaterialYouState.composeSurfaceOverrideArgb(
+                        mode,
+                        materialYouBackgroundArgb
+                );
+    }
+
+    private static native void applyComposePrismColor(
+            int overrideArgb,
+            boolean refreshPalettes
+    );
+
+    public static long resolveComposeSearchRowBackground(long nativePackedColor) {
+        return resolveComposeSurfaceBackground(nativePackedColor);
+    }
+
+    public static long resolveComposeSurfaceBackground(long nativePackedColor) {
+        return MaterialYouState.composeSearchRowBackground(
+                nativePackedColor,
+                lastComposeSurfaceOverrideArgb
+        );
+    }
+
+    private static void runThemeTransition(
+            Activity activity,
+            Runnable nativeAction,
+            boolean pikoRecreate,
+            boolean overlayChanged
+    ) {
+        boolean rootTransition = themeTransitionDepth == 0;
+        if (rootTransition) {
+            themeTransitionActivity = activity;
+            themeTransitionOverlayChanged = false;
+            themeTransitionPikoRecreate = false;
+        }
+        themeTransitionOverlayChanged |= overlayChanged;
+        themeTransitionPikoRecreate |= pikoRecreate;
+        themeTransitionDepth++;
+        try {
+            if (nativeAction != null) {
+                nativeAction.run();
+            }
+        } finally {
+            themeTransitionDepth--;
+            if (themeTransitionDepth == 0) {
+                Activity refreshActivity = themeTransitionActivity;
+                themeTransitionActivity = null;
+                boolean changedOverlay = themeTransitionOverlayChanged;
+                boolean recreateWithPiko = themeTransitionPikoRecreate;
+                themeTransitionOverlayChanged = false;
+                themeTransitionPikoRecreate = false;
+                if (refreshActivity != null && changedOverlay) {
+                    ACTIVITY_GENERATIONS.advance();
+                    ACTIVITY_GENERATIONS.recordCreated(refreshActivity);
+                }
+                if (refreshActivity != null && recreateWithPiko) {
+                    refreshActivity.recreate();
+                }
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Function1<Integer, Unit> unwrapNativeThemeCallback(
+            Function1<Integer, Unit> callback
+    ) {
+        if (callback instanceof NativeThemeCallback) {
+            return ((NativeThemeCallback) callback).delegate;
+        }
+        return callback;
+    }
+
+    private static ThemeMode currentMode() {
+        return MaterialYouState.resolveMode(
+                Boolean.TRUE.equals(SharedPref.getBooleanPref(Settings.MATERIAL_YOU_THEME)),
+                Boolean.TRUE.equals(SharedPref.getBooleanPref(Settings.AMOLED_THEME))
+        );
+    }
+
+    private static ThemeMode currentModeForRequest() {
+        return availableModeOrFallback(currentMode());
+    }
+
+    private static boolean persistMode(ThemeMode mode) {
+        boolean materialYouEnabled = MaterialYouState.hasMaterialYou(mode);
+        boolean amoledEnabled = MaterialYouState.hasAmoled(mode);
+        boolean materialYouWritten = Boolean.TRUE.equals(
+                SharedPref.setBooleanPref(Settings.MATERIAL_YOU_THEME.key, materialYouEnabled)
+        );
+        boolean amoledWritten = Boolean.TRUE.equals(
+                SharedPref.setBooleanPref(Settings.AMOLED_THEME.key, amoledEnabled)
+        );
+        return materialYouWritten && amoledWritten;
+    }
+
+    private static int currentInstagramThemeMode() {
+        try {
+            return MaterialYouState.sanitizeNativeThemeMode(
+                    Integer.parseInt(SharedPref.getStringPref(Settings.INSTAGRAM_THEME_MODE))
+            );
+        } catch (NumberFormatException ignored) {
+            return -1;
+        }
+    }
+
+    private static boolean persistInstagramThemeMode(int nativeMode) {
+        int sanitizedMode = MaterialYouState.sanitizeNativeThemeMode(nativeMode);
+        return Boolean.TRUE.equals(
+                SharedPref.setStringPref(
+                        Settings.INSTAGRAM_THEME_MODE.key,
+                        Integer.toString(sanitizedMode)
+                )
+        );
+    }
+
+    private static Activity getActivity(Context context) {
+        Context current = context;
+        while (current instanceof ContextWrapper) {
+            if (current instanceof Activity) {
+                return (Activity) current;
+            }
+
+            Context baseContext = ((ContextWrapper) current).getBaseContext();
+            if (baseContext == current) {
+                return null;
+            }
+            current = baseContext;
+        }
+        return current instanceof Activity ? (Activity) current : null;
+    }
+
+    private static synchronized void registerActivityCallbacks(Context context) {
+        if (lifecycleCallbacksRegistered || !(context instanceof Application)) {
+            return;
+        }
+        ((Application) context).registerActivityLifecycleCallbacks(ACTIVITY_CALLBACKS);
+        lifecycleCallbacksRegistered = true;
+    }
+
+    private static synchronized void logInitializationFailureOnce(Exception exception) {
+        if (initializationFailureLogged) {
+            return;
+        }
+        initializationFailureLogged = true;
+        Logger.printException(
+                () -> "Failed to initialize theme resources: ",
+                exception
+        );
+    }
+
+    private static final class ActivityThemeGeneration {
+        private final Map<Activity, Long> generations = new WeakHashMap<>();
+        private long currentGeneration;
+
+        private synchronized void recordCreated(Activity activity) {
+            generations.put(activity, currentGeneration);
+        }
+
+        private synchronized void advance() {
+            currentGeneration++;
+        }
+
+        private synchronized boolean claimStale(Activity activity) {
+            Long activityGeneration = generations.get(activity);
+            if (activityGeneration == null) {
+                recordCreated(activity);
+                return false;
+            }
+            if (activityGeneration == currentGeneration) {
+                return false;
+            }
+
+            generations.put(activity, currentGeneration);
+            return true;
+        }
+
+        private synchronized void remove(Activity activity) {
+            generations.remove(activity);
+        }
+    }
+
+    private static final class NativeThemeCallback implements Function1<Integer, Unit> {
+        private final Function1<Integer, Unit> delegate;
+
+        private NativeThemeCallback(Function1<Integer, Unit> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Unit invoke(Integer nativeMode) {
+            ThemeMode currentMode = currentModeForRequest();
+            requestNativeThemeChange(
+                    Utils.getActivity(),
+                    MaterialYouState.modeForNativeThemeSelection(currentMode),
+                    nativeMode,
+                    () -> delegate.invoke(nativeMode)
+            );
+            return Unit.INSTANCE;
+        }
+    }
+
+    private static final class LegacyNativeThemeController
+            implements RadioGroup.OnCheckedChangeListener {
+        private final RadioGroup.OnCheckedChangeListener delegate;
+        private final int amoledId;
+        private final int lightId;
+        private final int darkId;
+        private final int systemId;
+
+        private LegacyNativeThemeController(
+                RadioGroup.OnCheckedChangeListener delegate,
+                int amoledId,
+                int lightId,
+                int darkId,
+                int systemId
+        ) {
+            this.delegate = delegate;
+            this.amoledId = amoledId;
+            this.lightId = lightId;
+            this.darkId = darkId;
+            this.systemId = systemId;
+        }
+
+        @Override
+        public void onCheckedChanged(RadioGroup group, int checkedId) {
+            ThemeMode currentMode = currentModeForRequest();
+            boolean selectAmoled = checkedId == amoledId;
+            int nativeId = selectAmoled ? darkId : checkedId;
+            Integer nativeMode = selectAmoled
+                    ? NATIVE_THEME_DARK
+                    : MaterialYouState.nativeModeForLegacySelection(
+                            checkedId,
+                            lightId,
+                            darkId,
+                            systemId
+                    );
+            if (nativeMode == null) {
+                delegate.onCheckedChanged(group, checkedId);
+                return;
+            }
+            ThemeMode targetMode = selectAmoled
+                    ? MaterialYouState.modeForAmoledToggle(true, currentMode)
+                    : MaterialYouState.modeForNativeThemeSelection(currentMode);
+            requestNativeThemeChange(
+                    getActivity(group.getContext()),
+                    targetMode,
+                    nativeMode,
+                    () -> delegate.onCheckedChanged(group, nativeId)
+            );
+        }
+    }
+
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouThemeAPI31.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouThemeAPI31.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+package app.morphe.extension.instagram.theme;
+
+import android.app.Activity;
+import android.app.UiModeManager;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.content.res.Resources;
+import android.content.res.loader.ResourcesLoader;
+import android.content.res.loader.ResourcesProvider;
+import android.os.Looper;
+import android.os.ParcelFileDescriptor;
+
+import androidx.annotation.RequiresApi;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+@RequiresApi(31)
+final class MaterialYouThemeAPI31 {
+    private static final String MATERIAL_YOU_LIGHT_OVERLAY_ASSET =
+            "piko/material_you_light.arsc";
+    private static final String MATERIAL_YOU_DARK_OVERLAY_ASSET =
+            "piko/material_you_dark.arsc";
+    private static final String AMOLED_OVERLAY_ASSET = "piko/amoled.arsc";
+    private static final String AMOLED_MATERIAL_YOU_OVERLAY_ASSET =
+            "piko/amoled_material_you.arsc";
+    private static final Map<Resources, OverlayMode> APPLIED_MODES = new WeakHashMap<>();
+    private static final Map<OverlayMode, ResourcesProvider> PROVIDERS =
+            new EnumMap<>(OverlayMode.class);
+    private static final Map<OverlayMode, ResourcesLoader> LOADERS =
+            new EnumMap<>(OverlayMode.class);
+
+    private static Context applicationContext;
+
+    private MaterialYouThemeAPI31() {
+    }
+
+    static synchronized void initialize(Context context) throws IOException {
+        if (applicationContext != null) {
+            return;
+        }
+
+        Context preparedContext = context.getApplicationContext();
+        if (preparedContext == null) {
+            preparedContext = context;
+        }
+
+        applicationContext = preparedContext;
+        IOException failure = null;
+        try {
+            prepareOverlay(
+                    preparedContext,
+                    OverlayMode.MATERIAL_YOU_LIGHT,
+                    MATERIAL_YOU_LIGHT_OVERLAY_ASSET
+            );
+            prepareOverlay(
+                    preparedContext,
+                    OverlayMode.MATERIAL_YOU_DARK,
+                    MATERIAL_YOU_DARK_OVERLAY_ASSET
+            );
+        } catch (IOException exception) {
+            failure = exception;
+        }
+        try {
+            prepareOverlay(preparedContext, OverlayMode.AMOLED, AMOLED_OVERLAY_ASSET);
+        } catch (IOException exception) {
+            if (failure == null) {
+                failure = exception;
+            }
+        }
+        try {
+            prepareOverlay(
+                    preparedContext,
+                    OverlayMode.AMOLED_MATERIAL_YOU,
+                    AMOLED_MATERIAL_YOU_OVERLAY_ASSET
+            );
+        } catch (IOException exception) {
+            if (failure == null) {
+                failure = exception;
+            }
+        }
+
+        if (LOADERS.isEmpty()) {
+            applicationContext = null;
+            throw failure != null ? failure : new IOException("Unable to prepare theme resources");
+        }
+    }
+
+    static synchronized boolean isReady(ThemeMode mode) {
+        switch (mode) {
+            case MATERIAL_YOU:
+                return LOADERS.containsKey(OverlayMode.MATERIAL_YOU_LIGHT)
+                        && LOADERS.containsKey(OverlayMode.MATERIAL_YOU_DARK);
+            case AMOLED:
+                return LOADERS.containsKey(OverlayMode.AMOLED);
+            case AMOLED_MATERIAL_YOU:
+                return LOADERS.containsKey(OverlayMode.AMOLED_MATERIAL_YOU);
+            default:
+                return false;
+        }
+    }
+
+    static synchronized int getSystemNightMask() {
+        int resourceNightMask = Resources.getSystem().getConfiguration().uiMode
+                & Configuration.UI_MODE_NIGHT_MASK;
+        if (applicationContext == null) {
+            return resourceNightMask;
+        }
+
+        UiModeManager uiModeManager =
+                applicationContext.getSystemService(UiModeManager.class);
+        if (uiModeManager == null) {
+            return resourceNightMask;
+        }
+        int managerMode = uiModeManager.getNightMode();
+        return MaterialYouState.resolveSystemNightMask(
+                managerMode,
+                resourceNightMask
+        );
+    }
+
+    static synchronized boolean setResourcesMode(
+            Activity activity,
+            ThemeMode mode,
+            boolean instagramDark
+    ) {
+        OverlayMode requestedOverlay = overlayFor(mode, instagramDark);
+        if (applicationContext == null
+                || activity == null
+                || Looper.myLooper() != Looper.getMainLooper()
+                || (requestedOverlay != null && !LOADERS.containsKey(requestedOverlay))) {
+            return false;
+        }
+
+        List<Resources> resources = distinctTargets(
+                activity.getResources(),
+                applicationContext.getResources()
+        );
+
+        List<Resources> changedResources = new ArrayList<>();
+        Map<Resources, OverlayMode> previousModes = new WeakHashMap<>();
+        try {
+            for (Resources target : resources) {
+                OverlayMode previousMode = APPLIED_MODES.get(target);
+                previousModes.put(target, previousMode);
+                changedResources.add(target);
+                replaceLoader(target, requestedOverlay);
+                if (requestedOverlay == null) {
+                    APPLIED_MODES.remove(target);
+                } else {
+                    APPLIED_MODES.put(target, requestedOverlay);
+                }
+            }
+            return true;
+        } catch (Exception exception) {
+            rollbackResources(changedResources, previousModes);
+            return false;
+        }
+    }
+
+    private static void prepareOverlay(Context context, OverlayMode mode, String assetName)
+            throws IOException {
+        ResourcesProvider provider = null;
+        try {
+            File overlayFile = new File(
+                    context.getCodeCacheDir(),
+                    overlayFileName(mode)
+            );
+            copyOverlay(context, assetName, overlayFile);
+
+            try (ParcelFileDescriptor descriptor = ParcelFileDescriptor.open(
+                    overlayFile,
+                    ParcelFileDescriptor.MODE_READ_ONLY
+            )) {
+                provider = ResourcesProvider.loadFromTable(descriptor, null);
+            }
+
+            ResourcesLoader loader = new ResourcesLoader();
+            loader.addProvider(provider);
+            PROVIDERS.put(mode, provider);
+            LOADERS.put(mode, loader);
+        } catch (Exception exception) {
+            if (provider != null) {
+                provider.close();
+            }
+            if (exception instanceof IOException) {
+                throw (IOException) exception;
+            }
+            throw new IOException("Unable to prepare " + mode + " resources", exception);
+        }
+    }
+
+    private static String overlayFileName(OverlayMode mode) {
+        switch (mode) {
+            case MATERIAL_YOU_LIGHT:
+                return "piko-material-you-light.arsc";
+            case MATERIAL_YOU_DARK:
+                return "piko-material-you-dark.arsc";
+            case AMOLED:
+                return "piko-amoled.arsc";
+            case AMOLED_MATERIAL_YOU:
+                return "piko-amoled-material-you.arsc";
+            default:
+                throw new IllegalArgumentException("No overlay for " + mode);
+        }
+    }
+
+    private static OverlayMode overlayFor(ThemeMode mode, boolean instagramDark) {
+        switch (mode) {
+            case MATERIAL_YOU:
+                return instagramDark
+                        ? OverlayMode.MATERIAL_YOU_DARK
+                        : OverlayMode.MATERIAL_YOU_LIGHT;
+            case AMOLED:
+                return OverlayMode.AMOLED;
+            case AMOLED_MATERIAL_YOU:
+                return OverlayMode.AMOLED_MATERIAL_YOU;
+            default:
+                return null;
+        }
+    }
+
+    private static void replaceLoader(Resources target, OverlayMode mode) {
+        ResourcesLoader requestedLoader = mode == null ? null : LOADERS.get(mode);
+        for (ResourcesLoader loader : LOADERS.values()) {
+            target.removeLoaders(loader);
+        }
+        if (requestedLoader != null) {
+            target.addLoaders(requestedLoader);
+        }
+    }
+
+    private static List<Resources> distinctTargets(Resources primary, Resources secondary) {
+        List<Resources> targets = new ArrayList<>(2);
+        if (primary != null) {
+            targets.add(primary);
+        }
+        if (secondary != null && secondary != primary) {
+            targets.add(secondary);
+        }
+        return targets;
+    }
+
+    private static void copyOverlay(Context context, String assetName, File outputFile) throws IOException {
+        try (InputStream input = context.getAssets().open(assetName);
+             FileOutputStream output = new FileOutputStream(outputFile, false)) {
+            byte[] buffer = new byte[8192];
+            int bytesRead;
+            while ((bytesRead = input.read(buffer)) != -1) {
+                output.write(buffer, 0, bytesRead);
+            }
+        }
+    }
+
+    private static void rollbackResources(
+            List<Resources> changedResources,
+            Map<Resources, OverlayMode> previousModes
+    ) {
+        for (int index = changedResources.size() - 1; index >= 0; index--) {
+            Resources target = changedResources.get(index);
+            OverlayMode previousMode = previousModes.get(target);
+            try {
+                replaceLoader(target, previousMode);
+                if (previousMode == null) {
+                    APPLIED_MODES.remove(target);
+                } else {
+                    APPLIED_MODES.put(target, previousMode);
+                }
+            } catch (Exception ignored) {
+                // Keep the last successful state if Android rejects rollback.
+            }
+        }
+    }
+
+    private enum OverlayMode {
+        MATERIAL_YOU_LIGHT,
+        MATERIAL_YOU_DARK,
+        AMOLED,
+        AMOLED_MATERIAL_YOU
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/ThemeMode.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/ThemeMode.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+package app.morphe.extension.instagram.theme;
+
+public enum ThemeMode {
+    BASE,
+    MATERIAL_YOU,
+    AMOLED,
+    AMOLED_MATERIAL_YOU
+}

--- a/patches/build.gradle.kts
+++ b/patches/build.gradle.kts
@@ -13,6 +13,8 @@ patches {
 }
 
 dependencies {
+    compileOnly("com.github.REAndroid:ARSCLib:a28c6fb2a7")
+
     // Used by JsonGenerator.
     implementation(libs.gson)
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ComposePrismBlackPatch.kt
@@ -6,31 +6,49 @@
 
 package app.crimera.patches.instagram.misc.theme
 
-import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.opcode
-import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.toInstruction
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MethodImplementationBuilder
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21t
+import com.android.tools.smali.dexlib2.iface.instruction.Instruction
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.RegisterRangeInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.WideLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+import com.android.tools.smali.dexlib2.immutable.reference.ImmutableMethodReference
 
-// Thanks to instafel (https://github.com/mamiiblt/instafel) - GRAY_1600 is a
-// compiled constant in BasePrismColorsV2's <clinit>, not a color resource, so
-// the colors.xml overrides in ThemePatch.kt don't reach it. It's the
-// prism-black tone newer Compose screens use, so without this patch they stay
-// dark gray instead of pure black in AMOLED mode.
+// GRAY_1600 is compiled into Compose, so runtime themes override only its background uses.
 private const val PRISM_COLORS_V2_CLASS = "Lcom/instagram/compose/core/theme/BasePrismColorsV2;"
 private const val GRAY_1600_FIELD_NAME = "GRAY_1600"
-private const val PURE_BLACK_LITERAL = "0xff000000L"
+private const val GRAY_0100_FIELD_NAME = "GRAY_0100"
+private const val MATERIAL_YOU_THEME_CLASS =
+    "Lapp/morphe/extension/instagram/theme/MaterialYouTheme;"
+private const val COMPOSE_PRISM_COLOR_BRIDGE_NAME = "applyComposePrismColor"
+private const val COMPOSE_PRISM_REFRESH_METHOD_NAME = "pikoRefreshPrismPalette"
+private const val COMPOSE_SEARCH_ROW_BACKGROUND_RESOLVER =
+    "$MATERIAL_YOU_THEME_CLASS->resolveComposeSearchRowBackground(J)J"
+private const val PURE_BLACK_ARGB = 0xff000000L
+private const val EXPECTED_COMPOSE_PRISM_PALETTE_HOLDERS = 2
+private const val SEARCH_ROW_SEMANTICS_ID = "search_row"
 
-// Matches the const-wide that feeds GRAY_1600's sput-wide directly: a
-// shl-long/2addr sits in between (packing the ARGB value into Compose's
-// internal 64-bit color representation), so MatchAfterWithin(1) allows for
-// exactly that one unmatched instruction and no more - this is what pins the
-// const-wide to the one immediately preceding GRAY_1600 specifically, instead
-// of matching the first const-wide in the method.
+// Allow only the single packing instruction between the literal and GRAY_1600 write.
 internal object ComposePrismBlackFingerprint : Fingerprint(
     definingClass = PRISM_COLORS_V2_CLASS,
     name = "<clinit>",
@@ -45,23 +63,634 @@ internal object ComposePrismBlackFingerprint : Fingerprint(
     ),
 )
 
-internal val composePrismBlackPatch =
-    bytecodePatch(
-        description = "Rewrites the GRAY_1600 constant in BasePrismColorsV2 so newer " +
-            "Compose-based screens render true black instead of Instagram's stock dark " +
-            "gray prism tone. Required for the AMOLED theme option in the Theme patch " +
-            "to look correct on those screens.",
-        default = true,
+internal object ComposeSearchRowFingerprint : Fingerprint(
+    strings = listOf(SEARCH_ROW_SEMANTICS_ID),
+    returnType = "V",
+    filters = listOf(opcode(Opcode.IGET_WIDE)),
+)
+
+internal fun composePrismBlackLiteral(
+    legacyAmoled: Boolean,
+    nativeArgb: Long,
+): Long = if (legacyAmoled) PURE_BLACK_ARGB else nativeArgb
+
+internal fun composePrismBlackFieldAccessFlags(accessFlags: Int): Int =
+    accessFlags and AccessFlags.FINAL.value.inv()
+
+internal data class ComposePrismPaletteHolder(
+    val cachedPaletteField: FieldReference,
+    val refreshMethod: MethodReference,
+)
+
+internal data class ComposePrismPaletteRuntime(
+    val backgroundFields: List<FieldReference>,
+    val holders: List<ComposePrismPaletteHolder>,
+)
+
+internal fun createComposePrismColorBridge(
+    owner: String,
+    paletteRuntime: ComposePrismPaletteRuntime,
+): MutableMethod {
+    val implementation =
+        MethodImplementationBuilder(7).apply {
+            addInstruction(
+                BuilderInstruction21t(
+                    Opcode.IF_EQZ,
+                    6,
+                    getLabel("piko_compose_prism_write"),
+                ),
+            )
+            paletteRuntime.holders.forEach { holder ->
+                addInstruction("invoke-static {}, ${holder.refreshMethod}".toInstruction())
+            }
+            addLabel("piko_compose_prism_write")
+            addInstruction(
+                BuilderInstruction21t(
+                    Opcode.IF_EQZ,
+                    5,
+                    getLabel("piko_compose_prism_return"),
+                ),
+            )
+            addInstruction("int-to-long v0, v5".toInstruction())
+            addInstruction("const/16 v3, 0x20".toInstruction())
+            addInstruction("shl-long/2addr v0, v3".toInstruction())
+            paletteRuntime.holders.forEach { holder ->
+                addInstruction(
+                    "sget-object v2, ${holder.cachedPaletteField}".toInstruction(),
+                )
+                paletteRuntime.backgroundFields.forEach { backgroundField ->
+                    addInstruction(
+                        "iput-wide v0, v2, $backgroundField".toInstruction(),
+                    )
+                }
+            }
+            addLabel("piko_compose_prism_return")
+            addInstruction("return-void".toInstruction())
+        }.methodImplementation
+    return MutableMethod(
+        ImmutableMethod(
+            owner,
+            COMPOSE_PRISM_COLOR_BRIDGE_NAME,
+            listOf(
+                ImmutableMethodParameter("I", emptySet(), null),
+                ImmutableMethodParameter("Z", emptySet(), null),
+            ),
+            "V",
+            AccessFlags.PRIVATE.value or AccessFlags.STATIC.value,
+            emptySet(),
+            emptySet(),
+            implementation,
+        ),
+    )
+}
+
+context(patchContext: BytecodePatchContext)
+internal fun installComposePrismBlackRuntime(legacyAmoled: Boolean) {
+    val method = ComposePrismBlackFingerprint.method
+    val constWideMatch = ComposePrismBlackFingerprint.instructionMatches[0]
+    val storeMatch = ComposePrismBlackFingerprint.instructionMatches[1]
+    val register =
+        (constWideMatch.instruction as? OneRegisterInstruction)?.registerA
+            ?: throw PatchException("GRAY_1600 source is not a one-register const-wide")
+    val nativeArgb =
+        (constWideMatch.instruction as? WideLiteralInstruction)?.wideLiteral
+            ?: throw PatchException("GRAY_1600 source does not contain a wide literal")
+    if (storeMatch.index != constWideMatch.index + 2) {
+        throw PatchException("GRAY_1600 source is not followed by one packing instruction")
+    }
+    val shiftInstruction =
+        method.instructions[constWideMatch.index + 1] as? TwoRegisterInstruction
+            ?: throw PatchException("GRAY_1600 packing instruction does not use two registers")
+    if (
+        shiftInstruction.opcode != Opcode.SHL_LONG_2ADDR ||
+        shiftInstruction.registerA != register
     ) {
-        compatibleWith(COMPATIBILITY_INSTAGRAM)
+        throw PatchException("GRAY_1600 source is not packed with shl-long/2addr")
+    }
+    val shiftAmount =
+        method.instructions
+            .subList(0, constWideMatch.index)
+            .asReversed()
+            .firstOrNull { instruction ->
+                instruction is OneRegisterInstruction &&
+                    instruction is NarrowLiteralInstruction &&
+                    instruction.registerA == shiftInstruction.registerB
+            } as? NarrowLiteralInstruction
+    if (shiftAmount?.narrowLiteral != 32) {
+        throw PatchException("GRAY_1600 packing shift is not 32 bits")
+    }
 
-        execute {
-            val constWideMatch = ComposePrismBlackFingerprint.instructionMatches[0]
-            val register = (constWideMatch.instruction as OneRegisterInstruction).registerA
+    val field =
+        ((storeMatch.instruction as? ReferenceInstruction)?.reference as? FieldReference)
+            ?: throw PatchException("GRAY_1600 store does not reference a field")
+    if (
+        field.definingClass != PRISM_COLORS_V2_CLASS ||
+        field.name != GRAY_1600_FIELD_NAME ||
+        field.type != "J"
+    ) {
+        throw PatchException("GRAY_1600 field reference does not match the expected shape")
+    }
+    val fieldDefinition =
+        ComposePrismBlackFingerprint.classDef.fields.singleOrNull {
+            it.definingClass == field.definingClass &&
+                it.name == field.name &&
+                it.type == field.type
+        } ?: throw PatchException("Expected one GRAY_1600 field definition")
+    if (
+        !AccessFlags.PUBLIC.isSet(fieldDefinition.accessFlags) ||
+        !AccessFlags.STATIC.isSet(fieldDefinition.accessFlags) ||
+        !AccessFlags.FINAL.isSet(fieldDefinition.accessFlags)
+    ) {
+        throw PatchException("GRAY_1600 must remain public static final")
+    }
+    val legacyLiteral = composePrismBlackLiteral(legacyAmoled, nativeArgb)
+    if (legacyLiteral != nativeArgb) {
+        method.replaceInstruction(
+            constWideMatch.index,
+            "const-wide v$register, ${wideLiteral(legacyLiteral)}",
+        )
+    }
+    val paletteRuntime = installComposePrismPaletteRuntime(field)
+    installComposeSearchRowBackgroundOverride()
 
-            ComposePrismBlackFingerprint.method.replaceInstruction(
-                constWideMatch.index,
-                "const-wide v$register, $PURE_BLACK_LITERAL",
+    val extensionClass = patchContext.mutableClassDefBy(MATERIAL_YOU_THEME_CLASS)
+    val bridgeCandidates =
+        extensionClass.methods.filter {
+            it.name == COMPOSE_PRISM_COLOR_BRIDGE_NAME &&
+                it.parameterTypes.map(CharSequence::toString) == listOf("I", "Z") &&
+                it.returnType == "V"
+        }
+    if (bridgeCandidates.size != 1) {
+        throw PatchException(
+            "Expected one MaterialYouTheme compose prism bridge, found " +
+                bridgeCandidates.size,
+        )
+    }
+    val bridgeStub = bridgeCandidates.single()
+    if (
+        !AccessFlags.PRIVATE.isSet(bridgeStub.accessFlags) ||
+        !AccessFlags.STATIC.isSet(bridgeStub.accessFlags) ||
+        !AccessFlags.NATIVE.isSet(bridgeStub.accessFlags)
+    ) {
+        throw PatchException("MaterialYouTheme compose prism bridge has an invalid signature")
+    }
+    extensionClass.methods.remove(bridgeStub)
+    extensionClass.methods.add(
+        createComposePrismColorBridge(
+            owner = MATERIAL_YOU_THEME_CLASS,
+            paletteRuntime = paletteRuntime,
+        ),
+    )
+}
+
+context(patchContext: BytecodePatchContext)
+private fun installComposeSearchRowBackgroundOverride() {
+    val method = ComposeSearchRowFingerprint.method
+    composeSearchRowSurfaceWrites(method.instructions)
+        .sortedByDescending { it.index }
+        .forEach { write ->
+            method.addInstructions(
+                write.index + 1,
+                composeSearchRowOverrideInstructions(write.register),
             )
         }
+}
+
+internal data class ComposeSearchRowSurfaceWrite(
+    val index: Int,
+    val register: Int,
+)
+
+internal fun composeSearchRowSurfaceWrites(
+    instructions: List<Instruction>,
+): List<ComposeSearchRowSurfaceWrite> {
+    val paletteWrites =
+        instructions.withIndex().filter { (_, instruction) ->
+            instruction.opcode == Opcode.IGET_WIDE &&
+                ((instruction as? ReferenceInstruction)?.reference as? FieldReference)
+                    ?.type == "J"
+        }
+    if (paletteWrites.size != 1) {
+        throw PatchException(
+            "Expected one Compose search-row palette surface read, found ${paletteWrites.size}",
+        )
     }
+    val paletteWrite = paletteWrites.single()
+    val register =
+        (paletteWrite.value as? OneRegisterInstruction)?.registerA
+            ?: throw PatchException(
+                "Compose search-row palette surface read has no destination register",
+            )
+
+    val alternateWrites =
+        instructions.withIndex().filter { (index, instruction) ->
+            if (
+                index == 0 ||
+                instruction.opcode != Opcode.MOVE_RESULT_WIDE ||
+                (instruction as? OneRegisterInstruction)?.registerA != register
+            ) {
+                return@filter false
+            }
+            val source = instructions[index - 1]
+            source.opcode == Opcode.INVOKE_STATIC &&
+                ((source as? ReferenceInstruction)?.reference as? MethodReference)
+                    ?.returnType == "J"
+        }
+    if (alternateWrites.size != 1) {
+        throw PatchException(
+            "Expected one alternate Compose search-row surface result, found " +
+                alternateWrites.size,
+        )
+    }
+
+    return listOf(
+        ComposeSearchRowSurfaceWrite(paletteWrite.index, register),
+        ComposeSearchRowSurfaceWrite(alternateWrites.single().index, register),
+    )
+}
+
+internal fun composeSearchRowOverrideInstructions(register: Int): String {
+    if (register !in 0..14) {
+        throw PatchException(
+            "Compose search-row surface requires a 4-bit wide register, found v$register",
+        )
+    }
+    return """
+        invoke-static {v$register, v${register + 1}}, $COMPOSE_SEARCH_ROW_BACKGROUND_RESOLVER
+        move-result-wide v$register
+        """.trimIndent()
+}
+
+context(patchContext: BytecodePatchContext)
+private fun installComposePrismPaletteRuntime(
+    prismField: FieldReference,
+): ComposePrismPaletteRuntime {
+    val holderClasses = mutableListOf<com.android.tools.smali.dexlib2.iface.ClassDef>()
+    patchContext.classDefForEach { classDef ->
+        val clinit =
+            classDef.methods.singleOrNull {
+                it.name == "<clinit>" &&
+                    it.parameterTypes.isEmpty() &&
+                    it.returnType == "V"
+            } ?: return@classDefForEach
+        val readsPrismField =
+            clinit.implementation?.instructions?.any { instruction ->
+                instruction.opcode == Opcode.SGET_WIDE &&
+                    (instruction as? ReferenceInstruction)?.reference == prismField
+            } == true
+        if (readsPrismField) holderClasses += classDef
+    }
+    if (holderClasses.size != EXPECTED_COMPOSE_PRISM_PALETTE_HOLDERS) {
+        throw PatchException(
+            "Expected $EXPECTED_COMPOSE_PRISM_PALETTE_HOLDERS cached Compose prism " +
+                "palette holders, found ${holderClasses.size}",
+        )
+    }
+    val holderInitializers =
+        holderClasses.map { classDef ->
+            classDef.methods
+                .single {
+                    it.name == "<clinit>" &&
+                        it.parameterTypes.isEmpty() &&
+                        it.returnType == "V"
+                }.implementation
+                ?.instructions
+                ?.toList()
+                ?: throw PatchException(
+                    "Cached Compose prism palette initializer is missing in ${classDef.type}",
+                )
+        }
+
+    val holders = holderClasses.map { classDef ->
+        val holderClass = patchContext.mutableClassDefBy(classDef)
+        if (
+            holderClass.methods.any {
+                it.name == COMPOSE_PRISM_REFRESH_METHOD_NAME
+            }
+        ) {
+            throw PatchException(
+                "Compose prism palette refresh already exists in ${holderClass.type}",
+            )
+        }
+        val clinit =
+            holderClass.methods.single {
+                it.name == "<clinit>" &&
+                    it.parameterTypes.isEmpty() &&
+                    it.returnType == "V"
+            }
+        val holderWrites =
+            clinit.instructions
+                .filter { instruction ->
+                    instruction.opcode == Opcode.SPUT_OBJECT &&
+                        ((instruction as? ReferenceInstruction)?.reference as? FieldReference)
+                            ?.definingClass == holderClass.type
+                }
+                .map { instruction ->
+                    (instruction as ReferenceInstruction).reference as FieldReference
+                }
+                .distinct()
+        if (holderWrites.size != 1) {
+            throw PatchException(
+                "Expected one cached Compose prism palette field in ${holderClass.type}",
+            )
+        }
+        val holderFieldReference = holderWrites.single()
+        val holderField =
+            holderClass.fields.singleOrNull {
+                it.name == holderFieldReference.name &&
+                    it.type == holderFieldReference.type
+            } ?: throw PatchException(
+                "Cached Compose prism palette field is missing in ${holderClass.type}",
+            )
+        if (
+            !AccessFlags.PUBLIC.isSet(holderField.accessFlags) ||
+            !AccessFlags.STATIC.isSet(holderField.accessFlags) ||
+            !AccessFlags.FINAL.isSet(holderField.accessFlags)
+        ) {
+            throw PatchException(
+                "Cached Compose prism palette field has an invalid shape in " +
+                    holderClass.type,
+            )
+        }
+        holderField.accessFlags =
+            composePrismBlackFieldAccessFlags(holderField.accessFlags)
+
+        val refreshMethod =
+            MutableMethod(clinit).apply {
+                name = COMPOSE_PRISM_REFRESH_METHOD_NAME
+                accessFlags =
+                    AccessFlags.PUBLIC.value or
+                    AccessFlags.STATIC.value
+            }
+        holderClass.methods.add(refreshMethod)
+        ComposePrismPaletteHolder(
+            cachedPaletteField = holderFieldReference,
+            refreshMethod =
+                ImmutableMethodReference(
+                    holderClass.type,
+                    COMPOSE_PRISM_REFRESH_METHOD_NAME,
+                    emptyList(),
+                    "V",
+                ),
+        )
+    }
+
+    val paletteTypes = holders.map { it.cachedPaletteField.type }.distinct()
+    if (paletteTypes.size != 1) {
+        throw PatchException(
+            "Cached Compose prism palettes use different types: $paletteTypes",
+        )
+    }
+    val paletteClass = patchContext.mutableClassDefBy(paletteTypes.single())
+    val paletteConstructors =
+        paletteClass.methods.filter { method ->
+            method.name == "<init>" &&
+                method.parameterTypes.isNotEmpty() &&
+                method.parameterTypes.all { it.toString() == "J" }
+        }
+    val primaryBackgroundField =
+        paletteConstructors
+            .mapNotNull { method ->
+                runCatching {
+                    composePrismPrimaryBackgroundField(method)
+                }.getOrNull()
+            }
+            .distinct()
+            .singleOrNull()
+            ?: throw PatchException(
+                "Expected one cached Compose prism primary background field",
+            )
+    val rootBackgroundParameterOrdinal =
+        composePrismRootBackgroundParameterOrdinal(
+            paletteType = paletteClass.type,
+            holderInitializers = holderInitializers,
+        )
+    val bdsBackgroundField =
+        paletteConstructors
+            .mapNotNull { method ->
+                runCatching {
+                    composePrismBackgroundField(
+                        constructor = method,
+                        parameterOrdinal = rootBackgroundParameterOrdinal,
+                    )
+                }.getOrNull()
+            }
+            .distinct()
+            .singleOrNull()
+            ?: throw PatchException(
+                "Expected one cached Compose BDS root background field",
+            )
+    val backgroundFields =
+        listOf(primaryBackgroundField, bdsBackgroundField).distinct()
+    if (backgroundFields.size != 2) {
+        throw PatchException(
+            "Compose primary and BDS root backgrounds must use different fields",
+        )
+    }
+    backgroundFields.forEach { backgroundField ->
+        val definition =
+            paletteClass.fields.singleOrNull { field ->
+                field.name == backgroundField.name && field.type == backgroundField.type
+            } ?: throw PatchException(
+                "Cached Compose background field is missing",
+            )
+        if (
+            !AccessFlags.PUBLIC.isSet(definition.accessFlags) ||
+            AccessFlags.STATIC.isSet(definition.accessFlags) ||
+            !AccessFlags.FINAL.isSet(definition.accessFlags)
+        ) {
+            throw PatchException(
+                "Cached Compose background field has an invalid shape",
+            )
+        }
+        definition.accessFlags =
+            composePrismBlackFieldAccessFlags(definition.accessFlags)
+    }
+
+    return ComposePrismPaletteRuntime(
+        backgroundFields = backgroundFields,
+        holders = holders,
+    )
+}
+
+private data class ComposePrismHolderColorOrdinals(
+    val gray1600: Set<Int>,
+    val gray0100: Set<Int>,
+)
+
+internal fun composePrismRootBackgroundParameterOrdinal(
+    paletteType: String,
+    holderInitializers: List<List<Instruction>>,
+): Int {
+    if (holderInitializers.size != EXPECTED_COMPOSE_PRISM_PALETTE_HOLDERS) {
+        throw PatchException(
+            "Expected $EXPECTED_COMPOSE_PRISM_PALETTE_HOLDERS Compose prism palette " +
+                "initializers, found ${holderInitializers.size}",
+        )
+    }
+    val holderSources =
+        holderInitializers.map { instructions ->
+            val constructorCall =
+                instructions.withIndex().singleOrNull { (_, instruction) ->
+                    if (instruction.opcode != Opcode.INVOKE_DIRECT_RANGE) {
+                        return@singleOrNull false
+                    }
+                    val reference =
+                        (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                            ?: return@singleOrNull false
+                    reference.definingClass == paletteType &&
+                        reference.name == "<init>" &&
+                        reference.returnType == "V" &&
+                        reference.parameterTypes.isNotEmpty() &&
+                        reference.parameterTypes.all { it.toString() == "J" }
+                } ?: throw PatchException(
+                    "Expected one cached Compose prism palette constructor call",
+                )
+            val constructorReference =
+                (constructorCall.value as ReferenceInstruction).reference as MethodReference
+            val range =
+                constructorCall.value as? RegisterRangeInstruction
+                    ?: throw PatchException(
+                        "Cached Compose prism palette constructor is not a register range",
+                    )
+            val expectedRegisterCount = 1 + (constructorReference.parameterTypes.size * 2)
+            if (range.registerCount != expectedRegisterCount) {
+                throw PatchException(
+                    "Cached Compose prism palette constructor register count is invalid",
+                )
+            }
+            val firstParameterRegister = range.startRegister + 1
+
+            fun sourceOrdinals(fieldName: String): Set<Int> =
+                instructions
+                    .take(constructorCall.index)
+                    .mapNotNull { instruction ->
+                        if (instruction.opcode != Opcode.SGET_WIDE) {
+                            return@mapNotNull null
+                        }
+                        val field =
+                            (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                                ?: return@mapNotNull null
+                        if (
+                            field.definingClass != PRISM_COLORS_V2_CLASS ||
+                            field.name != fieldName ||
+                            field.type != "J"
+                        ) {
+                            return@mapNotNull null
+                        }
+                        val register =
+                            (instruction as? OneRegisterInstruction)?.registerA
+                                ?: return@mapNotNull null
+                        val offset = register - firstParameterRegister
+                        if (
+                            offset < 0 ||
+                            offset % 2 != 0 ||
+                            offset / 2 !in constructorReference.parameterTypes.indices
+                        ) {
+                            return@mapNotNull null
+                        }
+                        offset / 2
+                    }.toSet()
+
+            ComposePrismHolderColorOrdinals(
+                gray1600 = sourceOrdinals(GRAY_1600_FIELD_NAME),
+                gray0100 = sourceOrdinals(GRAY_0100_FIELD_NAME),
+            )
+        }
+    val darkHolder =
+        holderSources.singleOrNull { holder -> 0 in holder.gray1600 }
+            ?: throw PatchException(
+                "Expected one dark Compose prism palette initializer",
+            )
+    val lightHolder =
+        holderSources.single { holder -> holder !== darkHolder }
+    val candidates = darkHolder.gray1600.intersect(lightHolder.gray0100)
+    return candidates.singleOrNull()
+        ?: throw PatchException(
+            "Expected one Compose prism root background parameter, found $candidates",
+        )
+}
+
+internal fun composePrismPrimaryBackgroundField(
+    constructor: com.android.tools.smali.dexlib2.iface.Method,
+): FieldReference = composePrismBackgroundField(constructor, parameterOrdinal = 0)
+
+internal fun composePrismBackgroundField(
+    constructor: com.android.tools.smali.dexlib2.iface.Method,
+    parameterOrdinal: Int,
+): FieldReference {
+    if (
+        constructor.name != "<init>" ||
+        parameterOrdinal !in constructor.parameterTypes.indices ||
+        constructor.parameterTypes[parameterOrdinal].toString() != "J"
+    ) {
+        throw PatchException(
+            "Compose prism palette constructor parameter $parameterOrdinal is not a wide color",
+        )
+    }
+    val implementation =
+        constructor.implementation
+            ?: throw PatchException("Compose prism palette constructor has no implementation")
+    val parameterRegisterCount =
+        1 + constructor.parameterTypes.sumOf { type ->
+            when (type.first()) {
+                'J', 'D' -> 2
+                else -> 1
+            }
+        }
+    val thisRegister = implementation.registerCount - parameterRegisterCount
+    val colorRegister =
+        thisRegister +
+            1 +
+            constructor.parameterTypes
+                .take(parameterOrdinal)
+                .sumOf { type ->
+                    when (type.first()) {
+                        'J', 'D' -> 2
+                        else -> 1
+                    }
+                }
+    val instructions = implementation.instructions.toList()
+    return instructions
+        .withIndex()
+        .filter { (index, instruction) ->
+            if (instruction.opcode != Opcode.IPUT_WIDE) {
+                return@filter false
+            }
+            val store = instruction as? TwoRegisterInstruction ?: return@filter false
+            if (store.registerB != thisRegister) {
+                return@filter false
+            }
+            if (store.registerA == colorRegister) {
+                return@filter true
+            }
+            if (index == 0) {
+                return@filter false
+            }
+            val move = instructions[index - 1] as? TwoRegisterInstruction ?: return@filter false
+            instructions[index - 1].opcode in
+                setOf(
+                    Opcode.MOVE_WIDE,
+                    Opcode.MOVE_WIDE_FROM16,
+                    Opcode.MOVE_WIDE_16,
+                ) &&
+                move.registerA == store.registerA &&
+                move.registerB == colorRegister
+        }
+        .mapNotNull { (_, instruction) ->
+            (instruction as? ReferenceInstruction)?.reference as? FieldReference
+        }
+        .filter { field ->
+            field.definingClass == constructor.definingClass &&
+                field.type == "J"
+        }
+        .distinct()
+        .singleOrNull()
+        ?: throw PatchException(
+            "Expected one Compose prism background constructor store for parameter " +
+                parameterOrdinal,
+        )
+}
+
+private fun wideLiteral(value: Long): String =
+    "0x${value.toULong().toString(16)}L"

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeBytecode.kt
@@ -1,0 +1,331 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.crimera.patches.instagram.misc.extension.hooks.instagramInitHook
+import app.crimera.patches.instagram.misc.settings.IgFragmentActivityOnCreate
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.util.indexOfFirstInstruction
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+internal const val INSTAGRAM_APP_SHELL_SUFFIX = "/InstagramAppShell;"
+internal const val IG_FRAGMENT_ACTIVITY_DESCRIPTOR =
+    "Lcom/instagram/base/activity/IgFragmentActivity;"
+internal const val BUNDLE_DESCRIPTOR = "Landroid/os/Bundle;"
+internal const val FUNCTION1_DESCRIPTOR = "Lkotlin/jvm/functions/Function1;"
+internal const val STRING_DESCRIPTOR = "Ljava/lang/String;"
+internal const val LIST_DESCRIPTOR = "Ljava/util/List;"
+internal const val COLLECTION_DESCRIPTOR = "Ljava/util/Collection;"
+internal const val THEME_OBJECT_DESCRIPTOR = "Ljava/lang/Object;"
+internal const val RADIO_GROUP_LISTENER_DESCRIPTOR =
+    "Landroid/widget/RadioGroup\$OnCheckedChangeListener;"
+internal data class InvokeCall(
+    val index: Int,
+    val reference: MethodReference,
+    val registers: List<Int>,
+)
+
+internal fun legacyNativeThemeListenerInvocation(
+    listenerRegister: Int,
+    packedIdsRegister: Int,
+): String =
+    "invoke-static {v$listenerRegister, v$packedIdsRegister}, " +
+        "Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->" +
+        "wrapLegacyNativeThemeListener(" +
+        "Landroid/widget/RadioGroup\$OnCheckedChangeListener;I)" +
+        "Landroid/widget/RadioGroup\$OnCheckedChangeListener;"
+
+internal fun systemUiModeCacheResolutionInvocation(
+    resultRegister: Int,
+): String =
+    "invoke-static {v$resultRegister}, " +
+        "Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->" +
+        "resolveSystemUiModeCache(I)I"
+
+context(patchContext: BytecodePatchContext)
+internal fun installThemeLifecycleHooks() {
+    instagramInitHook.fingerprint.method.apply {
+        if (
+            !definingClass.endsWith(INSTAGRAM_APP_SHELL_SUFFIX) ||
+            name != "onCreate" ||
+            parameterTypes.isNotEmpty() ||
+            returnType != "V"
+        ) {
+            throw PatchException(
+                "Unexpected InstagramAppShell lifecycle method: " +
+                    "$definingClass->$name(${parameterTypes.joinToString()})$returnType",
+            )
+        }
+
+        val firstInvokeSuperIndex = indexOfFirstInstruction(Opcode.INVOKE_SUPER)
+        if (firstInvokeSuperIndex < 0) {
+            throw PatchException("InstagramAppShell.onCreate has no invoke-super instruction")
+        }
+        val contextRegister =
+            getInstruction(firstInvokeSuperIndex).registersUsed.firstOrNull()
+                ?: throw PatchException(
+                    "InstagramAppShell.onCreate invoke-super has no context register",
+                )
+
+        addInstruction(
+            firstInvokeSuperIndex + 1,
+            """
+            invoke-static {v$contextRegister}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->initialize(Landroid/content/Context;)V
+            """.trimIndent(),
+        )
+    }
+
+    IgFragmentActivityOnCreate.method.apply {
+        if (
+            definingClass != IG_FRAGMENT_ACTIVITY_DESCRIPTOR ||
+            name != "onCreate" ||
+            parameterTypes.size != 1 ||
+            parameterTypes[0].toString() != BUNDLE_DESCRIPTOR ||
+            returnType != "V"
+        ) {
+            throw PatchException(
+                "Unexpected IgFragmentActivity lifecycle method: " +
+                    "$definingClass->$name(${parameterTypes.joinToString()})$returnType",
+            )
+        }
+
+        addInstruction(
+            0,
+            """
+            invoke-static {p0}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->applyToActivity(Landroid/app/Activity;)V
+            """.trimIndent(),
+        )
+    }
+}
+
+context(patchContext: BytecodePatchContext)
+internal fun installSystemDefaultUiModeHook() {
+    val method =
+        CurrentSystemUiModeFingerprint
+            .matchAll(1..1)
+            .single()
+            .method
+    if (
+        !AccessFlags.STATIC.isSet(method.accessFlags) ||
+        method.parameterTypes.isNotEmpty() ||
+        method.returnType != "I"
+    ) {
+        throw PatchException(
+            "Unexpected current system ui mode method: " +
+                "${method.definingClass}->${method.name}" +
+                "(${method.parameterTypes.joinToString()})${method.returnType}",
+        )
+    }
+
+    val returnIndexes =
+        method.instructions.mapIndexedNotNull { index, instruction ->
+            if (instruction.opcode == Opcode.RETURN) index else null
+        }
+    if (returnIndexes.size != 1) {
+        throw PatchException(
+            "Expected one current system ui mode return, found ${returnIndexes.size}",
+        )
+    }
+
+    val returnIndex = returnIndexes.single()
+    val resultRegister =
+        (method.getInstruction(returnIndex) as? OneRegisterInstruction)
+            ?.registerA
+            ?: throw PatchException(
+                "Current system ui mode return does not use one register",
+            )
+    if (resultRegister !in 0..0xf) {
+        throw PatchException(
+            "Current system ui mode result register is not 4-bit: v$resultRegister",
+        )
+    }
+
+    method.addInstructions(
+        returnIndex,
+        """
+        ${systemUiModeCacheResolutionInvocation(resultRegister)}
+        move-result v$resultRegister
+        """.trimIndent(),
+    )
+}
+
+context(patchContext: BytecodePatchContext)
+
+internal fun installMaterialYouToggle(
+    titleId: Int,
+    amoledTitleId: Int,
+) {
+    if (titleId == 0 || amoledTitleId == 0) {
+        throw PatchException("Theme string resource ids must be non-zero")
+    }
+
+    installLegacyAmoledRadio(amoledTitleId)
+    installLegacyMaterialYouToggle()
+    installComposeMaterialYouToggle(
+        titleId = titleId,
+    )
+}
+
+internal fun MutableMethod.invokeCalls(): List<InvokeCall> =
+    instructions.mapIndexedNotNull { index, instruction ->
+        if (
+            instruction.opcode != Opcode.INVOKE_STATIC &&
+            instruction.opcode != Opcode.INVOKE_STATIC_RANGE
+        ) {
+            return@mapIndexedNotNull null
+        }
+        val reference =
+            (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                ?: return@mapIndexedNotNull null
+
+        InvokeCall(
+            index = index,
+            reference = reference,
+            registers = instruction.registersUsed,
+        )
+    }
+
+internal fun firstParameterRegister(method: MutableMethod): Int {
+    val implementation =
+        method.implementation
+            ?: throw PatchException("${method.name} has no implementation")
+    val parameterRegisterCount =
+        method.parameterTypes.sumOf { type ->
+            if (type == "J" || type == "D") 2 else 1
+        } + if (AccessFlags.STATIC.isSet(method.accessFlags)) 0 else 1
+    val firstParameterRegister = implementation.registerCount - parameterRegisterCount
+    if (firstParameterRegister < 0) {
+        throw PatchException(
+            "Invalid register count for ${method.definingClass}->${method.name}",
+        )
+    }
+
+    return firstParameterRegister
+}
+
+internal fun String.isObjectDescriptor(): Boolean =
+    length >= 3 && startsWith("L") && endsWith(";")
+
+internal data class LegacyBinding(
+    val method: MutableMethod,
+    val radioConstructor: InvokeCall,
+    val bindIndex: Int,
+    val collectionRegister: Int,
+)
+
+internal fun findLegacyBinding(method: MutableMethod): LegacyBinding? {
+    val instructions = method.instructions
+    val radioConstructors =
+        instructions.mapIndexedNotNull { index, instruction ->
+            if (
+                instruction.opcode != Opcode.INVOKE_DIRECT &&
+                instruction.opcode != Opcode.INVOKE_DIRECT_RANGE
+            ) {
+                return@mapIndexedNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapIndexedNotNull null
+            if (
+                reference.name != "<init>" ||
+                reference.returnType != "V" ||
+                reference.parameterTypes.map(CharSequence::toString) !=
+                listOf(
+                    RADIO_GROUP_LISTENER_DESCRIPTOR,
+                    STRING_DESCRIPTOR,
+                    LIST_DESCRIPTOR,
+                )
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            InvokeCall(
+                index = index,
+                reference = reference,
+                registers = instruction.registersUsed,
+            )
+        }
+    val bindingCandidates =
+        radioConstructors.mapNotNull { constructor ->
+            if (constructor.registers.size != 4 || constructor.index + 2 > instructions.lastIndex) {
+                return@mapNotNull null
+            }
+
+            val rowRegister = constructor.registers[0]
+            val addInstruction = instructions[constructor.index + 1]
+            val addReference =
+                (addInstruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapNotNull null
+            val addRegisters = addInstruction.registersUsed
+            if (
+                addInstruction.opcode != Opcode.INVOKE_VIRTUAL &&
+                addInstruction.opcode != Opcode.INVOKE_INTERFACE
+            ) {
+                return@mapNotNull null
+            }
+            if (
+                addReference.name != "add" ||
+                addReference.returnType != "Z" ||
+                addReference.parameterTypes.map(CharSequence::toString) !=
+                listOf(THEME_OBJECT_DESCRIPTOR) ||
+                addRegisters.size != 2 ||
+                addRegisters[1] != rowRegister
+            ) {
+                return@mapNotNull null
+            }
+
+            val bindIndex = constructor.index + 2
+            val bindInstruction = instructions[bindIndex]
+            val bindReference =
+                (bindInstruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapNotNull null
+            val bindRegisters = bindInstruction.registersUsed
+            if (
+                bindInstruction.opcode != Opcode.INVOKE_VIRTUAL &&
+                bindInstruction.opcode != Opcode.INVOKE_INTERFACE
+            ) {
+                return@mapNotNull null
+            }
+            if (
+                bindReference.returnType != "V" ||
+                bindReference.parameterTypes.map(CharSequence::toString) !=
+                listOf(COLLECTION_DESCRIPTOR) ||
+                bindReference.definingClass == method.definingClass ||
+                bindRegisters.size != 2 ||
+                bindRegisters[0] != firstParameterRegister(method) ||
+                bindRegisters[1] != addRegisters[0]
+            ) {
+                return@mapNotNull null
+            }
+
+            LegacyBinding(
+                method = method,
+                radioConstructor = constructor,
+                bindIndex = bindIndex,
+                collectionRegister = addRegisters[0],
+            )
+        }
+    if (bindingCandidates.size > 1) {
+        throw PatchException(
+            "Expected at most one RadioGroup append followed by adapter binding in " +
+                "${method.definingClass}->${method.name}, found ${bindingCandidates.size}",
+        )
+    }
+
+    return bindingCandidates.singleOrNull()
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeComposeBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeComposeBytecode.kt
@@ -1,0 +1,681 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.patcher.util.smali.toInstruction
+import app.morphe.util.findFreeRegister
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MethodImplementationBuilder
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val MATERIAL_YOU_TOGGLE_NAME = "pikoMaterialYouToggle"
+private const val MATERIAL_YOU_WRAPPER_NAME = "pikoMaterialYouToggleRow"
+
+private data class StringResourceCall(
+    val literalIndex: Int,
+    val resourceRegister: Int,
+    val reference: MethodReference,
+)
+
+private data class SettingRowCalls(
+    val dark: InvokeCall,
+    val light: InvokeCall,
+    val system: InvokeCall,
+)
+
+private data class ComposeRadioBinding(
+    val titleGetter: MethodReference,
+    val titleResourceRegister: Int,
+    val titleRegister: Int,
+    val itemFactory: MethodReference,
+    val itemFactoryIndex: Int,
+    val callbackRegister: Int,
+    val selectedRegister: Int,
+    val itemRegister: Int,
+    val rowReference: MethodReference,
+    val composerRegister: Int,
+    val styleRegister: Int,
+)
+
+context(patchContext: BytecodePatchContext)
+internal fun installComposeMaterialYouToggle(
+    titleId: Int,
+) {
+    val darkModeMatch = DarkModeSectionFingerprint.matchAll(1..1).single()
+    val reduceMotionMatch = ReduceMotionToggleFingerprint.matchAll(1..1).single()
+    val darkModeSection = darkModeMatch.method
+    val source = reduceMotionMatch.method
+
+    validateComposableMethods(
+        darkModeSection = darkModeSection,
+        source = source,
+    )
+
+    val owner = source.definingClass
+    val composerType = source.parameterTypes[0].toString()
+    val ownerClass = patchContext.mutableClassDefBy(owner)
+    if (
+        ownerClass.methods.any {
+            it.name == MATERIAL_YOU_TOGGLE_NAME ||
+                it.name == MATERIAL_YOU_WRAPPER_NAME
+        }
+    ) {
+        throw PatchException(
+            "Material You toggle methods already exist in $owner",
+        )
+    }
+
+    val copy =
+        MutableMethod(source).apply {
+            name = MATERIAL_YOU_TOGGLE_NAME
+        }
+    validateMethodCopy(source, copy)
+    val wrapper =
+        createMaterialYouToggleWrapper(
+            owner = owner,
+            composerType = composerType,
+        )
+
+    val stringCalls = findStringResourceCalls(copy, composerType)
+    val initialSettingRows =
+        findSettingRowCalls(
+            method = darkModeSection,
+            composerType = composerType,
+            composerRegister = firstParameterRegister(darkModeSection),
+        )
+    installComposeNativeThemeModeSync(
+        method = darkModeSection,
+        beforeIndex = initialSettingRows.dark.index,
+    )
+    val settingRows =
+        findSettingRowCalls(
+            method = darkModeSection,
+            composerType = composerType,
+            composerRegister = firstParameterRegister(darkModeSection),
+        )
+    val radioBinding =
+        deriveComposeRadioBinding(
+            method = darkModeSection,
+            composerType = composerType,
+            settingRows = settingRows,
+        )
+    val nativeCallbackRegister =
+        parameterRegister(
+            method = darkModeSection,
+            parameterIndex =
+                darkModeSection.parameterTypes.indexOfFirst {
+                    it.toString() == FUNCTION1_DESCRIPTOR
+                },
+        )
+    if (nativeCallbackRegister !in 0..0xf) {
+        throw PatchException("Compose native theme callback requires a 4-bit register")
+    }
+    val insertIndex = settingRows.system.index + 1
+    val freeRegisters = findTwoLocalRegisters(darkModeSection, insertIndex)
+    val stateRegister = freeRegisters[0]
+    val callbackRegister = freeRegisters[1]
+
+    copy.replaceInstruction(
+        stringCalls[0].literalIndex,
+        "const v${stringCalls[0].resourceRegister}, $titleId",
+    )
+    replaceStringResourceResultWithNull(
+        method = copy,
+        literalIndex = stringCalls[1].literalIndex,
+    )
+    redirectMaterialYouRestartCallback(
+        source = source,
+        copy = copy,
+        composerType = composerType,
+        targetName = MATERIAL_YOU_TOGGLE_NAME,
+    )
+
+    if (!ownerClass.methods.add(copy)) {
+        throw PatchException(
+            "Failed to add copied method $owner->$MATERIAL_YOU_TOGGLE_NAME",
+        )
+    }
+    if (!ownerClass.methods.add(wrapper)) {
+        throw PatchException(
+            "Failed to add wrapper method $owner->$MATERIAL_YOU_WRAPPER_NAME",
+        )
+    }
+    val originalInstruction = darkModeSection.getInstruction(insertIndex)
+    darkModeSection.addInstructionsWithLabels(
+        insertIndex,
+        """
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAvailable()Z
+        move-result v$stateRegister
+        if-eqz v$stateRegister, :piko_material_you_end
+
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getToggleCallback()Lkotlin/jvm/functions/Function1;
+        move-result-object v$callbackRegister
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isEnabled()Z
+        move-result v$stateRegister
+        invoke-static {p0, v$callbackRegister, v$stateRegister}, $owner->$MATERIAL_YOU_WRAPPER_NAME(${composerType}Lkotlin/jvm/functions/Function1;Z)V
+        """.trimIndent(),
+        ExternalLabel("piko_material_you_end", originalInstruction),
+    )
+    val materialYouInstruction = darkModeSection.getInstruction(insertIndex)
+    darkModeSection.addInstructionsWithLabels(
+        insertIndex,
+        """
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAmoledAvailable()Z
+        move-result v${radioBinding.selectedRegister}
+        if-eqz v${radioBinding.selectedRegister}, :piko_amoled_radio_end
+
+        ${composeAmoledTitleInvocation()}
+        move-result-object v${radioBinding.titleRegister}
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAmoledEnabled()Z
+        move-result v${radioBinding.selectedRegister}
+        invoke-static {v$nativeCallbackRegister}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getAmoledRadioCallback(Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function0;
+        move-result-object v${radioBinding.callbackRegister}
+        invoke-static {v${radioBinding.callbackRegister}, v${radioBinding.selectedRegister}}, ${radioBinding.itemFactory}
+        move-result-object v${radioBinding.itemRegister}
+        invoke-static {v${radioBinding.composerRegister}, v${radioBinding.styleRegister}, v${radioBinding.itemRegister}, v${radioBinding.titleRegister}}, ${radioBinding.rowReference}
+        """.trimIndent(),
+        ExternalLabel("piko_amoled_radio_end", materialYouInstruction),
+    )
+    darkModeSection.addInstructions(
+        radioBinding.itemFactoryIndex,
+        """
+        invoke-static {v${radioBinding.selectedRegister}}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->shouldSelectNativeDark(Z)Z
+        move-result v${radioBinding.selectedRegister}
+        """.trimIndent(),
+    )
+    darkModeSection.addInstructions(
+        0,
+        """
+        invoke-static {v$nativeCallbackRegister}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->wrapNativeThemeCallback(Lkotlin/jvm/functions/Function1;)Lkotlin/jvm/functions/Function1;
+        move-result-object v$nativeCallbackRegister
+        """.trimIndent(),
+    )
+}
+
+internal fun composeAmoledTitleInvocation(): String =
+    "invoke-static {}, " +
+        "Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->" +
+        "getAmoledTitle()Ljava/lang/String;"
+
+internal fun installComposeNativeThemeModeSync(
+    method: MutableMethod,
+    beforeIndex: Int,
+) {
+    val instructions = method.instructions
+    val candidates =
+        instructions.withIndex().mapNotNull { (index, instruction) ->
+            if (
+                index >= beforeIndex ||
+                instruction.opcode !in
+                setOf(
+                    Opcode.INVOKE_INTERFACE,
+                    Opcode.INVOKE_INTERFACE_RANGE,
+                )
+            ) {
+                return@mapNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapNotNull null
+            if (
+                reference.name != "getInt" ||
+                reference.parameterTypes.map(CharSequence::toString) !=
+                listOf(STRING_DESCRIPTOR, "I") ||
+                reference.returnType != "I"
+            ) {
+                return@mapNotNull null
+            }
+            val registers = instruction.registersUsed
+            if (registers.size != 3 || index + 1 >= instructions.size) {
+                return@mapNotNull null
+            }
+            val defaultRegister = registers[2]
+            val defaultValue =
+                instructions
+                    .subList(maxOf(0, index - 8), index)
+                    .asReversed()
+                    .mapNotNull { previous ->
+                        val register = (previous as? OneRegisterInstruction)?.registerA
+                        val literal = previous as? NarrowLiteralInstruction
+                        if (register == defaultRegister) literal?.narrowLiteral else null
+                    }.firstOrNull()
+            if (defaultValue != -1) {
+                return@mapNotNull null
+            }
+            val result = instructions[index + 1]
+            val resultRegister = (result as? OneRegisterInstruction)?.registerA
+            if (result.opcode != Opcode.MOVE_RESULT || resultRegister !in 0..0xf) {
+                return@mapNotNull null
+            }
+            index + 1 to resultRegister
+        }
+    val (resultIndex, resultRegister) =
+        candidates.singleOrNull()
+            ?: throw PatchException(
+                "Expected one Compose native theme setting read, found ${candidates.size}",
+            )
+    method.addInstruction(
+        resultIndex + 1,
+        "invoke-static {v$resultRegister}, " +
+            "Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->" +
+            "observeComposeNativeThemeMode(I)V",
+    )
+}
+
+private fun createMaterialYouToggleWrapper(
+    owner: String,
+    composerType: String,
+): MutableMethod {
+    val implementation =
+        MethodImplementationBuilder(4).apply {
+            addInstruction("const/4 v0, 0x0".toInstruction())
+            addInstruction(
+                (
+                    "invoke-static {v1, v2, v0, v3}, " +
+                        "$owner->$MATERIAL_YOU_TOGGLE_NAME(" +
+                        "${composerType}${FUNCTION1_DESCRIPTOR}IZ)V"
+                ).toInstruction(),
+            )
+            addInstruction("return-void".toInstruction())
+        }.methodImplementation
+    val accessFlags =
+        AccessFlags.PRIVATE.value or
+            AccessFlags.STATIC.value or
+            AccessFlags.FINAL.value
+    val wrapper =
+        MutableMethod(
+            ImmutableMethod(
+                owner,
+                MATERIAL_YOU_WRAPPER_NAME,
+                listOf(
+                    ImmutableMethodParameter(composerType, emptySet(), null),
+                    ImmutableMethodParameter(FUNCTION1_DESCRIPTOR, emptySet(), null),
+                    ImmutableMethodParameter("Z", emptySet(), null),
+                ),
+                "V",
+                accessFlags,
+                emptySet(),
+                emptySet(),
+                implementation,
+            ),
+        )
+    val wrapperParameters = wrapper.parameterTypes.map(CharSequence::toString)
+    if (
+        wrapper.definingClass != owner ||
+        wrapper.name != MATERIAL_YOU_WRAPPER_NAME ||
+        wrapperParameters != listOf(composerType, FUNCTION1_DESCRIPTOR, "Z") ||
+        wrapper.returnType != "V" ||
+        !AccessFlags.PRIVATE.isSet(wrapper.accessFlags) ||
+        !AccessFlags.STATIC.isSet(wrapper.accessFlags) ||
+        wrapper.implementation?.registerCount != 4 ||
+        firstParameterRegister(wrapper) != 1 ||
+        wrapper.instructions.any { instruction ->
+            instruction.registersUsed.any { it !in 0..0xf }
+        }
+    ) {
+        throw PatchException("Invalid Material You toggle wrapper")
+    }
+    return wrapper
+}
+
+private fun validateComposableMethods(
+    darkModeSection: MutableMethod,
+    source: MutableMethod,
+) {
+    val darkParameters = darkModeSection.parameterTypes.map(CharSequence::toString)
+    val sourceParameters = source.parameterTypes.map(CharSequence::toString)
+    if (
+        darkModeSection.definingClass != source.definingClass ||
+        darkModeSection.returnType != source.returnType ||
+        darkModeSection.returnType != "V" ||
+        darkParameters.isEmpty() ||
+        sourceParameters !=
+        listOf(
+            darkParameters[0],
+            FUNCTION1_DESCRIPTOR,
+            "I",
+            "Z",
+        ) ||
+        darkParameters.count { it == FUNCTION1_DESCRIPTOR } != 1 ||
+        darkParameters[0] != sourceParameters[0] ||
+        !darkParameters[0].isObjectDescriptor() ||
+        !AccessFlags.STATIC.isSet(darkModeSection.accessFlags) ||
+        !AccessFlags.STATIC.isSet(source.accessFlags)
+    ) {
+        throw PatchException(
+            "Unexpected DarkModeSection/ReduceMotionToggle signatures: " +
+                "${darkModeSection.definingClass}->${darkModeSection.name}" +
+                "(${darkParameters.joinToString()})${darkModeSection.returnType}, " +
+                "${source.definingClass}->${source.name}" +
+                "(${sourceParameters.joinToString()})${source.returnType}",
+        )
+    }
+}
+
+private fun validateMethodCopy(
+    source: MutableMethod,
+    copy: MutableMethod,
+) {
+    val sourceImplementation =
+        source.implementation
+            ?: throw PatchException("ReduceMotionToggle has no implementation")
+    val copyImplementation =
+        copy.implementation
+            ?: throw PatchException("Copied ReduceMotionToggle has no implementation")
+    val sourceInstructions = source.instructions
+    val copyInstructions = copy.instructions
+    val sourceBranchOffsets =
+        sourceInstructions.filterIsInstance<OffsetInstruction>().map { it.codeOffset }
+    val copyBranchOffsets =
+        copyInstructions.filterIsInstance<OffsetInstruction>().map { it.codeOffset }
+
+    if (
+        sourceImplementation.registerCount != copyImplementation.registerCount ||
+        sourceInstructions.size != copyInstructions.size ||
+        sourceBranchOffsets != copyBranchOffsets
+    ) {
+        throw PatchException(
+            "ReduceMotionToggle copy did not preserve registers, instructions, and branches",
+        )
+    }
+}
+
+private fun findStringResourceCalls(
+    method: MutableMethod,
+    composerType: String,
+): List<StringResourceCall> {
+    val invokes = method.invokeCalls()
+    val calls =
+        invokes.mapNotNull { call ->
+            val parameterTypes = call.reference.parameterTypes.map(CharSequence::toString)
+            if (
+                call.reference.returnType != STRING_DESCRIPTOR ||
+                parameterTypes != listOf(composerType, "I") ||
+                !call.reference.definingClass.isObjectDescriptor() ||
+                call.registers.size != 2 ||
+                call.index == 0
+            ) {
+                return@mapNotNull null
+            }
+
+            val literalInstruction = method.instructions[call.index - 1]
+            val oneRegisterInstruction =
+                literalInstruction as? OneRegisterInstruction
+                    ?: return@mapNotNull null
+            val narrowLiteralInstruction =
+                literalInstruction as? NarrowLiteralInstruction
+                    ?: return@mapNotNull null
+            if (
+                literalInstruction.opcode != Opcode.CONST ||
+                oneRegisterInstruction.registerA != call.registers[1] ||
+                narrowLiteralInstruction.narrowLiteral == 0
+            ) {
+                return@mapNotNull null
+            }
+
+            StringResourceCall(
+                literalIndex = call.index - 1,
+                resourceRegister = oneRegisterInstruction.registerA,
+                reference = call.reference,
+            )
+        }
+
+    val candidates =
+        calls
+            .groupBy { it.reference.toString() }
+            .values
+            .filter { group ->
+                group.size == 2 &&
+                    invokes.count { it.reference.toString() == group[0].reference.toString() } == 2
+            }
+    if (candidates.size != 1) {
+        throw PatchException(
+            "Expected exactly one string getter called by two resource literals, " +
+                "found ${candidates.size}",
+        )
+    }
+
+    return candidates.single().sortedBy(StringResourceCall::literalIndex)
+}
+
+internal fun replaceStringResourceResultWithNull(
+    method: MutableMethod,
+    literalIndex: Int,
+) {
+    val invokeIndex = literalIndex + 1
+    val resultIndex = literalIndex + 2
+    val instructions = method.instructions
+    val invokeReference =
+        (instructions.getOrNull(invokeIndex) as? ReferenceInstruction)
+            ?.reference as? MethodReference
+    val resultInstruction =
+        instructions.getOrNull(resultIndex) as? OneRegisterInstruction
+    val resultRegister = resultInstruction?.registerA
+    if (
+        invokeReference?.returnType != STRING_DESCRIPTOR ||
+        resultInstruction?.opcode != Opcode.MOVE_RESULT_OBJECT ||
+        resultRegister !in 0..0xf
+    ) {
+        throw PatchException(
+            "Expected a String getter followed by a 4-bit move-result-object",
+        )
+    }
+
+    method.replaceInstruction(
+        resultIndex,
+        "const/4 v$resultRegister, 0x0",
+    )
+}
+
+private fun findSettingRowCalls(
+    method: MutableMethod,
+    composerType: String,
+    composerRegister: Int,
+): SettingRowCalls {
+    val invokes = method.invokeCalls()
+    val fourArgumentGroups =
+        invokes
+            .filter { call ->
+                val parameterTypes = call.reference.parameterTypes.map(CharSequence::toString)
+                call.reference.returnType == "V" &&
+                    call.reference.definingClass.isObjectDescriptor() &&
+                    parameterTypes.size == 4 &&
+                    parameterTypes[0] == composerType &&
+                    parameterTypes.last() == STRING_DESCRIPTOR &&
+                    call.registers.size == 4 &&
+                    call.registers[0] == composerRegister
+            }.groupBy { it.reference.toString() }
+            .values
+            .filter { it.size == 2 }
+
+    val candidates =
+        fourArgumentGroups.mapNotNull { group ->
+            val ordered = group.sortedBy(InvokeCall::index)
+            val reference = ordered[0].reference
+            val parameterTypes = reference.parameterTypes.map(CharSequence::toString)
+            val fiveArgumentTypes = parameterTypes + STRING_DESCRIPTOR
+            val fiveArgumentCalls =
+                invokes.filter { call ->
+                    call.reference.definingClass == reference.definingClass &&
+                        call.reference.returnType == reference.returnType &&
+                        call.reference.parameterTypes.map(CharSequence::toString) ==
+                        fiveArgumentTypes &&
+                        call.registers.size == 5 &&
+                        call.registers[0] == composerRegister
+                }
+            if (
+                fiveArgumentCalls.size != 1 ||
+                ordered[0].index >= ordered[1].index ||
+                ordered[1].index >= fiveArgumentCalls[0].index
+            ) {
+                return@mapNotNull null
+            }
+
+            SettingRowCalls(
+                dark = ordered[0],
+                light = ordered[1],
+                system = fiveArgumentCalls[0],
+            )
+        }
+
+    if (candidates.size != 1) {
+        throw PatchException(
+            "Expected one ordered setting-row family with two 4-argument calls " +
+                "and one 5-argument call, found ${candidates.size}",
+        )
+    }
+
+    return candidates.single()
+}
+
+private fun deriveComposeRadioBinding(
+    method: MutableMethod,
+    composerType: String,
+    settingRows: SettingRowCalls,
+): ComposeRadioBinding {
+    val dark = settingRows.dark
+    val instructions = method.instructions
+    if (dark.registers.size != 4 || dark.index < 2) {
+        throw PatchException("Dark setting row has an unexpected call shape")
+    }
+    val rowParameterTypes = dark.reference.parameterTypes.map(CharSequence::toString)
+    if (
+        rowParameterTypes.size != 4 ||
+        rowParameterTypes[0] != composerType ||
+        rowParameterTypes[3] != STRING_DESCRIPTOR
+    ) {
+        throw PatchException("Dark setting row has an unexpected method descriptor")
+    }
+
+    val itemFactoryInstruction = instructions[dark.index - 2]
+    val itemFactory =
+        (itemFactoryInstruction as? ReferenceInstruction)?.reference as? MethodReference
+            ?: throw PatchException("Dark setting row item factory has no method reference")
+    val itemFactoryRegisters = itemFactoryInstruction.registersUsed
+    val itemMoveInstruction = instructions[dark.index - 1]
+    val itemMoveRegister =
+        (itemMoveInstruction as? OneRegisterInstruction)?.registerA
+            ?: throw PatchException("Dark setting row item factory has no result register")
+    if (
+        itemFactoryInstruction.opcode != Opcode.INVOKE_STATIC ||
+        itemFactory.parameterTypes.size != 2 ||
+        itemFactory.parameterTypes[1].toString() != "Z" ||
+        !itemFactory.returnType.isObjectDescriptor() ||
+        !rowParameterTypes[2].isObjectDescriptor() ||
+        itemFactoryRegisters.size != 2 ||
+        itemMoveInstruction.opcode != Opcode.MOVE_RESULT_OBJECT ||
+        itemMoveRegister != dark.registers[2]
+    ) {
+        throw PatchException("Could not derive the Dark setting row item factory")
+    }
+
+    val titleRegister = dark.registers[3]
+    val titleGetterCalls =
+        method.invokeCalls().filter { call ->
+            if (
+                call.index >= dark.index - 1 ||
+                call.reference.returnType != STRING_DESCRIPTOR ||
+                call.reference.parameterTypes.map(CharSequence::toString) !=
+                listOf(composerType, "I") ||
+                call.registers.size != 2 ||
+                call.registers[0] != dark.registers[0] ||
+                call.index + 1 >= instructions.size
+            ) {
+                return@filter false
+            }
+            val moveInstruction = instructions[call.index + 1]
+            moveInstruction.opcode == Opcode.MOVE_RESULT_OBJECT &&
+                (moveInstruction as? OneRegisterInstruction)?.registerA == titleRegister
+        }
+    val titleGetterCall =
+        titleGetterCalls.lastOrNull()
+            ?: throw PatchException("Could not derive the Dark setting row title getter")
+
+    val registers =
+        listOf(
+            titleGetterCall.registers[1],
+            titleRegister,
+            itemFactoryRegisters[0],
+            itemFactoryRegisters[1],
+            dark.registers[2],
+            dark.registers[0],
+            dark.registers[1],
+        )
+    if (registers.any { it !in 0..0xf }) {
+        throw PatchException("Compose AMOLED RadioItem requires 4-bit registers")
+    }
+
+    return ComposeRadioBinding(
+        titleGetter = titleGetterCall.reference,
+        titleResourceRegister = titleGetterCall.registers[1],
+        titleRegister = titleRegister,
+        itemFactory = itemFactory,
+        itemFactoryIndex = dark.index - 2,
+        callbackRegister = itemFactoryRegisters[0],
+        selectedRegister = itemFactoryRegisters[1],
+        itemRegister = dark.registers[2],
+        rowReference = dark.reference,
+        composerRegister = dark.registers[0],
+        styleRegister = dark.registers[1],
+    )
+}
+
+private fun findTwoLocalRegisters(
+    method: MutableMethod,
+    insertIndex: Int,
+): List<Int> {
+    val firstParameterRegister = firstParameterRegister(method)
+    val stateRegister = method.findFreeRegister(insertIndex)
+    val callbackRegister = method.findFreeRegister(insertIndex, stateRegister)
+    val registers = listOf(stateRegister, callbackRegister)
+    if (
+        registers.distinct().size != registers.size ||
+        registers.any { it < 0 || it >= firstParameterRegister || it > 0xf } ||
+        firstParameterRegister > 0xf
+    ) {
+        throw PatchException(
+            "Material You toggle requires two distinct local 4-bit registers " +
+                "without overwriting parameter registers; found $registers",
+        )
+    }
+
+    return registers
+}
+
+private fun parameterRegister(
+    method: MutableMethod,
+    parameterIndex: Int,
+): Int {
+    if (parameterIndex !in method.parameterTypes.indices) {
+        throw PatchException(
+            "Could not derive parameter register $parameterIndex for " +
+                "${method.definingClass}->${method.name}",
+        )
+    }
+    return firstParameterRegister(method) +
+        method.parameterTypes.take(parameterIndex).sumOf { type ->
+            if (type == "J" || type == "D") 2 else 1
+        }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeFingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeFingerprints.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.Fingerprint
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object LegacyDarkModeFragmentConstructorFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    parameters = emptyList(),
+    strings = listOf("theme_settings"),
+)
+
+internal object CurrentSystemUiModeFingerprint : Fingerprint(
+    returnType = "I",
+    parameters = emptyList(),
+    strings =
+        listOf(
+            "ig_device_theme",
+            "KEY_CONFIG_CURRENT_SYSTEM_UI_MODE",
+        ),
+    custom = { method, _ ->
+        AccessFlags.STATIC.isSet(method.accessFlags) &&
+            method.implementation != null
+    },
+)
+
+internal object SwitchItemConstructorFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    parameters =
+        listOf(
+            "Landroid/widget/CompoundButton${'$'}OnCheckedChangeListener;",
+            "Ljava/lang/CharSequence;",
+            "Z",
+        ),
+    custom = { _, classDef ->
+        classDef.fields.count { it.type == "Ljava/lang/CharSequence;" } == 2
+    },
+)
+
+internal object DarkModeSectionFingerprint : Fingerprint(
+    returnType = "V",
+    strings =
+        listOf(
+            "com.instagram.settings.impl.accessibility.DarkModeSection " +
+                "(AccessibilityOptionsComposeFragment.kt:267)",
+            "dark",
+            "light",
+            "system",
+        ),
+    custom = { method, _ ->
+        method.parameterTypes.count {
+            it == "Lkotlin/jvm/functions/Function1;"
+        } == 1
+    },
+)
+
+internal object ReduceMotionToggleFingerprint : Fingerprint(
+    returnType = "V",
+    strings =
+        listOf(
+            "com.instagram.settings.impl.accessibility.ReduceMotionToggle " +
+                "(AccessibilityOptionsComposeFragment.kt:313)",
+        ),
+    custom = { method, _ ->
+        method.parameterTypes.size == 4 &&
+            method.parameterTypes[1] == "Lkotlin/jvm/functions/Function1;" &&
+            method.parameterTypes[2] == "I" &&
+            method.parameterTypes[3] == "Z"
+    },
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
@@ -1,0 +1,729 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.findFreeRegister
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+
+private data class LegacyRadioItemBinding(
+    val type: String,
+    val objectConstructor: MethodReference,
+    val titleField: FieldReference,
+    val nativeModeField: FieldReference,
+    val descriptionField: FieldReference,
+    val idField: FieldReference,
+    val lightId: Int,
+    val darkId: Int,
+    val systemId: Int,
+    val amoledId: Int,
+)
+
+private data class LegacyTitleBinding(
+    val displayIdRegister: Int,
+    val titleResourceRegister: Int,
+    val titleMoveIndex: Int,
+    val titleStringRegister: Int,
+)
+
+private data class LegacyOnCreateBinding(
+    val method: MutableMethod,
+    val insertIndex: Int,
+    val listRegister: Int,
+    val itemRegister: Int,
+    val addReference: MethodReference,
+    val itemType: String,
+    val listField: FieldReference,
+    val receiverRegister: Int,
+)
+
+private data class LegacyItemRecord(
+    var nativeMode: Int? = null,
+    var id: String? = null,
+)
+
+context(patchContext: BytecodePatchContext)
+internal fun installLegacyAmoledRadio(titleId: Int) {
+    val fragmentConstructor =
+        LegacyDarkModeFragmentConstructorFingerprint
+            .matchAll(1..1)
+            .single()
+            .method
+    val owner = fragmentConstructor.definingClass
+    val ownerClass = patchContext.mutableClassDefBy(owner)
+    val onCreate =
+        ownerClass.methods.singleOrNull { method ->
+            method.name == "onCreate" &&
+                method.parameterTypes.map(CharSequence::toString) == listOf(BUNDLE_DESCRIPTOR) &&
+                method.returnType == "V" &&
+                !AccessFlags.STATIC.isSet(method.accessFlags)
+        } ?: throw PatchException("Expected one legacy theme onCreate(Bundle) method in $owner")
+    val onCreateBinding = deriveLegacyOnCreateBinding(onCreate)
+    val itemBinding =
+        deriveLegacyRadioItemBinding(
+            itemType = onCreateBinding.itemType,
+        )
+
+    val onResumeBinding =
+        ownerClass.methods.mapNotNull { method ->
+            if (
+                method.name == "onResume" &&
+                method.parameterTypes.isEmpty() &&
+                method.returnType == "V" &&
+                !AccessFlags.STATIC.isSet(method.accessFlags)
+            ) {
+                findLegacyBinding(method)
+            } else {
+                null
+            }
+        }.singleOrNull()
+            ?: throw PatchException(
+                "Expected one legacy theme onResume RadioGroup/adapter binding in $owner",
+            )
+    installLegacyOnResumeRadioHooks(
+        binding = onResumeBinding,
+        itemBinding = itemBinding,
+    )
+    installLegacyOnCreateAmoledItem(
+        binding = onCreateBinding,
+        itemBinding = itemBinding,
+        titleId = titleId,
+    )
+}
+
+private fun deriveLegacyOnCreateBinding(method: MutableMethod): LegacyOnCreateBinding {
+    data class AddCandidate(
+        val index: Int,
+        val listRegister: Int,
+        val itemRegister: Int,
+        val addReference: MethodReference,
+        val itemType: String,
+    )
+
+    val instructions = method.instructions
+    val candidates =
+        instructions.mapIndexedNotNull { index, instruction ->
+            if (
+                index == 0 ||
+                (
+                    instruction.opcode != Opcode.INVOKE_INTERFACE &&
+                        instruction.opcode != Opcode.INVOKE_VIRTUAL
+                    )
+            ) {
+                return@mapIndexedNotNull null
+            }
+            val addReference =
+                (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapIndexedNotNull null
+            val addRegisters = instruction.registersUsed
+            if (
+                addReference.name != "add" ||
+                addReference.parameterTypes.map(CharSequence::toString) !=
+                listOf(THEME_OBJECT_DESCRIPTOR) ||
+                addReference.returnType != "Z" ||
+                addRegisters.size != 2
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            val itemInstruction = instructions[index - 1]
+            val itemField =
+                (itemInstruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapIndexedNotNull null
+            val itemRegisters = itemInstruction.registersUsed
+            if (
+                itemInstruction.opcode != Opcode.SGET_OBJECT ||
+                itemRegisters.size != 1 ||
+                itemRegisters[0] != addRegisters[1] ||
+                !itemField.type.isObjectDescriptor()
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            AddCandidate(
+                index = index,
+                listRegister = addRegisters[0],
+                itemRegister = addRegisters[1],
+                addReference = addReference,
+                itemType = itemField.type,
+            )
+        }
+    val groups =
+        candidates
+            .groupBy { Triple(it.listRegister, it.itemType, it.addReference.toString()) }
+            .values
+            .filter { group ->
+                group.size == 3 &&
+                    group.zipWithNext().all { (first, second) -> second.index == first.index + 2 }
+            }
+    if (groups.size != 1) {
+        throw PatchException(
+            "Expected one legacy onCreate sequence with three RadioItem List.add calls, " +
+                "found ${groups.size}",
+        )
+    }
+    val group = groups.single().sortedBy(AddCandidate::index)
+    val first = group.first()
+    val receiverRegister = firstParameterRegister(method)
+    val listFields =
+        instructions
+            .take(first.index)
+            .mapIndexedNotNull { index, instruction ->
+                if (instruction.opcode != Opcode.IGET_OBJECT) {
+                    return@mapIndexedNotNull null
+                }
+                val reference =
+                    (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                        ?: return@mapIndexedNotNull null
+                val registers = instruction.registersUsed
+                if (
+                    reference.definingClass == method.definingClass &&
+                    reference.type == LIST_DESCRIPTOR &&
+                    registers.size == 2 &&
+                    registers[0] == first.listRegister &&
+                    registers[1] == receiverRegister
+                ) {
+                    index to reference
+                } else {
+                    null
+                }
+            }
+    if (listFields.size != 1) {
+        throw PatchException(
+            "Expected one legacy RadioItem List field read before the three additions, " +
+                "found ${listFields.size}",
+        )
+    }
+
+    val last = group.last()
+    return LegacyOnCreateBinding(
+        method = method,
+        insertIndex = last.index + 1,
+        listRegister = last.listRegister,
+        itemRegister = last.itemRegister,
+        addReference = last.addReference,
+        itemType = last.itemType,
+        listField = listFields.single().second,
+        receiverRegister = receiverRegister,
+    )
+}
+
+context(patchContext: BytecodePatchContext)
+private fun deriveLegacyRadioItemBinding(itemType: String): LegacyRadioItemBinding {
+    val itemClass = patchContext.mutableClassDefBy(itemType)
+    val classInitializer =
+        itemClass.methods.singleOrNull { method ->
+            method.name == "<clinit>" &&
+                method.parameterTypes.isEmpty() &&
+                method.returnType == "V" &&
+                AccessFlags.STATIC.isSet(method.accessFlags)
+        } ?: throw PatchException("Expected one RadioItem class initializer in $itemType")
+    val instructions = classInitializer.instructions
+    val instanceFields =
+        instructions.mapNotNull { instruction ->
+            if (instruction.opcode != Opcode.IPUT && instruction.opcode != Opcode.IPUT_OBJECT) {
+                return@mapNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapNotNull null
+            reference.takeIf { it.definingClass == itemType }
+        }.distinctBy(FieldReference::fieldKey)
+    val intFields = instanceFields.filter { it.type == "I" }
+    val descriptionFields = instanceFields.filter { it.type == "Ljava/lang/Integer;" }
+    val idFields = instanceFields.filter { it.type == STRING_DESCRIPTOR }
+    if (intFields.size != 2 || descriptionFields.size != 1 || idFields.size != 1) {
+        throw PatchException(
+            "Expected RadioItem fields (two int, Integer, String) in $itemType, found " +
+                "${intFields.size}, ${descriptionFields.size}, ${idFields.size}",
+        )
+    }
+
+    val intValues =
+        intFields.associateWith { field ->
+            instructions.mapIndexedNotNull { index, instruction ->
+                val reference =
+                    (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                        ?: return@mapIndexedNotNull null
+                if (instruction.opcode != Opcode.IPUT || !reference.sameField(field)) {
+                    return@mapIndexedNotNull null
+                }
+                val sourceRegister = instruction.registersUsed.firstOrNull()
+                    ?: return@mapIndexedNotNull null
+                findPreviousNarrowLiteral(classInitializer, index, sourceRegister)
+            }
+        }
+    val nativeModeFields =
+        intValues.filterValues { values ->
+            values.size == 3 && values.toSet() == setOf(2, 1, -1)
+        }.keys
+    if (nativeModeFields.size != 1) {
+        throw PatchException(
+            "Expected one RadioItem native-mode field with values 2, 1, -1, " +
+                "found ${nativeModeFields.size}",
+        )
+    }
+    val nativeModeField = nativeModeFields.single()
+    val titleFields = intFields.filterNot { it.sameField(nativeModeField) }
+    if (
+        titleFields.size != 1 ||
+        intValues.getValue(titleFields.single()).size != 3 ||
+        intValues.getValue(titleFields.single()).any { it == 0 }
+    ) {
+        throw PatchException("Expected one non-zero RadioItem title resource field")
+    }
+    val titleField = titleFields.single()
+    val descriptionField = descriptionFields.single()
+    val idField = idFields.single()
+
+    val objectConstructorCalls =
+        instructions.mapNotNull { instruction ->
+            if (
+                instruction.opcode != Opcode.INVOKE_DIRECT &&
+                instruction.opcode != Opcode.INVOKE_DIRECT_RANGE
+            ) {
+                return@mapNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapNotNull null
+            reference.takeIf {
+                it.definingClass == THEME_OBJECT_DESCRIPTOR &&
+                    it.name == "<init>" &&
+                    it.parameterTypes.isEmpty() &&
+                    it.returnType == "V"
+            }
+        }
+    if (
+        objectConstructorCalls.size != 3 ||
+        objectConstructorCalls.distinctBy(MethodReference::toString).size != 1
+    ) {
+        throw PatchException(
+            "Expected three RadioItem Object constructor calls, found " +
+                objectConstructorCalls.size,
+        )
+    }
+
+    val currentItems = mutableMapOf<Int, LegacyItemRecord>()
+    val records = mutableListOf<LegacyItemRecord>()
+    instructions.forEachIndexed { index, instruction ->
+        if (
+            instruction.opcode == Opcode.NEW_INSTANCE &&
+            (instruction as? ReferenceInstruction)?.reference.toString() == itemType
+        ) {
+            val register = (instruction as? OneRegisterInstruction)?.registerA
+                ?: throw PatchException("RadioItem new-instance has no destination register")
+            val record = LegacyItemRecord()
+            currentItems[register] = record
+            records += record
+            return@forEachIndexed
+        }
+
+        val field =
+            (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                ?: return@forEachIndexed
+        if (
+            (instruction.opcode != Opcode.IPUT &&
+                instruction.opcode != Opcode.IPUT_OBJECT) ||
+            field.definingClass != itemType
+        ) {
+            return@forEachIndexed
+        }
+        val registers = instruction.registersUsed
+        if (registers.size != 2) {
+            throw PatchException("RadioItem field assignment has unexpected register count")
+        }
+        val record = currentItems[registers[1]]
+            ?: throw PatchException("RadioItem field assignment has no matching new-instance")
+        when {
+            field.sameField(nativeModeField) ->
+                record.nativeMode =
+                    findPreviousNarrowLiteral(classInitializer, index, registers[0])
+            field.sameField(idField) ->
+                record.id = findPreviousStringLiteral(classInitializer, index, registers[0])
+        }
+    }
+    if (records.size != 3 || records.any { it.nativeMode == null || it.id == null }) {
+        throw PatchException("Expected three complete native-mode/id RadioItem records")
+    }
+    val numericIds =
+        records.map { record ->
+            record.id?.toIntOrNull()
+                ?: throw PatchException("RadioItem id is not numeric: ${record.id}")
+        }
+    if (numericIds.sorted() != numericIds.indices.toList()) {
+        throw PatchException("RadioItem ids are not the expected contiguous list indices")
+    }
+    val darkRecords = records.filter { it.nativeMode == 2 }
+    if (darkRecords.size != 1) {
+        throw PatchException("Expected one native Dark RadioItem")
+    }
+    val darkId =
+        darkRecords.single().id?.toInt()
+            ?: throw PatchException("Native Dark RadioItem has no numeric id")
+    val lightRecords = records.filter { it.nativeMode == 1 }
+    if (lightRecords.size != 1) {
+        throw PatchException("Expected one native Light RadioItem")
+    }
+    val lightId =
+        lightRecords.single().id?.toInt()
+            ?: throw PatchException("Native Light RadioItem has no numeric id")
+    val systemRecords = records.filter { it.nativeMode == -1 }
+    if (systemRecords.size != 1) {
+        throw PatchException("Expected one native System-default RadioItem")
+    }
+    val systemId =
+        systemRecords.single().id?.toInt()
+            ?: throw PatchException("Native System-default RadioItem has no numeric id")
+    val amoledId = generateSequence(0) { it + 1 }.first { it !in numericIds }
+    if (amoledId != records.size) {
+        throw PatchException("Derived AMOLED id does not match the appended list index")
+    }
+
+    return LegacyRadioItemBinding(
+        type = itemType,
+        objectConstructor = objectConstructorCalls.first(),
+        titleField = titleField,
+        nativeModeField = nativeModeField,
+        descriptionField = descriptionField,
+        idField = idField,
+        lightId = lightId,
+        darkId = darkId,
+        systemId = systemId,
+        amoledId = amoledId,
+    )
+}
+
+private fun installLegacyOnCreateAmoledItem(
+    binding: LegacyOnCreateBinding,
+    itemBinding: LegacyRadioItemBinding,
+    titleId: Int,
+) {
+    val method = binding.method
+    val insertIndex = binding.insertIndex
+    val tempRegister = binding.listRegister
+    val registers = listOf(binding.listRegister, binding.itemRegister)
+    if (
+        registers.distinct().size != registers.size ||
+        registers.any { it !in 0..0xf } ||
+        binding.receiverRegister !in 0..0xf
+    ) {
+        throw PatchException("Legacy AMOLED item requires two distinct 4-bit registers")
+    }
+    val originalInstruction = method.getInstruction(insertIndex)
+    method.addInstructionsWithLabels(
+        insertIndex,
+        """
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAmoledAvailable()Z
+        move-result v${binding.itemRegister}
+        if-eqz v${binding.itemRegister}, :piko_legacy_amoled_item_end
+
+        new-instance v${binding.itemRegister}, ${itemBinding.type}
+        invoke-direct {v${binding.itemRegister}}, ${itemBinding.objectConstructor}
+        const v$tempRegister, $titleId
+        iput v$tempRegister, v${binding.itemRegister}, ${itemBinding.titleField}
+        const/4 v$tempRegister, 0x2
+        iput v$tempRegister, v${binding.itemRegister}, ${itemBinding.nativeModeField}
+        const/4 v$tempRegister, 0x0
+        iput-object v$tempRegister, v${binding.itemRegister}, ${itemBinding.descriptionField}
+        const-string v$tempRegister, "${itemBinding.amoledId}"
+        iput-object v$tempRegister, v${binding.itemRegister}, ${itemBinding.idField}
+        iget-object v${binding.listRegister}, v${binding.receiverRegister}, ${binding.listField}
+        invoke-interface {v${binding.listRegister}, v${binding.itemRegister}}, ${binding.addReference}
+        """.trimIndent(),
+        ExternalLabel("piko_legacy_amoled_item_end", originalInstruction),
+    )
+}
+
+private fun installLegacyOnResumeRadioHooks(
+    binding: LegacyBinding,
+    itemBinding: LegacyRadioItemBinding,
+) {
+    val method = binding.method
+    val constructor = binding.radioConstructor
+    if (constructor.registers.size != 4 || constructor.index == 0) {
+        throw PatchException("Legacy RadioGroup row constructor has an unexpected shape")
+    }
+    val rowRegister = constructor.registers[0]
+    val listenerRegister = constructor.registers[1]
+    val selectedIdRegister = constructor.registers[2]
+    val rowNewIndex = constructor.index - 1
+    val rowNewInstruction = method.getInstruction(rowNewIndex)
+    if (
+        rowNewInstruction.opcode != Opcode.NEW_INSTANCE ||
+        (rowNewInstruction as? OneRegisterInstruction)?.registerA != rowRegister ||
+        (rowNewInstruction as? ReferenceInstruction)?.reference.toString() !=
+        constructor.reference.definingClass
+    ) {
+        throw PatchException("Could not derive the legacy RadioGroup row new-instance")
+    }
+    val selectedIdReads =
+        method.instructions
+            .take(rowNewIndex)
+            .mapIndexedNotNull { index, instruction ->
+                val field =
+                    (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                        ?: return@mapIndexedNotNull null
+                val registers = instruction.registersUsed
+                if (
+                    instruction.opcode == Opcode.IGET_OBJECT &&
+                    field.sameField(itemBinding.idField) &&
+                    registers.size == 2 &&
+                    registers[0] == selectedIdRegister
+                ) {
+                    index
+                } else {
+                    null
+                }
+            }
+    if (selectedIdReads.size != 1) {
+        throw PatchException(
+            "Expected one selected RadioItem id read, found ${selectedIdReads.size}",
+        )
+    }
+
+    val wrapperIdsRegister =
+        method.findFreeRegister(
+            rowNewIndex,
+            rowRegister,
+            listenerRegister,
+            selectedIdRegister,
+        )
+    val selectionTempRegister =
+        method.findFreeRegister(
+            selectedIdReads.single() + 1,
+            selectedIdRegister,
+        )
+    val firstParameter = firstParameterRegister(method)
+    val injectedRegisters =
+        listOf(
+            listenerRegister,
+            wrapperIdsRegister,
+            selectedIdRegister,
+            selectionTempRegister,
+        )
+    if (
+        injectedRegisters.any { it !in 0..0xf || it >= firstParameter } ||
+        selectionTempRegister == selectedIdRegister
+    ) {
+        throw PatchException("Legacy AMOLED RadioGroup hooks require local 4-bit registers")
+    }
+
+    val packedIds =
+        packLegacyRadioIds(
+            amoledId = itemBinding.amoledId,
+            lightId = itemBinding.lightId,
+            darkId = itemBinding.darkId,
+            systemId = itemBinding.systemId,
+        )
+    method.addInstructions(
+        rowNewIndex,
+        """
+        const v$wrapperIdsRegister, $packedIds
+        ${legacyNativeThemeListenerInvocation(listenerRegister, wrapperIdsRegister)}
+        move-result-object v$listenerRegister
+        """.trimIndent(),
+    )
+    val selectedIdIndex = selectedIdReads.single()
+    method.addInstructions(
+        selectedIdIndex + 1,
+        """
+        const v$selectionTempRegister, $packedIds
+        invoke-static {v$selectedIdRegister, v$selectionTempRegister}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getLegacySelectedRadioId(Ljava/lang/String;I)Ljava/lang/String;
+        move-result-object v$selectedIdRegister
+        """.trimIndent(),
+    )
+    installLegacyAmoledTitleHook(
+        method = method,
+        rowNewIndex = rowNewIndex,
+        idField = itemBinding.idField,
+        titleField = itemBinding.titleField,
+        amoledId = itemBinding.amoledId,
+    )
+}
+
+internal fun installLegacyAmoledTitleHook(
+    method: MutableMethod,
+    rowNewIndex: Int,
+    idField: FieldReference,
+    titleField: FieldReference,
+    amoledId: Int,
+) {
+    val firstParameter = firstParameterRegister(method)
+    val bindings =
+        (0 until rowNewIndex - 3).mapNotNull { idReadIndex ->
+            val idRead = method.getInstruction(idReadIndex)
+            val idReadField =
+                (idRead as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapNotNull null
+            val idRegisters = idRead.registersUsed
+            if (
+                idRead.opcode != Opcode.IGET_OBJECT ||
+                !idReadField.sameField(idField) ||
+                idRegisters.size != 2
+            ) {
+                return@mapNotNull null
+            }
+
+            val titleRead = method.getInstruction(idReadIndex + 1)
+            val titleReadField =
+                (titleRead as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapNotNull null
+            val titleRegisters = titleRead.registersUsed
+            if (
+                titleRead.opcode != Opcode.IGET ||
+                !titleReadField.sameField(titleField) ||
+                titleRegisters.size != 2 ||
+                titleRegisters[1] != idRegisters[1]
+            ) {
+                return@mapNotNull null
+            }
+
+            val titleGetter = method.getInstruction(idReadIndex + 2)
+            val titleGetterReference =
+                (titleGetter as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapNotNull null
+            if (
+                titleGetter.opcode != Opcode.INVOKE_VIRTUAL &&
+                titleGetter.opcode != Opcode.INVOKE_VIRTUAL_RANGE ||
+                titleGetterReference.definingClass !=
+                "Landroidx/fragment/app/Fragment;" ||
+                titleGetterReference.name != "getString" ||
+                titleGetterReference.parameterTypes.map(CharSequence::toString) != listOf("I") ||
+                titleGetterReference.returnType != STRING_DESCRIPTOR ||
+                titleGetter.registersUsed != listOf(firstParameter, titleRegisters[0])
+            ) {
+                return@mapNotNull null
+            }
+
+            val titleMoveIndex = idReadIndex + 3
+            val titleMove = method.getInstruction(titleMoveIndex)
+            if (titleMove.opcode != Opcode.MOVE_RESULT_OBJECT) {
+                return@mapNotNull null
+            }
+            val titleStringRegister =
+                (titleMove as? OneRegisterInstruction)?.registerA
+                    ?: return@mapNotNull null
+            LegacyTitleBinding(
+                displayIdRegister = idRegisters[0],
+                titleResourceRegister = titleRegisters[0],
+                titleMoveIndex = titleMoveIndex,
+                titleStringRegister = titleStringRegister,
+            )
+        }
+    if (bindings.size != 1) {
+        throw PatchException(
+            "Expected one displayed RadioItem title binding, found ${bindings.size}",
+        )
+    }
+    val binding = bindings.single()
+    if (
+        listOf(
+            binding.displayIdRegister,
+            binding.titleResourceRegister,
+            binding.titleStringRegister,
+        ).let { registers ->
+            registers.distinct().size != registers.size ||
+                registers.any { it !in 0 until firstParameter || it > 0xf }
+        }
+    ) {
+        throw PatchException(
+            "Legacy AMOLED title hook requires distinct local 4-bit registers",
+        )
+    }
+
+    method.addInstructions(
+        binding.titleMoveIndex + 1,
+        """
+        const-string v${binding.titleResourceRegister}, "$amoledId"
+        invoke-static {v${binding.displayIdRegister}, v${binding.titleResourceRegister}, v${binding.titleStringRegister}}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getLegacyRadioTitle(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+        move-result-object v${binding.titleStringRegister}
+        """.trimIndent(),
+    )
+}
+
+internal fun packLegacyRadioIds(
+    amoledId: Int,
+    lightId: Int,
+    darkId: Int,
+    systemId: Int,
+): Int {
+    val ids = listOf(amoledId, lightId, darkId, systemId)
+    if (ids.any { it !in 0..0xff }) {
+        throw PatchException("Legacy theme radio IDs must fit in one unsigned byte")
+    }
+    return amoledId or
+        (lightId shl 8) or
+        (darkId shl 16) or
+        (systemId shl 24)
+}
+
+private fun findPreviousNarrowLiteral(
+    method: MutableMethod,
+    instructionIndex: Int,
+    register: Int,
+): Int {
+    for (index in instructionIndex - 1 downTo maxOf(0, instructionIndex - 8)) {
+        val instruction = method.getInstruction(index)
+        if (
+            instruction is OneRegisterInstruction &&
+            instruction is NarrowLiteralInstruction &&
+            instruction.registerA == register
+        ) {
+            return instruction.narrowLiteral
+        }
+    }
+    throw PatchException(
+        "Could not derive narrow literal for v$register before " +
+            "${method.definingClass}->${method.name} instruction $instructionIndex",
+    )
+}
+
+private fun findPreviousStringLiteral(
+    method: MutableMethod,
+    instructionIndex: Int,
+    register: Int,
+): String {
+    for (index in instructionIndex - 1 downTo maxOf(0, instructionIndex - 8)) {
+        val instruction = method.getInstruction(index)
+        if (
+            (instruction.opcode == Opcode.CONST_STRING ||
+                instruction.opcode == Opcode.CONST_STRING_JUMBO) &&
+            (instruction as? OneRegisterInstruction)?.registerA == register
+        ) {
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? StringReference
+                    ?: throw PatchException("String literal instruction has no StringReference")
+            return reference.string
+        }
+    }
+    throw PatchException(
+        "Could not derive string literal for v$register before " +
+            "${method.definingClass}->${method.name} instruction $instructionIndex",
+    )
+}
+
+private fun FieldReference.fieldKey(): Triple<String, String, String> =
+    Triple(definingClass, name, type)
+
+private fun FieldReference.sameField(other: FieldReference): Boolean =
+    fieldKey() == other.fieldKey()

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.toInstruction
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MethodImplementationBuilder
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction21t
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+
+private const val COMPOUND_BUTTON_LISTENER_DESCRIPTOR =
+    "Landroid/widget/CompoundButton\$OnCheckedChangeListener;"
+private const val MATERIAL_YOU_LEGACY_HELPER_NAME = "pikoAddMaterialYouSwitch"
+
+private data class LegacySwitchItemBinding(
+    val constructor: MethodReference,
+    val descriptionField: FieldReference,
+)
+
+context(patchContext: BytecodePatchContext)
+internal fun installLegacyMaterialYouToggle() {
+    val constructor =
+        LegacyDarkModeFragmentConstructorFingerprint
+            .matchAll(1..1)
+            .single()
+            .method
+    val owner = constructor.definingClass
+    val ownerClass = patchContext.mutableClassDefBy(owner)
+    val legacyBindings =
+        ownerClass.methods.mapNotNull { method ->
+            if (
+                method.name != "onResume" ||
+                method.parameterTypes.isNotEmpty() ||
+                method.returnType != "V" ||
+                AccessFlags.STATIC.isSet(method.accessFlags)
+            ) {
+                null
+            } else {
+                findLegacyBinding(method)
+            }
+        }
+    if (legacyBindings.size != 1) {
+        throw PatchException(
+            "Expected one legacy theme onResume RadioGroup/adapter binding in $owner, " +
+                "found ${legacyBindings.size}",
+        )
+    }
+    if (ownerClass.methods.any { it.name == MATERIAL_YOU_LEGACY_HELPER_NAME }) {
+        throw PatchException(
+            "Material You legacy helper already exists in $owner",
+        )
+    }
+
+    val switchBinding = deriveSwitchItemBinding()
+    val helper =
+        createLegacyMaterialYouHelper(
+            owner = owner,
+            switchBinding = switchBinding,
+        )
+    if (!ownerClass.methods.add(helper)) {
+        throw PatchException(
+            "Failed to add legacy helper $owner->$MATERIAL_YOU_LEGACY_HELPER_NAME",
+        )
+    }
+
+    val binding = legacyBindings.single()
+    if (binding.collectionRegister !in 0..0xf) {
+        throw PatchException(
+            "Legacy Material You collection register requires a 4-bit register, " +
+                "found v${binding.collectionRegister}",
+        )
+    }
+    binding.method.addInstruction(
+        binding.bindIndex,
+        """
+        invoke-static {v${binding.collectionRegister}}, $owner->$MATERIAL_YOU_LEGACY_HELPER_NAME(Ljava/util/Collection;)V
+        """.trimIndent(),
+    )
+}
+
+context(patchContext: BytecodePatchContext)
+private fun deriveSwitchItemBinding(): LegacySwitchItemBinding {
+    val constructor =
+        SwitchItemConstructorFingerprint
+            .matchAll(1..1)
+            .single()
+            .method
+    val switchType = constructor.definingClass
+    if (
+        constructor.name != "<init>" ||
+        constructor.returnType != "V" ||
+        constructor.parameterTypes.map(CharSequence::toString) !=
+        listOf(
+            COMPOUND_BUTTON_LISTENER_DESCRIPTOR,
+            "Ljava/lang/CharSequence;",
+            "Z",
+        ) ||
+        !switchType.isObjectDescriptor()
+    ) {
+        throw PatchException(
+            "Invalid derived SwitchItem listener/title/checked constructor: " +
+                "$switchType->${constructor.name}(${constructor.parameterTypes.joinToString()})" +
+                constructor.returnType,
+        )
+    }
+
+    val switchClass = patchContext.mutableClassDefBy(switchType)
+    if (switchClass.type != switchType) {
+        throw PatchException(
+            "Derived SwitchItem constructor owner mismatch: " +
+                "${switchClass.type} != $switchType",
+        )
+    }
+    val charSequenceFields =
+        switchClass.fields.filter { it.type == "Ljava/lang/CharSequence;" }
+    if (charSequenceFields.size != 2) {
+        throw PatchException(
+            "Expected exactly two SwitchItem CharSequence fields, " +
+                "found ${charSequenceFields.size}",
+        )
+    }
+
+    val constructorCharSequenceFields =
+        constructor.instructions.mapNotNull { instruction ->
+            if (instruction.opcode != Opcode.IPUT_OBJECT) {
+                return@mapNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapNotNull null
+            reference.takeIf {
+                it.definingClass == switchType &&
+                    it.type == "Ljava/lang/CharSequence;"
+            }
+        }.distinctBy { Triple(it.definingClass, it.name, it.type) }
+    if (constructorCharSequenceFields.size != 1) {
+        throw PatchException(
+            "Expected the derived SwitchItem constructor to assign one CharSequence field, " +
+                "found ${constructorCharSequenceFields.size}",
+        )
+    }
+    val titleField = constructorCharSequenceFields.single()
+    val descriptionFields =
+        charSequenceFields.filterNot {
+            it.definingClass == titleField.definingClass &&
+                it.name == titleField.name &&
+                it.type == titleField.type
+        }
+    if (descriptionFields.size != 1) {
+        throw PatchException(
+            "Expected one derived SwitchItem description CharSequence field, " +
+                "found ${descriptionFields.size}",
+        )
+    }
+
+    return LegacySwitchItemBinding(
+        constructor = constructor,
+        descriptionField = descriptionFields.single(),
+    )
+}
+
+private fun createLegacyMaterialYouHelper(
+    owner: String,
+    switchBinding: LegacySwitchItemBinding,
+): MutableMethod {
+    val switchConstructor = switchBinding.constructor
+    val switchType = switchConstructor.definingClass
+    val implementationBuilder = MethodImplementationBuilder(6)
+    implementationBuilder.addInstruction(
+        """
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAvailable()Z
+        """.trimIndent().toInstruction(),
+    )
+    implementationBuilder.addInstruction("move-result v0".toInstruction())
+    implementationBuilder.addInstruction(
+        BuilderInstruction21t(
+            Opcode.IF_EQZ,
+            0,
+            implementationBuilder.getLabel("piko_material_you_unavailable"),
+        ),
+    )
+    """
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getLegacyToggleListener()Landroid/widget/CompoundButton${'$'}OnCheckedChangeListener;
+    move-result-object v1
+    const-string v2, "piko_material_you_title"
+    invoke-static {v2}, Lapp/morphe/extension/instagram/utils/IgStr;->str(Ljava/lang/String;)Ljava/lang/String;
+    move-result-object v2
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isEnabled()Z
+    move-result v0
+    new-instance v4, $switchType
+    invoke-direct {v4, v1, v2, v0}, $switchConstructor
+    invoke-interface {v5, v4}, Ljava/util/Collection;->add(Ljava/lang/Object;)Z
+    """.trimIndent().lineSequence().forEach { instruction ->
+        implementationBuilder.addInstruction(instruction.toInstruction())
+    }
+    implementationBuilder.addLabel("piko_material_you_unavailable")
+    implementationBuilder.addInstruction("return-void".toInstruction())
+
+    val accessFlags =
+        AccessFlags.PRIVATE.value or
+            AccessFlags.STATIC.value or
+            AccessFlags.FINAL.value
+    val helper =
+        MutableMethod(
+            ImmutableMethod(
+                owner,
+                MATERIAL_YOU_LEGACY_HELPER_NAME,
+                listOf(
+                    ImmutableMethodParameter(COLLECTION_DESCRIPTOR, emptySet(), null),
+                ),
+                "V",
+                accessFlags,
+                emptySet(),
+                emptySet(),
+                implementationBuilder.methodImplementation,
+            ),
+        )
+    if (
+        helper.definingClass != owner ||
+        helper.name != MATERIAL_YOU_LEGACY_HELPER_NAME ||
+        helper.parameterTypes.map(CharSequence::toString) != listOf(COLLECTION_DESCRIPTOR) ||
+        helper.returnType != "V" ||
+        !AccessFlags.PRIVATE.isSet(helper.accessFlags) ||
+        !AccessFlags.STATIC.isSet(helper.accessFlags) ||
+        helper.implementation?.registerCount != 6 ||
+        firstParameterRegister(helper) != 5 ||
+        helper.instructions.count { it.opcode == Opcode.IF_EQZ } != 1 ||
+        helper.instructions.any { instruction ->
+            instruction.registersUsed.any { it !in 0..0xf }
+        }
+    ) {
+        throw PatchException("Invalid legacy Material You SwitchItem helper")
+    }
+
+    return helper
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeOverlayTable.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeOverlayTable.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import com.reandroid.apk.xmlencoder.XMLTableBlockEncoder
+import com.reandroid.arsc.base.Block
+import java.io.File
+import java.nio.file.Files
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.transform.OutputKeys
+import javax.xml.transform.TransformerFactory
+import javax.xml.transform.dom.DOMSource
+import javax.xml.transform.stream.StreamResult
+
+internal data class OverlayValues(
+    val day: Map<String, String>,
+    val night: Map<String, String>,
+    val dayApi34: Map<String, String>? = null,
+    val nightApi34: Map<String, String>? = null,
+) {
+    init {
+        require((dayApi34 == null) == (nightApi34 == null))
+        require(dayApi34 == null || dayApi34.keys == day.keys)
+        require(nightApi34 == null || nightApi34.keys == night.keys)
+    }
+}
+
+internal fun buildThemeOverlayTable(
+    sourceManifest: File,
+    sourcePublic: File,
+    packageName: String,
+    outputFile: File,
+    values: OverlayValues,
+): File {
+    require(sourceManifest.isFile)
+    require(sourcePublic.isFile)
+    require(packageName.isNotBlank())
+    require(values.day.keys == values.night.keys)
+
+    val workRoot = Files.createTempDirectory("piko-theme-overlay").toFile()
+    try {
+        sourceManifest
+            .copyTo(workRoot.resolve("AndroidManifest.xml"), overwrite = true)
+
+        val targetPackage = workRoot.resolve("resources/$packageName")
+        val targetValues = targetPackage.resolve("res/values")
+        targetValues.mkdirs()
+        writePublicSubset(
+            source = sourcePublic,
+            output = targetValues.resolve("public.xml"),
+            values = values,
+        )
+
+        writeValuesXml(
+            targetPackage.resolve("res/values-v31/colors.xml"),
+            values.day,
+        )
+        writeValuesXml(
+            targetPackage.resolve("res/values-night-v31/colors.xml"),
+            values.night,
+        )
+        values.dayApi34?.let { api34Values ->
+            writeValuesXml(
+                targetPackage.resolve("res/values-v34/colors.xml"),
+                api34Values,
+            )
+        }
+        values.nightApi34?.let { api34Values ->
+            writeValuesXml(
+                targetPackage.resolve("res/values-night-v34/colors.xml"),
+                api34Values,
+            )
+        }
+
+        val encoder = XMLTableBlockEncoder()
+        encoder.scanMainDirectory(workRoot)
+        outputFile.parentFile.mkdirs()
+        val tableBlock: Block = encoder.tableBlock
+        outputFile.outputStream().use { tableBlock.writeBytes(it) }
+        check(outputFile.isFile && outputFile.length() > 0L)
+        return outputFile
+    } finally {
+        workRoot.deleteRecursively()
+    }
+}
+
+private fun writeValuesXml(
+    output: File,
+    colors: Map<String, String>,
+) {
+    output.parentFile.mkdirs()
+    val document = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .newDocument()
+    val resources = document.createElement("resources")
+    document.appendChild(resources)
+
+    colors.forEach { (name, value) ->
+        resources.appendChild(
+            document.createElement("color").apply {
+                setAttribute("name", name)
+                textContent = value
+            },
+        )
+    }
+    TransformerFactory.newInstance().newTransformer().apply {
+        setOutputProperty(OutputKeys.INDENT, "yes")
+        transform(DOMSource(document), StreamResult(output))
+    }
+}
+
+private data class PublicName(
+    val type: String,
+    val name: String,
+)
+
+private val localReference =
+    Regex("""[@?](?:(com\.instagram\.android):)?([A-Za-z_][\w]*)/([A-Za-z0-9_.]+)""")
+
+private fun writePublicSubset(
+    source: File,
+    output: File,
+    values: OverlayValues,
+) {
+    val factory = DocumentBuilderFactory.newInstance()
+    val sourceDocument = factory.newDocumentBuilder().parse(source)
+    val sourceRoot = sourceDocument.documentElement
+    val required = mutableSetOf<PublicName>()
+
+    values.day.keys.forEach { required += PublicName("color", it) }
+    (
+        values.day.values +
+            values.night.values +
+            values.dayApi34.orEmpty().values +
+            values.nightApi34.orEmpty().values
+    ).forEach { value ->
+        collectLocalReferences(value, required)
+    }
+
+    val publicNodes = sourceDocument.getElementsByTagName("public")
+    val publicByName = buildMap {
+        for (index in 0 until publicNodes.length) {
+            val element = publicNodes.item(index) as org.w3c.dom.Element
+            put(
+                PublicName(
+                    type = element.getAttribute("type"),
+                    name = element.getAttribute("name"),
+                ),
+                element,
+            )
+        }
+    }
+    val missing = required - publicByName.keys
+    require(missing.isEmpty()) {
+        "Missing public resource ids: ${missing.sortedBy { "${it.type}/${it.name}" }}"
+    }
+
+    val outputDocument = factory.newDocumentBuilder().newDocument()
+    val outputRoot = outputDocument.createElement("resources").apply {
+        setAttribute("package", sourceRoot.getAttribute("package"))
+        setAttribute("id", sourceRoot.getAttribute("id"))
+    }
+    outputDocument.appendChild(outputRoot)
+    required
+        .map { requireNotNull(publicByName[it]) }
+        .sortedBy { it.getAttribute("id").removePrefix("0x").toLong(16) }
+        .forEach { outputRoot.appendChild(outputDocument.importNode(it, true)) }
+
+    output.parentFile.mkdirs()
+    TransformerFactory.newInstance().newTransformer().apply {
+        setOutputProperty(OutputKeys.INDENT, "yes")
+        transform(DOMSource(outputDocument), StreamResult(output))
+    }
+}
+
+private fun collectLocalReferences(
+    text: String,
+    output: MutableSet<PublicName>,
+) {
+    localReference.findAll(text).forEach { match ->
+        output += PublicName(
+            type = match.groupValues[2],
+            name = match.groupValues[3],
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+internal const val MATERIAL_YOU_LIGHT_SWITCH_OFF_TRACK_FALLBACK = "#ffe2e6f0"
+internal const val MATERIAL_YOU_DARK_SWITCH_OFF_TRACK_FALLBACK = "#ff2b3036"
+internal const val MATERIAL_YOU_LIGHT_SWITCH_OFF_TRACK_DYNAMIC =
+    "@android:color/system_neutral1_100"
+internal const val MATERIAL_YOU_DARK_SWITCH_OFF_TRACK_DYNAMIC =
+    "@android:color/system_neutral1_800"
+
+// Static fallbacks used when Android dynamic colors are unavailable.
+internal val materialYouLightFallbackAliases =
+    mapOf(
+        "piko_dynamic_primary" to "#ff4557a5",
+        "piko_dynamic_primary_pressed" to "#ff36468c",
+        "piko_dynamic_primary_container" to "#ffdde1ff",
+        "piko_dynamic_on_primary" to "#ffffffff",
+        "piko_dynamic_on_primary_container" to "#ff001456",
+        "piko_dynamic_background" to "#ffeef1f8",
+        "piko_dynamic_pressed_background" to "#ffe2e6f0",
+        "piko_dynamic_on_surface" to "#ff1a1c1f",
+        "piko_dynamic_on_surface_variant" to "#ff44474e",
+        "piko_dynamic_outline" to "#ff74777f",
+        "piko_dynamic_outline_variant" to "#ffc4c6d0",
+        "piko_dynamic_switch_off_track" to MATERIAL_YOU_LIGHT_SWITCH_OFF_TRACK_FALLBACK,
+        "piko_dynamic_prism_black" to "#ff121316",
+        "piko_dynamic_prism_white" to "#ffeef1f8",
+    )
+
+internal val materialYouDarkFallbackAliases =
+    mapOf(
+        "piko_dynamic_primary" to "#ff8ea0ff",
+        "piko_dynamic_primary_pressed" to "#ffc0c7ff",
+        "piko_dynamic_primary_container" to "#ff31448f",
+        "piko_dynamic_on_primary" to "#ff101a3f",
+        "piko_dynamic_on_primary_container" to "#ffe0e0ff",
+        "piko_dynamic_background" to "#ff121316",
+        "piko_dynamic_pressed_background" to "#ff1d1f22",
+        "piko_dynamic_on_surface" to "#ffe1e3e6",
+        "piko_dynamic_on_surface_variant" to "#ffc1c7cf",
+        "piko_dynamic_outline" to "#ff8b929b",
+        "piko_dynamic_outline_variant" to "#ff3f4750",
+        "piko_dynamic_switch_off_track" to MATERIAL_YOU_DARK_SWITCH_OFF_TRACK_FALLBACK,
+        "piko_dynamic_prism_black" to "#ff121316",
+        "piko_dynamic_prism_white" to "#ffe1e3e6",
+    )
+
+private val materialYouLightDynamicAliases =
+    mapOf(
+        "piko_dynamic_primary" to "@android:color/system_accent1_600",
+        "piko_dynamic_primary_pressed" to "@android:color/system_accent1_700",
+        "piko_dynamic_primary_container" to "@android:color/system_accent1_100",
+        "piko_dynamic_on_primary" to "@android:color/system_neutral1_10",
+        "piko_dynamic_on_primary_container" to "@android:color/system_accent1_900",
+        "piko_dynamic_background" to "@android:color/system_accent1_50",
+        "piko_dynamic_pressed_background" to "@android:color/system_accent1_100",
+        "piko_dynamic_on_surface" to "@android:color/system_neutral1_900",
+        "piko_dynamic_on_surface_variant" to "@android:color/system_neutral2_700",
+        "piko_dynamic_outline" to "@android:color/system_neutral2_500",
+        "piko_dynamic_outline_variant" to "@android:color/system_neutral2_200",
+        "piko_dynamic_switch_off_track" to MATERIAL_YOU_LIGHT_SWITCH_OFF_TRACK_DYNAMIC,
+        "piko_dynamic_prism_black" to "@android:color/system_neutral1_900",
+        "piko_dynamic_prism_white" to "@android:color/system_accent1_50",
+    )
+
+private val materialYouDarkDynamicAliases =
+    mapOf(
+        "piko_dynamic_primary" to "@android:color/system_accent1_200",
+        "piko_dynamic_primary_pressed" to "@android:color/system_accent1_100",
+        "piko_dynamic_primary_container" to "@android:color/system_accent1_800",
+        "piko_dynamic_on_primary" to "@android:color/system_neutral1_900",
+        "piko_dynamic_on_primary_container" to "@android:color/system_accent1_100",
+        "piko_dynamic_background" to "@android:color/system_neutral1_900",
+        "piko_dynamic_pressed_background" to "@android:color/system_neutral1_800",
+        "piko_dynamic_on_surface" to "@android:color/system_neutral1_10",
+        "piko_dynamic_on_surface_variant" to "@android:color/system_neutral2_200",
+        "piko_dynamic_outline" to "@android:color/system_neutral2_400",
+        "piko_dynamic_outline_variant" to "@android:color/system_neutral2_700",
+        "piko_dynamic_switch_off_track" to MATERIAL_YOU_DARK_SWITCH_OFF_TRACK_DYNAMIC,
+        "piko_dynamic_prism_black" to "@android:color/system_neutral1_900",
+        "piko_dynamic_prism_white" to "@android:color/system_neutral1_10",
+    )
+
+// Instagram reuses literal greys for opposite roles across themes, so these stay mode-invariant.
+internal val materialYouNeutralConstantsHex =
+    mapOf(
+        "piko_dynamic_neutral_light" to "#ffc1c7cf",
+        "piko_dynamic_neutral_mid" to "#ff8b929b",
+        "piko_dynamic_neutral_dark" to "#ff3f4750",
+        "piko_dynamic_neutral_deep" to "#ff2b3036",
+    )
+
+private val materialYouNeutralConstantsDynamic =
+    mapOf(
+        "piko_dynamic_neutral_light" to "@android:color/system_neutral2_200",
+        "piko_dynamic_neutral_mid" to "@android:color/system_neutral2_400",
+        "piko_dynamic_neutral_dark" to "@android:color/system_neutral2_700",
+        "piko_dynamic_neutral_deep" to "@android:color/system_neutral2_800",
+    )
+
+private val materialYouBaseMappings =
+    mapOf(
+        "bds_black" to "@color/piko_dynamic_prism_black",
+        "bds_white" to "@color/piko_dynamic_prism_white",
+        "bds_grey_0" to "@color/piko_dynamic_prism_white",
+        "bds_grey_1" to "@color/piko_dynamic_prism_white",
+        "bds_grey_2" to "@color/piko_dynamic_neutral_light",
+        "bds_grey_3" to "@color/piko_dynamic_neutral_light",
+        "bds_grey_4" to "@color/piko_dynamic_neutral_mid",
+        "bds_grey_6" to "@color/piko_dynamic_neutral_dark",
+        "bds_grey_7" to "@color/piko_dynamic_prism_black",
+        "bds_grey_8" to "@color/piko_dynamic_prism_black",
+        "bds_grey_9" to "@color/piko_dynamic_prism_black",
+        "bds_grey_10" to "@color/piko_dynamic_prism_black",
+        "bds_grey_11" to "@color/piko_dynamic_prism_black",
+        "bds_grey_12" to "@color/piko_dynamic_prism_black",
+        "bds_grey_16" to "@color/piko_dynamic_prism_black",
+        "bds_grey_18" to "@color/piko_dynamic_prism_black",
+        "bds_grey_21" to "@color/piko_dynamic_prism_black",
+        "bds_grey_22" to "@color/piko_dynamic_prism_black",
+        "bds_grey_24" to "@color/piko_dynamic_prism_black",
+        "igds_prism_gray_00" to "@color/piko_dynamic_prism_white",
+        "igds_prism_gray_08" to "@color/piko_dynamic_neutral_deep",
+        "igds_prism_gray_10" to "@color/piko_dynamic_prism_black",
+        "bds_blue_0" to "@color/piko_dynamic_primary",
+        "bds_blue_1" to "@color/piko_dynamic_primary_pressed",
+        "bds_blue_2" to "@color/piko_dynamic_primary_container",
+        "bottom_sheet_undo_redo_color" to "@color/piko_dynamic_background",
+        "badge_color" to "@color/piko_dynamic_primary",
+        "igds_prism_indigo_1000" to "@color/piko_dynamic_primary_container",
+    )
+
+private val materialYouAccentMappings =
+    mapOf(
+        "igds_primary_button" to "@color/piko_dynamic_primary",
+        "igds_link" to "@color/piko_dynamic_primary",
+        "igds_prism_black" to "@color/piko_dynamic_prism_black",
+        "fds_blue_60" to "@color/piko_dynamic_primary",
+    )
+
+private val materialYouThemeMappings =
+    mapOf(
+        "igds_primary_background" to "@color/piko_dynamic_background",
+        "igds_secondary_background" to "@color/piko_dynamic_background",
+        "igds_elevated_background" to "@color/piko_dynamic_background",
+        "igds_elevated_highlight_background" to "@color/piko_dynamic_pressed_background",
+        "igds_elevated_separator" to "@color/piko_dynamic_outline_variant",
+        "igds_separator" to "@color/piko_dynamic_outline_variant",
+        "igds_stroke" to "@color/piko_dynamic_outline",
+        "igds_primary_text" to "@color/piko_dynamic_on_surface",
+        "igds_secondary_text" to "@color/piko_dynamic_on_surface_variant",
+        "igds_primary_icon" to "@color/piko_dynamic_on_surface",
+        "igds_secondary_icon" to "@color/piko_dynamic_on_surface_variant",
+        "material_selected_track" to "@color/piko_dynamic_primary",
+        "checkbox_image_tint" to "@color/piko_dynamic_on_primary",
+        "material_unselected_track" to "@color/piko_dynamic_switch_off_track",
+        "material_track_border" to "@color/piko_dynamic_outline",
+        "checkbox_unchecked_enabled" to "@color/piko_dynamic_outline",
+    )
+
+// Some surfaces resolve through GM3/AppCompat leaves instead of the IGDS aliases above.
+private val materialYouSurfaceBaselineMappings =
+    mapOf(
+        "gm3_baseline_surface_dark" to "@color/piko_dynamic_background",
+        "gm3_baseline_surface_container_dark" to "@color/piko_dynamic_background",
+        "baseline_neutral_10_with_surface_tint_dark_alpha_5" to "@color/piko_dynamic_background",
+        "baseline_neutral_10_with_surface_tint_dark_alpha_11" to "@color/piko_dynamic_background",
+        "baseline_neutral_10_with_surface_tint_dark_alpha_14" to "@color/piko_dynamic_background",
+        "basel_bottom_sheet_background_color" to "@color/piko_dynamic_background",
+        "igds_context_menu_background_color" to "@color/piko_dynamic_background",
+        "igds_creation_menu_background" to "@color/piko_dynamic_background",
+        "design_dark_default_color_background" to "@color/piko_dynamic_background",
+        "cardview_dark_background" to "@color/piko_dynamic_background",
+        "material_grey_850" to "@color/piko_dynamic_background",
+        "material_grey_900" to "@color/piko_dynamic_background",
+        "igds_prism_gray_07" to "@color/piko_dynamic_prism_black",
+        // Keep search and pressed rows distinct from the primary background.
+        "igds_prism_gray_09" to "@color/piko_dynamic_pressed_background",
+        "igds_prism_gray_13" to "@color/piko_dynamic_prism_black",
+        "igds_prism_gray_14" to "@color/piko_dynamic_prism_black",
+        "igds_prism_gray_1500" to "@color/piko_dynamic_prism_black",
+        "igds_prism_gray_09_alpha_95" to "@color/piko_dynamic_prism_black",
+        "igds_prism_gray_10_alpha_95" to "@color/piko_dynamic_prism_black",
+        "bds_grey_9_95_transparent" to "@color/piko_dynamic_prism_black",
+        "bds_grey_10_90_transparent" to "@color/piko_dynamic_prism_black",
+        "gm3_baseline_surface_container" to "@color/piko_dynamic_background",
+        "gm3_baseline_surface_container_light" to "@color/piko_dynamic_background",
+        "baseline_neutral_100_with_surface_tint_light_alpha_12" to "@color/piko_dynamic_background",
+        "material_grey_100" to "@color/piko_dynamic_background",
+        // This shared surface/foreground token must follow the surface to preserve dark mode.
+        "abc_decor_view_status_guard_light" to "@color/piko_dynamic_background",
+        "background_floating_material_light" to "@color/piko_dynamic_background",
+        "igds_prism_gray_01" to "@color/piko_dynamic_prism_white",
+        "igds_prism_gray_02" to "@color/piko_dynamic_prism_white",
+        "igds_prism_gray_03" to "@color/piko_dynamic_neutral_light",
+    )
+
+internal val amoledSurfaceBaselineMappings =
+    materialYouSurfaceBaselineMappings
+        .filterValues { value ->
+            value == "@color/piko_dynamic_background" ||
+                value == "@color/piko_dynamic_prism_black"
+        }
+        .mapValues { "@color/bds_black" }
+
+internal val materialYouNamedMappings =
+    materialYouBaseMappings +
+        materialYouAccentMappings +
+        materialYouThemeMappings +
+        materialYouSurfaceBaselineMappings
+
+private val amoledMaterialYouAliases =
+    materialYouDarkDynamicAliases +
+        materialYouNeutralConstantsDynamic +
+        mapOf(
+            "piko_dynamic_background" to "#ff000000",
+            "piko_dynamic_prism_black" to "#ff000000",
+        )
+
+internal fun amoledMaterialYouOverlayMappings(): Map<String, String> =
+    materialYouNamedMappings.mapValues { (_, value) ->
+        val alias = value.removePrefix("@color/")
+        amoledMaterialYouAliases[alias] ?: value
+    }
+
+internal fun dynamicOverlayMappings(night: Boolean): Map<String, String> {
+    val aliases =
+        if (night) {
+            materialYouDarkDynamicAliases + materialYouNeutralConstantsDynamic
+        } else {
+            materialYouLightDynamicAliases + materialYouNeutralConstantsDynamic
+        }
+
+    return materialYouNamedMappings.mapValues { (_, value) ->
+        val alias = value.removePrefix("@color/")
+        aliases[alias] ?: value
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -6,541 +6,85 @@
 
 package app.crimera.patches.instagram.misc.theme
 
+import app.crimera.patches.instagram.misc.extension.sharedExtensionPatch
+import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.morphe.patcher.patch.ResourcePatchContext
-import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patcher.patch.BytecodePatchContext
 import app.morphe.patcher.patch.booleanOption
-import app.morphe.util.findElementByAttributeValueOrThrow
-import org.w3c.dom.Document
-import org.w3c.dom.Element
-import java.io.FileWriter
-import java.nio.file.Files
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
 
 @Suppress("unused")
 val themePatch =
     resourcePatch(
         name = "Theme",
-        description = "Applies either amoled or material you theme for Instagram at patch time. [default = material you]",
-        default = false,
+        description =
+            "Adds Material You and AMOLED options to Instagram's Dark mode settings " +
+                "on Android 12 and later. On Android 8–11, it applies a fixed " +
+                "Material You-style theme or an optional AMOLED theme.",
+        default = true,
     ) {
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         val amoled by booleanOption(
             key = "amoled",
             default = false,
-            title = "Pure-black AMOLED theme",
-            description = "By default this patch applies a Material You dynamic theme that " +
-                "follows your device's light/dark setting. Turn this on to override it " +
-                "with a pure-black AMOLED theme instead.",
+            title = "Pure-black AMOLED theme for Android 8–11",
+            description =
+                "Use a fixed pure-black AMOLED theme instead of the fixed Material " +
+                    "You-style theme on Android 8–11. On Android 12 and later, select " +
+                    "AMOLED in Instagram's Dark mode settings.",
         )
 
-        
-        dependsOn(composePrismBlackPatch)
+        var bytecodePatchContext: BytecodePatchContext? = null
 
-        execute {
-            forceWhiteOnMediaChrome()
-            if (amoled == true) applyAmoledTheme() else applyMaterialYouTheme()
-        }
-    }
-
-// On-media chrome — the feed post header (username / subtitle / follow / ⋯ menu),
-// "Watch again" and similar labels drawn over photos/video — resolves through
-// igds_color_primary_text_on_media / _icon_on_media / _primary_button_on_media,
-// which all point at abc_decor_view_status_guard_light. That leaf is ALSO the dark
-// app surface (igds_color_primary_background), so it can't be recoloured white
-// (that turns the whole app light in dark mode). Instead repoint the on-media
-// attributes themselves straight to white, leaving the shared surface leaf intact.
-// On-media chrome sits over media (arbitrary/dark), so white is correct in every
-// theme. Guarded so a missing/undecoded styles.xml can never fail the build.
-// muteIconPrimaryColor: same on-media conflict as the igds_* attrs above,
-// just under IG's own naming (not bds_/igds_). Two style blocks define it
-// with fixed mid-greys (grey_14/grey_15) that had adequate contrast against
-// the original audio-bar pill background — but igds_prism_gray_08 (that pill's
-// background) is remapped to piko_dynamic_prism_black below, so the icon
-// needs to be forced white too, like the rest of on-media chrome.
-private val onMediaChromeAttrs =
-    setOf(
-        "igds_color_primary_text_on_media",
-        "igds_color_icon_on_media",
-        "igds_color_primary_button_on_media",
-        "muteIconPrimaryColor",
-    )
-
-// SmartCapture (the Stories/Reels camera UI) has its own on-media attribute
-// namespace (sc_*) that ALSO conflicts through abc_decor_view_status_guard_light
-// in some style blocks (e.g. IgSmartCaptureTheme, SmartCapture) - same underlying
-// bug as onMediaChromeAttrs above. Unlike those igds_* attrs (always bds_white
-// wherever they appear), these sc_* names are reused with genuinely different,
-// intentional values elsewhere (e.g. SmartCapture.Selfie.Ig.Dark deliberately
-// uses a darker sc_fds_gray_90 for that one selfie sub-mode), so this can't be a
-// blanket by-name replace like onMediaChromeAttrs - it has to match by the
-// CURRENT value instead, only touching the specific instances that still point
-// at the conflicted background resource.
-private val onMediaAttrsPointingAtGuardLight =
-    setOf(
-        "sc_primary_icon_on_media",
-        "sc_primary_text_on_media",
-        "sc_always_white",
-    )
-
-private fun ResourcePatchContext.forceWhiteOnMediaChrome() {
-    listOf(
-        "res/values/styles.xml",
-        "res/values-night/styles.xml",
-    ).forEach { path ->
-        try {
-            if (!get(path).exists()) return@forEach
-            document(path).use { document ->
-                val items = document.getElementsByTagName("item")
-                for (index in 0 until items.length) {
-                    val item = items.item(index) as? Element ?: continue
-                    val name = item.getAttribute("name")
-
-                    if (onMediaChromeAttrs.contains(name)) {
-                        item.textContent = "@color/bds_white"
-                    } else if (
-                        onMediaAttrsPointingAtGuardLight.contains(name) &&
-                        item.textContent == "@color/abc_decor_view_status_guard_light"
-                    ) {
-                        item.textContent = "@color/bds_white"
-                    }
+        dependsOn(
+            settingsPatch,
+            sharedExtensionPatch,
+            resourceMappingPatch,
+            bytecodePatch {
+                execute {
+                    bytecodePatchContext = this
                 }
-            }
-        } catch (_: Exception) {
-        }
-    }
-}
-
-private fun ResourcePatchContext.applyAmoledTheme() {
-    val nightOverrides =
-        mapOf(
-            "igds_secondary_background" to "@color/bds_black",
-            "igds_elevated_background" to "@color/bds_black",
-            "igds_elevated_highlight_background" to "@color/bds_black",
-        )
-
-    document("res/values-night/colors.xml").use { document ->
-        val colors = document.getElementsByTagName("color")
-        nightOverrides.forEach { (name, value) ->
-            colors.findElementByAttributeValueOrThrow("name", name).textContent = value
-        }
-    }
-
-    val defaultOverrides =
-        mapOf(
-            "igds_prism_black" to "#ff000000",
-        )
-
-    document("res/values/colors.xml").use { document ->
-        val colors = document.getElementsByTagName("color")
-        defaultOverrides.forEach { (name, value) ->
-            colors.findElementByAttributeValueOrThrow("name", name).textContent = value
-        }
-    }
-}
-
-private fun ResourcePatchContext.applyMaterialYouTheme() {
-    // piko_dynamic_* alias palette. The alias NAMES are identical in every bucket
-    // (so the token -> alias remaps further down apply uniformly), but the VALUES
-    // differ: light tones in the day buckets, dark tones in the -night buckets, so
-    // the theme follows the device's light/dark setting. The -v31 buckets use the
-    // Android 12+ dynamic palette; the plain buckets carry fixed-hex fallbacks for
-    // older devices.
-    listOf(
-        "res/values" to (materialYouLightFallbackAliases + materialYouNeutralConstantsHex),
-        "res/values-night" to (materialYouDarkFallbackAliases + materialYouNeutralConstantsHex),
-        "res/values-v31" to (materialYouLightDynamicAliases + materialYouNeutralConstantsDynamic),
-        "res/values-night-v31" to (materialYouDarkDynamicAliases + materialYouNeutralConstantsDynamic),
-    ).forEach { (directoryPath, aliases) ->
-        ensureColorsXml(directoryPath)
-
-        document("$directoryPath/colors.xml").use { document ->
-            aliases.forEach { (name, value) ->
-                document.upsertColor(name, value)
-            }
-        }
-    }
-
-    listOf(
-        "res/values/colors.xml",
-        "res/values-night/colors.xml",
-        "res/values-v31/colors.xml",
-        "res/values-night-v31/colors.xml",
-    ).forEach { colorsFile ->
-        document(colorsFile).use { document ->
-            materialYouNamedMappings.forEach { (name, value) ->
-                document.upsertColor(name, value)
-            }
-        }
-    }
-}
-
-private fun ResourcePatchContext.ensureColorsXml(directoryPath: String) {
-    val directory = get(directoryPath)
-    if (!directory.isDirectory) {
-        Files.createDirectories(directory.toPath())
-    }
-
-    val colorsXml = directory.resolve("colors.xml")
-    if (!colorsXml.exists()) {
-        FileWriter(colorsXml).use {
-            it.write("<?xml version=\"1.0\" encoding=\"utf-8\"?><resources></resources>")
-        }
-    }
-}
-
-private fun Document.upsertColor(name: String, value: String) {
-    val existingColor = findColor(name)
-    if (existingColor != null) {
-        existingColor.textContent = value
-    } else {
-        documentElement.appendChild(
-            createElement("color").apply {
-                setAttribute("name", name)
-                textContent = value
             },
         )
-    }
-}
 
-private fun Document.findColor(name: String): Element? {
-    val colors = getElementsByTagName("color")
-    for (index in 0 until colors.length) {
-        val color = colors.item(index) as? Element ?: continue
-        if (color.getAttribute("name") == name) {
-            return color
+        execute {
+            try {
+                val originalApi31Base = captureApi31Base()
+
+                forceWhiteOnMediaChrome()
+                applyLegacyTheme(amoled == true)
+
+                restoreApi31Base(
+                    snapshot = originalApi31Base,
+                )
+                val materialYouStringIds =
+                    reservePublicStringIds(
+                        publicXml = get("res/values/public.xml"),
+                        names =
+                            listOf(
+                                "piko_material_you_title",
+                                "piko_amoled_title",
+                            ),
+                    )
+                writeMaterialYouOverlay(night = false)
+                writeMaterialYouOverlay(night = true)
+                writeAmoledOverlay(originalApi31Base)
+                writeAmoledMaterialYouOverlay()
+
+                context(requireNotNull(bytecodePatchContext)) {
+                    installComposePrismBlackRuntime(legacyAmoled = amoled == true)
+                    installSystemDefaultUiModeHook()
+                    installThemeLifecycleHooks()
+                    installMaterialYouToggle(
+                        titleId = materialYouStringIds.getValue("piko_material_you_title"),
+                        amoledTitleId = materialYouStringIds.getValue("piko_amoled_title"),
+                    )
+                }
+            } finally {
+                bytecodePatchContext = null
+            }
         }
     }
-
-    return null
-}
-
-// Fixed-hex fallbacks (pre-Android-12, no dynamic palette). LIGHT variant lives in
-// res/values; the DARK variant in res/values-night. prism_black / prism_white are
-// deliberately mode-invariant "constants" (a black-branded element stays dark and a
-// white-branded element stays light in both modes) — every other role flips.
-private val materialYouLightFallbackAliases =
-    mapOf(
-        "piko_dynamic_primary" to "#ff4557a5",
-        "piko_dynamic_primary_pressed" to "#ff36468c",
-        "piko_dynamic_primary_container" to "#ffdde1ff",
-        "piko_dynamic_on_primary" to "#ffffffff",
-        "piko_dynamic_on_primary_container" to "#ff001456",
-        "piko_dynamic_background" to "#ffeef1f8",
-        "piko_dynamic_pressed_background" to "#ffe2e6f0",
-        "piko_dynamic_on_surface" to "#ff1a1c1f",
-        "piko_dynamic_on_surface_variant" to "#ff44474e",
-        "piko_dynamic_outline" to "#ff74777f",
-        "piko_dynamic_outline_variant" to "#ffc4c6d0",
-        "piko_dynamic_prism_black" to "#ff121316",
-        "piko_dynamic_prism_white" to "#ffeef1f8",
-    )
-
-private val materialYouDarkFallbackAliases =
-    mapOf(
-        "piko_dynamic_primary" to "#ff8ea0ff",
-        "piko_dynamic_primary_pressed" to "#ffc0c7ff",
-        "piko_dynamic_primary_container" to "#ff31448f",
-        "piko_dynamic_on_primary" to "#ff101a3f",
-        "piko_dynamic_on_primary_container" to "#ffe0e0ff",
-        "piko_dynamic_background" to "#ff121316",
-        "piko_dynamic_pressed_background" to "#ff1d1f22",
-        "piko_dynamic_on_surface" to "#ffe1e3e6",
-        "piko_dynamic_on_surface_variant" to "#ffc1c7cf",
-        "piko_dynamic_outline" to "#ff8b929b",
-        "piko_dynamic_outline_variant" to "#ff3f4750",
-        "piko_dynamic_prism_black" to "#ff121316",
-        "piko_dynamic_prism_white" to "#ffe1e3e6",
-    )
-
-// Android 12+ dynamic palette. Lower tone number = lighter (neutral1_0 ≈ white,
-// neutral1_1000 ≈ black), so the light and dark variants pull opposite ends of the
-// same wallpaper-derived ramp. Surfaces use the NEUTRAL palette (system_neutral1_*)
-// rather than accent, so the background doesn't pick up the wallpaper's colour cast
-// — a calmer backdrop for a photo-first app.
-private val materialYouLightDynamicAliases =
-    mapOf(
-        "piko_dynamic_primary" to "@android:color/system_accent1_600",
-        "piko_dynamic_primary_pressed" to "@android:color/system_accent1_700",
-        "piko_dynamic_primary_container" to "@android:color/system_accent1_100",
-        "piko_dynamic_on_primary" to "@android:color/system_neutral1_10",
-        "piko_dynamic_on_primary_container" to "@android:color/system_accent1_900",
-        // Light surfaces use the PRIMARY accent palette (accent1) at a light tone so
-        // the wallpaper colour is actually visible, instead of the near-white
-        // system_neutral1_10 (reads as plain white) or the muted accent2 (barely
-        // tinted). Both light-surface paths get it — background AND prism_white (the
-        // latter is what the main feed bg, default_bg_color_light -> bds_white,
-        // resolves through) — so the tint is uniform. Dial by tone/palette:
-        // system_accent2_50 = very subtle, system_accent1_50 = current (light tint),
-        // system_accent1_100 = clearly coloured (deeper), system_neutral1_50 = grey/
-        // no colour. on_surface text stays neutral for readable contrast.
-        "piko_dynamic_background" to "@android:color/system_accent1_50",
-        "piko_dynamic_pressed_background" to "@android:color/system_accent1_100",
-        "piko_dynamic_on_surface" to "@android:color/system_neutral1_900",
-        "piko_dynamic_on_surface_variant" to "@android:color/system_neutral2_700",
-        "piko_dynamic_outline" to "@android:color/system_neutral2_500",
-        "piko_dynamic_outline_variant" to "@android:color/system_neutral2_200",
-        "piko_dynamic_prism_black" to "@android:color/system_neutral1_900",
-        "piko_dynamic_prism_white" to "@android:color/system_accent1_50",
-    )
-
-private val materialYouDarkDynamicAliases =
-    mapOf(
-        "piko_dynamic_primary" to "@android:color/system_accent1_200",
-        "piko_dynamic_primary_pressed" to "@android:color/system_accent1_100",
-        // Colored container: one tone darker (700 -> 800) so tinted surfaces sit
-        // lower/dimmer against the neutral background below.
-        "piko_dynamic_primary_container" to "@android:color/system_accent1_800",
-        "piko_dynamic_on_primary" to "@android:color/system_neutral1_900",
-        "piko_dynamic_on_primary_container" to "@android:color/system_accent1_100",
-        // The dynamic palette only exposes discrete tones: _900 (≈ dark grey) and
-        // _1000 (near-black). To go darker still, flip the two "…neutral1_900" lines
-        // below to "…neutral1_1000" (near-black — close to the AMOLED theme, but
-        // keeps dynamic accents).
-        "piko_dynamic_background" to "@android:color/system_neutral1_900",
-        "piko_dynamic_pressed_background" to "@android:color/system_neutral1_800",
-        "piko_dynamic_on_surface" to "@android:color/system_neutral1_10",
-        "piko_dynamic_on_surface_variant" to "@android:color/system_neutral2_200",
-        "piko_dynamic_outline" to "@android:color/system_neutral2_400",
-        "piko_dynamic_outline_variant" to "@android:color/system_neutral2_700",
-        "piko_dynamic_prism_black" to "@android:color/system_neutral1_900",
-        "piko_dynamic_prism_white" to "@android:color/system_neutral1_10",
-    )
-
-// Greyscale CONSTANTS — identical in the light and dark buckets (so they do NOT
-// flip with the device theme). Literal grey/black/white *scale* tokens must map to
-// these, never to the mode-flipping aliases above, because Instagram reuses the
-// same literal for OPPOSITE roles per mode: e.g. bds_black is a dark surface in
-// dark mode but dark TEXT/ICONS in light mode (igds_color_primary_icon ->
-// ?igds_color_primary_text -> bds_black in the light theme). A constant keeps such
-// a token the right lightness in both modes; IG's own theme decides which literal
-// to use where. The extremes reuse piko_dynamic_prism_white / prism_black; only
-// three mid-greys are added here. neutral2 tones = the wallpaper-derived neutral
-// ramp (pre-12 hex fallbacks mirror the old dark tones so dark mode is unchanged).
-private val materialYouNeutralConstantsHex =
-    mapOf(
-        "piko_dynamic_neutral_light" to "#ffc1c7cf",
-        "piko_dynamic_neutral_mid" to "#ff8b929b",
-        "piko_dynamic_neutral_dark" to "#ff3f4750",
-    )
-
-private val materialYouNeutralConstantsDynamic =
-    mapOf(
-        "piko_dynamic_neutral_light" to "@android:color/system_neutral2_200",
-        "piko_dynamic_neutral_mid" to "@android:color/system_neutral2_400",
-        "piko_dynamic_neutral_dark" to "@android:color/system_neutral2_700",
-    )
-
-// Literal greyscale tokens (bds_grey_0 lightest .. bds_grey_24 darkest;
-// igds_prism_gray_00 lightest .. _1500 darkest — verified against the 435.x table)
-// map to the fixed CONSTANTS above by lightness, NOT to the mode-flipping aliases.
-// The accent tokens (bds_blue_*, badge/emphasized, prism_indigo) DO flip, because
-// IG uses the same accent literal on both light and dark surfaces and it needs a
-// different tone for contrast in each mode.
-private val materialYouBaseMappings =
-    mapOf(
-        "bds_black" to "@color/piko_dynamic_prism_black",
-        "bds_white" to "@color/piko_dynamic_prism_white",
-        "bds_grey_0" to "@color/piko_dynamic_prism_white",
-        "bds_grey_1" to "@color/piko_dynamic_prism_white",
-        "bds_grey_2" to "@color/piko_dynamic_neutral_light",
-        "bds_grey_3" to "@color/piko_dynamic_neutral_light",
-        "bds_grey_4" to "@color/piko_dynamic_neutral_mid",
-        "bds_grey_6" to "@color/piko_dynamic_neutral_dark",
-        "bds_grey_7" to "@color/piko_dynamic_prism_black",
-        "bds_grey_8" to "@color/piko_dynamic_prism_black",
-        "bds_grey_9" to "@color/piko_dynamic_prism_black",
-        "bds_grey_10" to "@color/piko_dynamic_prism_black",
-        "bds_grey_11" to "@color/piko_dynamic_prism_black",
-        "bds_grey_12" to "@color/piko_dynamic_prism_black",
-        "bds_grey_16" to "@color/piko_dynamic_prism_black",
-        "bds_grey_18" to "@color/piko_dynamic_prism_black",
-        "bds_grey_21" to "@color/piko_dynamic_prism_black",
-        "bds_grey_22" to "@color/piko_dynamic_prism_black",
-        "bds_grey_24" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_00" to "@color/piko_dynamic_prism_white",
-        "igds_prism_gray_08" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_10" to "@color/piko_dynamic_prism_black",
-        "bds_blue_0" to "@color/piko_dynamic_primary",
-        "bds_blue_1" to "@color/piko_dynamic_primary_pressed",
-        "bds_blue_2" to "@color/piko_dynamic_primary_container",
-        // Semantic snackbar surface — flips with the theme like other surfaces.
-        "bottom_sheet_undo_redo_color" to "@color/piko_dynamic_background",
-        "emphasized_action_color" to "@color/piko_dynamic_primary",
-        "badge_color" to "@color/piko_dynamic_primary",
-        "igds_prism_indigo_1000" to "@color/piko_dynamic_primary_container",
-    )
-
-private val materialYouAccentMappings =
-    mapOf(
-        "igds_primary_button" to "@color/piko_dynamic_primary",
-        "igds_link" to "@color/piko_dynamic_primary",
-        "igds_prism_black" to "@color/piko_dynamic_prism_black",
-        "fds_blue_60" to "@color/piko_dynamic_primary",
-    )
-
-// Real IGDS colour-resource tokens (verified present in the target APK). NOTE:
-// the flat igds_*_background surfaces (bottom sheet / dialog / menu / action
-// sheet / modal / popover / toast / list / cell / row / etc.) and their
-// igds_color_* twins were REMOVED here — Instagram has no such colour resources
-// (upsertColor was silently creating dead entries). Those surfaces are themed
-// via the ?attr/igds_color_*_background theme-attribute chains, whose grey
-// leaves are remapped in materialYouSurfaceBaselineMappings below.
-private val materialYouThemeMappings =
-    mapOf(
-        "igds_primary_background" to "@color/piko_dynamic_background",
-        "igds_secondary_background" to "@color/piko_dynamic_background",
-        "igds_elevated_background" to "@color/piko_dynamic_background",
-        "igds_elevated_highlight_background" to "@color/piko_dynamic_background",
-        "igds_elevated_separator" to "@color/piko_dynamic_outline_variant",
-        "igds_separator" to "@color/piko_dynamic_outline_variant",
-        "igds_stroke" to "@color/piko_dynamic_outline",
-        "igds_primary_text" to "@color/piko_dynamic_on_surface",
-        "igds_secondary_text" to "@color/piko_dynamic_on_surface_variant",
-        "igds_primary_icon" to "@color/piko_dynamic_on_surface",
-        "igds_secondary_icon" to "@color/piko_dynamic_on_surface_variant",
-    )
-
-// Surfaces like popup/context menus, alert dialogs, action/bottom sheets and
-// toasts do NOT resolve through the igds_* surface tokens above. They flow
-// through Instagram's GM3/"baseline" Material substrate — a separate colour
-// chain that the igds mappings never reach — which is why those pages (and the
-// activity/notifications feed, which uses the generic default_bg_color) kept
-// rendering in dark grey after the rest of the app was themed.
-//
-// The chains bottom out here (values verified against the patched 435.x APK):
-//   dialog_bg_color_dark_baseline  -> default_bg_color_dark_elev_3 -> baseline_neutral_10_..._alpha_11 (#ff313336)
-//   menu_item_bg_color_dark_baseline -> default_bg_color_dark_elev_5 -> baseline_neutral_10_..._alpha_14 (#ff37393d)
-//   toast_bg_color (night)         -> default_bg_color_dark_elev_1 -> baseline_neutral_10_..._alpha_5  (#ff28282a)
-//   default_bg_color_dark          -> gm3_baseline_surface_dark    -> baseline_neutral_10_..._alpha_5  (#ff28282a)
-//   menu_bg_color_baseline         -> gm3_baseline_surface_container_dark (#ff1e1f20)
-// Remapping the leaves fixes every surface downstream in one place. The alpha_*
-// tokens are misleadingly named — their shipped values are fully opaque, so
-// pointing them at the opaque dynamic background loses no translucency.
-private val materialYouSurfaceBaselineMappings =
-    mapOf(
-        "gm3_baseline_surface_dark" to "@color/piko_dynamic_background",
-        "gm3_baseline_surface_container_dark" to "@color/piko_dynamic_background",
-        "baseline_neutral_10_with_surface_tint_dark_alpha_5" to "@color/piko_dynamic_background",
-        "baseline_neutral_10_with_surface_tint_dark_alpha_11" to "@color/piko_dynamic_background",
-        "baseline_neutral_10_with_surface_tint_dark_alpha_14" to "@color/piko_dynamic_background",
-        // Bottom-sheet variant that hard-codes a raw grey (#ff1c1f24) instead of
-        // going through igds_* / default_bg_color tokens.
-        "basel_bottom_sheet_background_color" to "@color/piko_dynamic_background",
-        // IGDS context / creation menus resolve to translucent prism-gray / bds-grey
-        // leaves not covered by the plain igds_prism_gray_* / bds_grey_* remaps.
-        // Remap the surface tokens directly so their pressed-state item overlays
-        // (subtle 5% alpha tokens) are left intact.
-        "igds_context_menu_background_color" to "@color/piko_dynamic_background",
-        "igds_creation_menu_background" to "@color/piko_dynamic_background",
-        // AppCompat / Material Components (MDC) surface greys. Alert dialogs,
-        // popup & context menus, and MDC bottom sheets don't read the igds_*/gm3_*
-        // colour RESOURCES above — they resolve MDC theme ATTRIBUTES set in
-        // Theme.Instagram: colorSurface -> design_dark_default_color_background
-        // (#ff121212), and colorBackgroundFloating -> background_floating_material_dark
-        // -> cardview_dark_background (#ff424242). background_material_dark falls
-        // through to material_grey_850/900. Those attribute chains bottom out at
-        // these four leaves, so they are the dark greys that survived every other
-        // remap. (elevationOverlayColor is ?attr/colorOnSurface with the overlay
-        // enabled, so elevated MDC surfaces may still show a faint tonal lift on
-        // top of the dynamic background — that's the intended Material elevation
-        // look, not the flat grey being fixed here.)
-        "design_dark_default_color_background" to "@color/piko_dynamic_background",
-        "cardview_dark_background" to "@color/piko_dynamic_background",
-        "material_grey_850" to "@color/piko_dynamic_background",
-        "material_grey_900" to "@color/piko_dynamic_background",
-        // IGDS surfaces — bottom sheets, dialogs, banners, toasts, and the
-        // secondary/notification cells — do NOT read the igds_color_* colour
-        // RESOURCES (those were phantom entries the patch created). Their shape
-        // drawables (igds_bottom_sheet_background, igds_dialog_bg, …) fill via the
-        // theme ATTRIBUTE ?attr/igds_color_elevated_background (and the
-        // _secondary_/_highlight_background attrs). In dark mode the active
-        // overlays — IgdsElevatedBackgroundFixDark / IgdsPrismGrayOverridesDark /
-        // StoryCommentColorsDark — point those attrs at the dark prism-gray leaves
-        // below. prism_gray_08/10 and bds_grey_7..24 were already remapped, but
-        // these darker elevated steps were missed, which is why the sheets/dialogs
-        // stayed grey no matter what the colour resources said.
-        // Dark prism-greys: these are dark-mode elevated surfaces, but IG also uses
-        // the mid-dark ones as dark FOREGROUND (icons/secondary text) in light mode,
-        // so they must be a dark CONSTANT, not the mode-flipping background (which
-        // would flip them to near-white and hide them in light mode).
-        "igds_prism_gray_07" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_09" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_13" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_14" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_1500" to "@color/piko_dynamic_prism_black",
-        // Near-opaque (>=80% alpha) surface/panel variants used for banners,
-        // toasts, notifications and the creation menu. Flattening to the opaque
-        // dynamic background is imperceptible at these alphas. The low-alpha
-        // hover / pressed / scrim tints (…_alpha_50, …_70_transparent,
-        // white_*_transparent, bds_black_*_transparent) are deliberately left
-        // translucent so ripples and overlays keep working.
-        "igds_prism_gray_09_alpha_95" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_10_alpha_95" to "@color/piko_dynamic_prism_black",
-        "bds_grey_9_95_transparent" to "@color/piko_dynamic_prism_black",
-        // bds_grey_10_80_transparent is intentionally EXCLUDED from this flatten:
-        // it's shared with igds_secondary_button_on_media (the reel "watch again"
-        // pill and similar on-media buttons), which needs to stay translucent over
-        // arbitrary media. Flattening it turned that pill into a solid opaque black
-        // block instead of a translucent overlay. igds_creation_menu_background,
-        // the other consumer of this literal, already gets its own direct override
-        // above, so it's unaffected by leaving this literal alone.
-        "bds_grey_10_90_transparent" to "@color/piko_dynamic_prism_black",
-        // LIGHT-mode counterparts of the dark surface leaves above (all confirmed
-        // present in the 435.x resource table). In light mode Instagram resolves the
-        // same attribute chains to the "_light" / non-"_dark" twins, so the day
-        // buckets need them remapped too or light-mode surfaces fall through to stock
-        // white. These stay on the mode-flipping background alias on purpose: in the
-        // light buckets that resolves to the light dynamic surface (correct), and in
-        // the -night buckets it's the dark surface — harmless, since IG doesn't read
-        // the light leaves in dark mode. (The main light window bg, default_bg_color_
-        // light -> bds_white, is already covered by the bds_white constant above.)
-        "gm3_baseline_surface" to "@color/piko_dynamic_background",
-        "gm3_baseline_surface_light" to "@color/piko_dynamic_background",
-        "gm3_baseline_surface_container" to "@color/piko_dynamic_background",
-        "gm3_baseline_surface_container_light" to "@color/piko_dynamic_background",
-        "baseline_neutral_100_with_surface_tint_light_alpha_5" to "@color/piko_dynamic_background",
-        "baseline_neutral_100_with_surface_tint_light_alpha_11" to "@color/piko_dynamic_background",
-        "baseline_neutral_100_with_surface_tint_light_alpha_12" to "@color/piko_dynamic_background",
-        "baseline_neutral_100_with_surface_tint_light_alpha_14" to "@color/piko_dynamic_background",
-        "design_default_color_background" to "@color/piko_dynamic_background",
-        "cardview_light_background" to "@color/piko_dynamic_background",
-        "material_grey_50" to "@color/piko_dynamic_background",
-        "material_grey_100" to "@color/piko_dynamic_background",
-        // The big light-mode gap: in the light theme, MDC colorSurface AND one
-        // igds_color_primary_background variant resolve to abc_decor_view_status_
-        // guard_light (raw #ffffff), and colorBackgroundFloating ->
-        // background_floating_material_light (also raw white). MDC bottom sheets,
-        // alert dialogs and the feed pull colorSurface / colorBackgroundFloating, so
-        // these stayed pure white while every documented igds_/bds_ chain was themed.
-        // (Dark analogues design_dark_default_color_background / cardview_dark_* /
-        // material_grey_850/900 were already mapped above.)
-        //
-        // abc_decor_view_status_guard_light is OVERLOADED and CONFLICTED: it's the
-        // light colorSurface / an igds_color_primary_background variant — a mode-
-        // flipping app SURFACE (must be dark in -night) — AND the on-media text/icon
-        // colour (igds_color_primary_text_on_media/_icon_on_media, wants light always).
-        // The SURFACE role wins: mapping it to a light constant turned the whole app
-        // light in dark mode. So it stays on the mode-flipping background. The cost is
-        // on-media text ("Watch again" / on-video labels) rendering dark in dark mode
-        // — a minor media-overlay issue in the same unreachable class as the
-        // notifications/Bloks surfaces (a single leaf can't be both a dark surface and
-        // light text).
-        "abc_decor_view_status_guard_light" to "@color/piko_dynamic_background",
-        // Pure surface (colorBackgroundFloating) — not reused for text — so the
-        // mode-flipping background is fine here.
-        "background_floating_material_light" to "@color/piko_dynamic_background",
-        // Light near-white prism-greys used as light-mode surfaces / secondary
-        // panels (stock #f3f5f7 / #e9edf0). Map to the light constant so they follow
-        // the light surface tint (and remain light text in dark mode). prism_gray_03
-        // (#dbdfe4) is a light divider tone -> the light-grey constant.
-        "igds_prism_gray_01" to "@color/piko_dynamic_prism_white",
-        "igds_prism_gray_02" to "@color/piko_dynamic_prism_white",
-        "igds_prism_gray_03" to "@color/piko_dynamic_neutral_light",
-    )
-
-private val materialYouNamedMappings =
-    materialYouBaseMappings +
-        materialYouAccentMappings +
-        materialYouThemeMappings +
-        materialYouSurfaceBaselineMappings

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePublicResources.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePublicResources.kt
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.resource.PublicXmlManager
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import org.w3c.dom.Element
+
+private const val STRING_RESOURCE_TYPE = "string"
+
+private data class PublicResourceEntry(
+    val type: String,
+    val name: String,
+    val id: Int,
+)
+
+internal fun reservePublicStringIds(
+    publicXml: File,
+    names: List<String>,
+): Map<String, Int> {
+    if (!publicXml.isFile) {
+        throw PatchException("Missing res/values/public.xml before adding resources")
+    }
+    if (names.isEmpty() || names.any(String::isBlank) || names.distinct().size != names.size) {
+        throw PatchException("Material You public string names must be non-empty and unique")
+    }
+
+    val existingEntries = readPublicResourceEntries(publicXml)
+    validatePublicResourceEntries(existingEntries)
+    val existingByKey = existingEntries.groupBy { it.type to it.name }
+    val stringTypePrefixes =
+        existingEntries
+            .filter { it.type == STRING_RESOURCE_TYPE }
+            .map { it.id ushr 16 }
+            .toSet()
+    if (stringTypePrefixes.size != 1) {
+        throw PatchException(
+            "Expected one existing string resource type id, found $stringTypePrefixes",
+        )
+    }
+
+    PublicXmlManager(publicXml).use { manager ->
+        names.forEach { name ->
+            val key = STRING_RESOURCE_TYPE to name
+            val existing = existingByKey[key].orEmpty()
+            val managerHasId = manager.idExists(STRING_RESOURCE_TYPE, name)
+            if (managerHasId) {
+                if (existing.size != 1) {
+                    throw PatchException(
+                        "Expected one existing public resource for string/$name, " +
+                            "found ${existing.size}",
+                    )
+                }
+            } else {
+                if (existing.isNotEmpty()) {
+                    throw PatchException(
+                        "PublicXmlManager did not recognize existing string/$name",
+                    )
+                }
+                manager.createPublicId(STRING_RESOURCE_TYPE, name)
+                if (!manager.idExists(STRING_RESOURCE_TYPE, name)) {
+                    throw PatchException(
+                        "Failed to reserve public resource id for string/$name",
+                    )
+                }
+            }
+        }
+    }
+
+    val updatedEntries = readPublicResourceEntries(publicXml)
+    val reservedIds =
+        names.associateWith { name ->
+            val matches =
+                updatedEntries.filter {
+                    it.type == STRING_RESOURCE_TYPE && it.name == name
+                }
+            if (matches.size != 1) {
+                throw PatchException(
+                    "Expected one reserved public resource for string/$name, " +
+                        "found ${matches.size}",
+                )
+            }
+            matches.single().id
+        }
+    validateReservedPublicStringIds(
+        entries = updatedEntries,
+        expected = reservedIds,
+        stringTypePrefix = stringTypePrefixes.single(),
+    )
+    return reservedIds
+}
+
+private fun readPublicResourceEntries(publicXml: File): List<PublicResourceEntry> =
+    try {
+        val nodes =
+            DocumentBuilderFactory
+                .newInstance()
+                .newDocumentBuilder()
+                .parse(publicXml)
+                .getElementsByTagName("public")
+        buildList {
+            for (index in 0 until nodes.length) {
+                val element = nodes.item(index) as? Element ?: continue
+                val idText = element.getAttribute("id")
+                val id =
+                    idText
+                        .takeIf { it.startsWith("0x") }
+                        ?.removePrefix("0x")
+                        ?.toLongOrNull(16)
+                        ?.takeIf { it in 1..0xffffffffL }
+                        ?.toInt()
+                        ?: throw PatchException(
+                            "Invalid public resource id: $idText",
+                        )
+                add(
+                    PublicResourceEntry(
+                        type = element.getAttribute("type"),
+                        name = element.getAttribute("name"),
+                        id = id,
+                    ),
+                )
+            }
+        }
+    } catch (exception: PatchException) {
+        throw exception
+    } catch (exception: Exception) {
+        throw PatchException(
+            "Failed to read public resources: ${exception.message}",
+        )
+    }
+
+private fun validatePublicResourceEntries(entries: List<PublicResourceEntry>) {
+    val duplicateKeys =
+        entries
+            .groupingBy { it.type to it.name }
+            .eachCount()
+            .filterValues { it != 1 }
+            .keys
+    if (duplicateKeys.isNotEmpty()) {
+        throw PatchException(
+            "Duplicate public resource names: ${duplicateKeys.joinToString()}",
+        )
+    }
+
+    val duplicateIds =
+        entries
+            .groupingBy(PublicResourceEntry::id)
+            .eachCount()
+            .filterValues { it != 1 }
+            .keys
+    if (duplicateIds.isNotEmpty()) {
+        throw PatchException(
+            "Duplicate public resource ids: " +
+                duplicateIds.joinToString { "0x${it.toUInt().toString(16)}" },
+        )
+    }
+}
+
+private fun validateReservedPublicStringIds(
+    entries: List<PublicResourceEntry>,
+    expected: Map<String, Int>,
+    stringTypePrefix: Int,
+) {
+    validatePublicResourceEntries(entries)
+    if (expected.values.any { it == 0 } || expected.values.toSet().size != expected.size) {
+        throw PatchException("Reserved Material You public string ids must be non-zero and unique")
+    }
+
+    expected.forEach { (name, id) ->
+        if (id ushr 16 != stringTypePrefix) {
+            throw PatchException(
+                "Reserved public resource id for string/$name changed resource type",
+            )
+        }
+        val matches =
+            entries.filter {
+                it.type == STRING_RESOURCE_TYPE && it.name == name && it.id == id
+            }
+        if (matches.size != 1) {
+            throw PatchException(
+                "Expected one reserved public resource for string/$name with id " +
+                    "0x${id.toUInt().toString(16)}, found ${matches.size}",
+            )
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeResources.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeResources.kt
@@ -1,0 +1,306 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.patch.ResourcePatchContext
+import app.morphe.util.findElementByAttributeValueOrThrow
+import java.io.File
+import java.io.FileWriter
+import java.nio.file.Files
+import org.w3c.dom.Document
+import org.w3c.dom.Element
+
+internal data class Api31BaseSnapshot(
+    val dayColors: Map<String, String>,
+    val nightColors: Map<String, String>,
+)
+
+private val onMediaChromeAttrs =
+    setOf(
+        "igds_color_primary_text_on_media",
+        "igds_color_icon_on_media",
+        "igds_color_primary_button_on_media",
+        "muteIconPrimaryColor",
+    )
+
+private val onMediaAttrsPointingAtGuardLight =
+    setOf(
+        "sc_primary_icon_on_media",
+        "sc_primary_text_on_media",
+        "sc_always_white",
+    )
+
+private val amoledDayOverrides =
+    mapOf(
+        "igds_prism_black" to "#ff000000",
+    )
+
+private val amoledNightOverrides =
+    mapOf(
+        "igds_secondary_background" to "@color/bds_black",
+        "igds_elevated_background" to "@color/bds_black",
+        "igds_elevated_highlight_background" to "@color/bds_black",
+        "igds_prism_black" to "#ff000000",
+    )
+
+internal fun Document.forceWhiteOnMediaChromeItems() {
+    val items = getElementsByTagName("item")
+    for (index in 0 until items.length) {
+        val item = items.item(index) as? Element ?: continue
+        val name = item.getAttribute("name")
+        if (name in onMediaChromeAttrs) {
+            item.textContent = "@color/bds_white"
+        } else if (
+            name in onMediaAttrsPointingAtGuardLight &&
+            item.textContent == "@color/abc_decor_view_status_guard_light"
+        ) {
+            item.textContent = "@color/bds_white"
+        }
+    }
+}
+
+internal fun ResourcePatchContext.forceWhiteOnMediaChrome() {
+    listOf(
+        "res/values/styles.xml",
+        "res/values-night/styles.xml",
+    ).forEach { path ->
+        if (!get(path).exists()) return@forEach
+        document(path).use { document ->
+            document.forceWhiteOnMediaChromeItems()
+        }
+    }
+}
+
+internal fun ResourcePatchContext.captureApi31Base(): Api31BaseSnapshot {
+    val values = readColors("res/values/colors.xml")
+    val nightValues = readColors("res/values-night/colors.xml")
+    val api31Values = readColors("res/values-v31/colors.xml")
+    val api31NightValues = readColors("res/values-night-v31/colors.xml")
+
+    return Api31BaseSnapshot(
+        dayColors = resolveBaseColors(api31Values, values),
+        nightColors = resolveBaseColors(
+            api31NightValues,
+            nightValues,
+            api31Values,
+            values,
+        ),
+    )
+}
+
+internal fun ResourcePatchContext.applyLegacyTheme(amoled: Boolean) {
+    if (amoled) {
+        applyLegacyAmoledTheme()
+    } else {
+        applyLegacyMaterialYouTheme()
+    }
+}
+
+internal fun ResourcePatchContext.restoreApi31Base(
+    snapshot: Api31BaseSnapshot,
+) {
+    writeColors(
+        directoryPath = "res/values-v31",
+        values = snapshot.dayColors,
+    )
+    writeColors(
+        directoryPath = "res/values-night-v31",
+        values = snapshot.nightColors,
+    )
+}
+
+internal fun materialYouOverlayValues(night: Boolean): OverlayValues {
+    val values = dynamicOverlayMappings(night)
+    val api34Values = values + materialYouSwitchApi34Mappings(night)
+    return OverlayValues(
+        day = values,
+        night = values,
+        dayApi34 = api34Values,
+        nightApi34 = api34Values,
+    )
+}
+
+internal fun ResourcePatchContext.writeMaterialYouOverlay(night: Boolean): File =
+    buildThemeOverlayTable(
+        sourceManifest = get("AndroidManifest.xml"),
+        sourcePublic = get("res/values/public.xml"),
+        packageName = packageMetadata.packageName,
+        outputFile =
+            get(
+                if (night) {
+                    "assets/piko/material_you_dark.arsc"
+                } else {
+                    "assets/piko/material_you_light.arsc"
+                },
+                copy = false,
+            ),
+        values = materialYouOverlayValues(night),
+    )
+
+internal fun ResourcePatchContext.writeAmoledOverlay(
+    snapshot: Api31BaseSnapshot,
+): File =
+    buildThemeOverlayTable(
+        sourceManifest = get("AndroidManifest.xml"),
+        sourcePublic = get("res/values/public.xml"),
+        packageName = packageMetadata.packageName,
+        outputFile = get("assets/piko/amoled.arsc", copy = false),
+        values = amoledOverlayValues(snapshot),
+    )
+
+internal fun amoledMaterialYouOverlayValues(): OverlayValues {
+    val values = amoledMaterialYouOverlayMappings()
+    val api34Values = values + materialYouSwitchApi34Mappings(night = true)
+    return OverlayValues(
+        day = values,
+        night = values,
+        dayApi34 = api34Values,
+        nightApi34 = api34Values,
+    )
+}
+
+private fun materialYouSwitchApi34Mappings(night: Boolean): Map<String, String> =
+    if (night) {
+        mapOf(
+            "material_selected_track" to "@android:color/system_primary_dark",
+            "checkbox_image_tint" to "@android:color/system_on_primary_dark",
+            "material_unselected_track" to
+                "@android:color/system_surface_container_highest_dark",
+            "material_track_border" to "@android:color/system_outline_dark",
+            "checkbox_unchecked_enabled" to "@android:color/system_outline_dark",
+        )
+    } else {
+        mapOf(
+            "material_selected_track" to "@android:color/system_primary_light",
+            "checkbox_image_tint" to "@android:color/system_on_primary_light",
+            "material_unselected_track" to
+                "@android:color/system_surface_container_highest_light",
+            "material_track_border" to "@android:color/system_outline_light",
+            "checkbox_unchecked_enabled" to "@android:color/system_outline_light",
+        )
+    }
+
+internal fun ResourcePatchContext.writeAmoledMaterialYouOverlay(): File =
+    buildThemeOverlayTable(
+        sourceManifest = get("AndroidManifest.xml"),
+        sourcePublic = get("res/values/public.xml"),
+        packageName = packageMetadata.packageName,
+        outputFile = get("assets/piko/amoled_material_you.arsc", copy = false),
+        values = amoledMaterialYouOverlayValues(),
+    )
+
+internal fun amoledOverlayValues(snapshot: Api31BaseSnapshot): OverlayValues =
+    (snapshot.nightColors + amoledSurfaceBaselineMappings + amoledNightOverrides).let { values ->
+        OverlayValues(day = values, night = values)
+    }
+
+private fun ResourcePatchContext.applyLegacyAmoledTheme() {
+    document("res/values-night/colors.xml").use { document ->
+        val colors = document.getElementsByTagName("color")
+        amoledNightOverrides
+            .filterKeys { it != "igds_prism_black" }
+            .forEach { (name, value) ->
+                colors.findElementByAttributeValueOrThrow("name", name).textContent = value
+            }
+    }
+
+    document("res/values/colors.xml").use { document ->
+        val colors = document.getElementsByTagName("color")
+        amoledDayOverrides.forEach { (name, value) ->
+            colors.findElementByAttributeValueOrThrow("name", name).textContent = value
+        }
+    }
+}
+
+private fun ResourcePatchContext.applyLegacyMaterialYouTheme() {
+    listOf(
+        "res/values" to (materialYouLightFallbackAliases + materialYouNeutralConstantsHex),
+        "res/values-night" to (materialYouDarkFallbackAliases + materialYouNeutralConstantsHex),
+    ).forEach { (directoryPath, aliases) ->
+        ensureColorsXml(directoryPath)
+        document("$directoryPath/colors.xml").use { document ->
+            (aliases + materialYouNamedMappings).forEach { (name, value) ->
+                document.upsertColor(name, value)
+            }
+        }
+    }
+}
+
+private fun ResourcePatchContext.readColors(path: String): Map<String, String> {
+    if (!get(path).exists()) return emptyMap()
+
+    return document(path).use { document ->
+        buildMap {
+            val colors = document.getElementsByTagName("color")
+            for (index in 0 until colors.length) {
+                val color = colors.item(index) as? Element ?: continue
+                put(color.getAttribute("name"), color.textContent)
+            }
+        }
+    }
+}
+
+private fun resolveBaseColors(
+    vararg buckets: Map<String, String>,
+): Map<String, String> =
+    materialYouNamedMappings.keys.associateWith { name ->
+        checkNotNull(buckets.firstNotNullOfOrNull { it[name] }) {
+            "Unable to resolve base color: $name"
+        }
+    }
+
+private fun ResourcePatchContext.writeColors(
+    directoryPath: String,
+    values: Map<String, String>,
+) {
+    ensureColorsXml(directoryPath)
+    document("$directoryPath/colors.xml").use { document ->
+        values.forEach { (name, value) ->
+            document.upsertColor(name, value)
+        }
+    }
+}
+
+private fun ResourcePatchContext.ensureColorsXml(directoryPath: String) {
+    val directory = get(directoryPath)
+    if (!directory.isDirectory) {
+        Files.createDirectories(directory.toPath())
+    }
+
+    val colorsXml = directory.resolve("colors.xml")
+    if (!colorsXml.exists()) {
+        FileWriter(colorsXml).use {
+            it.write("<?xml version=\"1.0\" encoding=\"utf-8\"?><resources></resources>")
+        }
+    }
+}
+
+private fun Document.upsertColor(name: String, value: String) {
+    val existingColor = findColor(name)
+    if (existingColor != null) {
+        existingColor.textContent = value
+    } else {
+        documentElement.appendChild(
+            createElement("color").apply {
+                setAttribute("name", name)
+                textContent = value
+            },
+        )
+    }
+}
+
+private fun Document.findColor(name: String): Element? {
+    val colors = getElementsByTagName("color")
+    for (index in 0 until colors.length) {
+        val color = colors.item(index) as? Element ?: continue
+        if (color.getAttribute("name") == name) {
+            return color
+        }
+    }
+
+    return null
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeRestartCallback.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeRestartCallback.kt
@@ -1,0 +1,670 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.theme
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.BuilderOffsetInstruction
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderInstruction31t
+import com.android.tools.smali.dexlib2.builder.instruction.BuilderSwitchElement
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.SwitchPayload
+import com.android.tools.smali.dexlib2.iface.instruction.TwoRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+
+private const val OBJECT_DESCRIPTOR = "Ljava/lang/Object;"
+
+private data class RestartRegistration(
+    val literalIndex: Int,
+    val selectorRegister: Int,
+    val selector: Int,
+    val helperReference: MethodReference,
+)
+
+private data class NewCallbackSelector(
+    val selector: Int,
+    val callbackInvoke: MutableMethod,
+    val switchIndex: Int,
+    val originalSwitch: BuilderInstruction31t,
+    val selectorRegister: Int,
+    val receiverRegister: Int,
+    val firstArgumentRegister: Int,
+    val secondArgumentRegister: Int,
+    val composerRegister: Int,
+    val booleanRegister: Int,
+    val callbackRegister: Int,
+    val flagsRegister: Int,
+    val composerConverter: MethodReference,
+    val booleanField: FieldReference,
+    val callbackField: FieldReference,
+    val flagsHelper: MethodReference,
+    val returnInstructionIndex: Int,
+)
+
+context(patchContext: BytecodePatchContext)
+internal fun redirectMaterialYouRestartCallback(
+    source: MutableMethod,
+    copy: MutableMethod,
+    composerType: String,
+    targetName: String,
+) {
+    val sourceRegistration = findRestartRegistration(source, composerType)
+    val copiedRegistration = findRestartRegistration(copy, composerType)
+    if (
+        sourceRegistration.literalIndex != copiedRegistration.literalIndex ||
+        sourceRegistration.selectorRegister != copiedRegistration.selectorRegister ||
+        sourceRegistration.selector != copiedRegistration.selector ||
+        !sourceRegistration.helperReference.sameMethodAs(
+            copiedRegistration.helperReference,
+        )
+    ) {
+        throw PatchException(
+            "Copied ReduceMotionToggle restart registration did not match its source",
+        )
+    }
+
+    val selector =
+        findNewCallbackSelector(
+            source = source,
+            registration = sourceRegistration,
+            composerType = composerType,
+        )
+    val targetDescriptor =
+        "${source.definingClass}->$targetName(" +
+            source.parameterTypes.joinToString(separator = "") +
+            ")${source.returnType}"
+    val returnInstruction =
+        selector.callbackInvoke.getInstruction(selector.returnInstructionIndex)
+
+    copy.replaceInstruction(
+        copiedRegistration.literalIndex,
+        "const v${copiedRegistration.selectorRegister}, ${selector.selector}",
+    )
+    selector.callbackInvoke.addInstructionsWithLabels(
+        selector.switchIndex,
+        """
+        add-int/lit8 v${selector.selectorRegister}, v${selector.selectorRegister}, -${selector.selector}
+        if-eqz v${selector.selectorRegister}, :piko_material_you_restart
+        add-int/lit8 v${selector.selectorRegister}, v${selector.selectorRegister}, ${selector.selector}
+        goto/32 :piko_original_restart_switch
+
+        :piko_material_you_restart
+        invoke-static {v${selector.firstArgumentRegister}, v${selector.secondArgumentRegister}}, ${selector.composerConverter}
+        move-result-object v${selector.composerRegister}
+        iget-boolean v${selector.booleanRegister}, v${selector.receiverRegister}, ${selector.booleanField}
+        iget-object v${selector.callbackRegister}, v${selector.receiverRegister}, ${selector.callbackField}
+        check-cast v${selector.callbackRegister}, $FUNCTION1_DESCRIPTOR
+        invoke-static {v${selector.receiverRegister}}, ${selector.flagsHelper}
+        move-result v${selector.flagsRegister}
+        invoke-static {v${selector.composerRegister}, v${selector.callbackRegister}, v${selector.flagsRegister}, v${selector.booleanRegister}}, $targetDescriptor
+        goto/32 :piko_restart_return
+        """.trimIndent(),
+        ExternalLabel("piko_original_restart_switch", selector.originalSwitch),
+        ExternalLabel("piko_restart_return", returnInstruction),
+    )
+}
+
+private fun findRestartRegistration(
+    method: MutableMethod,
+    composerType: String,
+): RestartRegistration {
+    val firstParameter = firstParameterRegister(method)
+    val composerParameter = firstParameter
+    val callbackParameter = firstParameter + 1
+    val flagsParameter = firstParameter + 2
+    val booleanParameter = firstParameter + 3
+    val instructions = method.instructions
+    val candidates =
+        instructions.mapIndexedNotNull { index, instruction ->
+            if (
+                index < 4 ||
+                instruction.opcode !in
+                setOf(
+                    Opcode.INVOKE_STATIC,
+                    Opcode.INVOKE_STATIC_RANGE,
+                )
+            ) {
+                return@mapIndexedNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapIndexedNotNull null
+            val parameterTypes = reference.parameterTypes.map(CharSequence::toString)
+            val registers = instruction.registersUsed
+            if (
+                reference.returnType != "V" ||
+                parameterTypes.size != 5 ||
+                !parameterTypes[0].isReferenceDescriptor() ||
+                parameterTypes.drop(1) != listOf(OBJECT_DESCRIPTOR, "I", "I", "Z") ||
+                registers.size != 5 ||
+                registers[1] != callbackParameter ||
+                registers[2] != flagsParameter ||
+                registers[4] != booleanParameter
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            val literalInstruction = instructions[index - 1]
+            val literalRegister =
+                (literalInstruction as? OneRegisterInstruction)?.registerA
+                    ?: return@mapIndexedNotNull null
+            val selector =
+                (literalInstruction as? NarrowLiteralInstruction)?.narrowLiteral
+                    ?: return@mapIndexedNotNull null
+            if (
+                literalInstruction.opcode !in
+                setOf(Opcode.CONST, Opcode.CONST_4, Opcode.CONST_16) ||
+                literalRegister != registers[3]
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            val nullCheck = instructions[index - 2] as? OneRegisterInstruction
+            val moveResult = instructions[index - 3] as? OneRegisterInstruction
+            val scopeGetterInstruction = instructions[index - 4]
+            val scopeGetter =
+                (scopeGetterInstruction as? ReferenceInstruction)?.reference as? MethodReference
+                    ?: return@mapIndexedNotNull null
+            if (
+                instructions[index - 2].opcode != Opcode.IF_EQZ ||
+                nullCheck?.registerA != registers[0] ||
+                instructions[index - 3].opcode != Opcode.MOVE_RESULT_OBJECT ||
+                moveResult?.registerA != registers[0] ||
+                scopeGetterInstruction.opcode !in
+                setOf(
+                    Opcode.INVOKE_INTERFACE,
+                    Opcode.INVOKE_INTERFACE_RANGE,
+                ) ||
+                scopeGetter.parameterTypes.isNotEmpty() ||
+                scopeGetter.returnType != parameterTypes[0] ||
+                scopeGetter.definingClass != composerType ||
+                scopeGetterInstruction.registersUsed != listOf(composerParameter)
+            ) {
+                return@mapIndexedNotNull null
+            }
+
+            RestartRegistration(
+                literalIndex = index - 1,
+                selectorRegister = literalRegister,
+                selector = selector,
+                helperReference = reference,
+            )
+        }
+
+    if (candidates.size != 1) {
+        throw PatchException(
+            "Expected exactly one ReduceMotionToggle restart registration, " +
+                "found ${candidates.size}",
+        )
+    }
+    return candidates.single()
+}
+
+context(patchContext: BytecodePatchContext)
+private fun findNewCallbackSelector(
+    source: MutableMethod,
+    registration: RestartRegistration,
+    composerType: String,
+): NewCallbackSelector {
+    val helperReference = registration.helperReference
+    val helperClass = patchContext.mutableClassDefBy(helperReference.definingClass)
+    val helperMethods =
+        helperClass.methods.filter { it.sameMethodAs(helperReference) }
+    if (helperMethods.size != 1) {
+        throw PatchException(
+            "Expected exactly one restart callback helper, found ${helperMethods.size}",
+        )
+    }
+    val helper = helperMethods.single()
+    if (!AccessFlags.STATIC.isSet(helper.accessFlags)) {
+        throw PatchException("Restart callback helper must be static")
+    }
+
+    val callbackClassDescriptor = findCallbackClassDescriptor(helper, helperReference)
+    val callbackClass = patchContext.mutableClassDefBy(callbackClassDescriptor)
+    val callbackInvokes =
+        callbackClass.methods.filter { method ->
+            method.name == "invoke" &&
+                method.parameterTypes.map(CharSequence::toString) ==
+                listOf(OBJECT_DESCRIPTOR, OBJECT_DESCRIPTOR) &&
+                method.returnType == OBJECT_DESCRIPTOR &&
+                !AccessFlags.STATIC.isSet(method.accessFlags)
+        }
+    if (callbackInvokes.size != 1) {
+        throw PatchException(
+            "Expected exactly one restart callback invoke method, found ${callbackInvokes.size}",
+        )
+    }
+    val callbackInvoke = callbackInvokes.single()
+    val switches =
+        callbackInvoke.instructions.mapIndexedNotNull { index, instruction ->
+            if (instruction.opcode != Opcode.PACKED_SWITCH) {
+                return@mapIndexedNotNull null
+            }
+            val switchInstruction = instruction as? BuilderInstruction31t
+                ?: throw PatchException("Restart callback switch is not mutable")
+            val payload =
+                switchInstruction.target.location.instruction as? SwitchPayload
+                    ?: throw PatchException("Restart callback switch payload is missing")
+            Triple(index, switchInstruction, payload)
+        }
+    if (switches.size != 1) {
+        throw PatchException(
+            "Expected exactly one packed switch in restart callback, found ${switches.size}",
+        )
+    }
+
+    val (switchIndex, switchInstruction, payload) = switches.single()
+    val switchElements = payload.switchElements
+    if (switchElements.isEmpty()) {
+        throw PatchException("Restart callback switch has no cases")
+    }
+    val sourceElements =
+        switchElements.filter { it.key == registration.selector }
+    if (sourceElements.size != 1) {
+        throw PatchException(
+            "Expected one restart callback case for selector ${registration.selector}, " +
+                "found ${sourceElements.size}",
+        )
+    }
+    val sourceElement = sourceElements.single() as? BuilderSwitchElement
+        ?: throw PatchException("Restart callback switch case is not mutable")
+    val caseIndex = sourceElement.target.location.index
+
+    val selectorFieldInstruction =
+        callbackInvoke.instructions
+            .take(switchIndex)
+            .filter { instruction ->
+                instruction.opcode == Opcode.IGET &&
+                    (instruction as? OneRegisterInstruction)?.registerA ==
+                    switchInstruction.registerA
+            }
+    if (selectorFieldInstruction.size != 1) {
+        throw PatchException(
+            "Expected one restart callback selector field read, " +
+                "found ${selectorFieldInstruction.size}",
+        )
+    }
+    val selectorRead = selectorFieldInstruction.single()
+    val selectorField =
+        (selectorRead as? ReferenceInstruction)?.reference as? FieldReference
+            ?: throw PatchException("Restart callback selector field reference is missing")
+    val receiverRegister =
+        (selectorRead as? TwoRegisterInstruction)?.registerB
+            ?: throw PatchException("Restart callback selector receiver is missing")
+    if (
+        selectorField.definingClass != callbackClassDescriptor ||
+        selectorField.type != "I" ||
+        !callbackInvoke.hasObjectMoveFromParameter(
+            destination = receiverRegister,
+            parameterIndex = 0,
+            beforeIndex = switchIndex,
+        )
+    ) {
+        throw PatchException("Unexpected restart callback selector field access")
+    }
+
+    val switchKeys = switchElements.map { it.key }.toSet()
+    val nextSelector =
+        switchKeys.maxOrNull()
+            ?.takeIf { it != Int.MAX_VALUE }
+            ?.plus(1)
+            ?: throw PatchException("Restart callback selector range is exhausted")
+    val comparedSelectors =
+        findComparedSelectorValues(callbackClass.methods, selectorField)
+    if (nextSelector in switchKeys || nextSelector in comparedSelectors) {
+        throw PatchException(
+            "New restart callback selector $nextSelector collides with an existing selector",
+        )
+    }
+    if (
+        nextSelector !in Byte.MIN_VALUE..Byte.MAX_VALUE ||
+        -nextSelector !in Byte.MIN_VALUE..Byte.MAX_VALUE
+    ) {
+        throw PatchException(
+            "New restart callback selector $nextSelector does not fit add-int/lit8",
+        )
+    }
+
+    val caseInstructions =
+        (0..8).map { offset ->
+            callbackInvoke.instructions.getOrNull(caseIndex + offset)
+                ?: throw PatchException("Restart callback case is truncated")
+        }
+    val composerConverter =
+        caseInstructions[0].staticCall()
+            ?: throw PatchException("Restart callback composer conversion is missing")
+    val composerRegisters = caseInstructions[0].registersUsed
+    val composerResult =
+        (caseInstructions[1] as? OneRegisterInstruction)?.registerA
+            ?: throw PatchException("Restart callback composer result is missing")
+    if (
+        caseInstructions[1].opcode != Opcode.MOVE_RESULT_OBJECT ||
+        composerConverter.parameterTypes.map(CharSequence::toString) !=
+        listOf(OBJECT_DESCRIPTOR, OBJECT_DESCRIPTOR) ||
+        composerConverter.returnType != composerType ||
+        composerRegisters.size != 2 ||
+        !callbackInvoke.hasObjectMoveFromParameter(
+            destination = composerRegisters[0],
+            parameterIndex = 1,
+            beforeIndex = switchIndex,
+        ) ||
+        !callbackInvoke.hasObjectMoveFromParameter(
+            destination = composerRegisters[1],
+            parameterIndex = 2,
+            beforeIndex = switchIndex,
+        )
+    ) {
+        throw PatchException("Unexpected restart callback composer conversion")
+    }
+
+    val booleanInstruction = caseInstructions[2]
+    val booleanField =
+        (booleanInstruction as? ReferenceInstruction)?.reference as? FieldReference
+            ?: throw PatchException("Restart callback boolean field is missing")
+    val booleanRegisters = booleanInstruction as? TwoRegisterInstruction
+        ?: throw PatchException("Restart callback boolean registers are missing")
+    if (
+        booleanInstruction.opcode != Opcode.IGET_BOOLEAN ||
+        booleanField.definingClass != callbackClassDescriptor ||
+        booleanField.type != "Z" ||
+        booleanRegisters.registerB != receiverRegister
+    ) {
+        throw PatchException("Unexpected restart callback boolean field access")
+    }
+
+    val callbackInstruction = caseInstructions[3]
+    val callbackField =
+        (callbackInstruction as? ReferenceInstruction)?.reference as? FieldReference
+            ?: throw PatchException("Restart callback captured callback field is missing")
+    val callbackRegisters = callbackInstruction as? TwoRegisterInstruction
+        ?: throw PatchException("Restart callback captured callback registers are missing")
+    val callbackCast =
+        (caseInstructions[4] as? ReferenceInstruction)?.reference as? TypeReference
+            ?: throw PatchException("Restart callback Function1 cast is missing")
+    if (
+        callbackInstruction.opcode != Opcode.IGET_OBJECT ||
+        callbackField.definingClass != callbackClassDescriptor ||
+        callbackField.type != OBJECT_DESCRIPTOR ||
+        callbackRegisters.registerB != receiverRegister ||
+        caseInstructions[4].opcode != Opcode.CHECK_CAST ||
+        (caseInstructions[4] as? OneRegisterInstruction)?.registerA !=
+        callbackRegisters.registerA ||
+        callbackCast.type != FUNCTION1_DESCRIPTOR
+    ) {
+        throw PatchException("Unexpected restart callback captured callback access")
+    }
+
+    val flagsHelper =
+        caseInstructions[5].staticCall()
+            ?: throw PatchException("Restart callback flags helper is missing")
+    val flagsResult =
+        (caseInstructions[6] as? OneRegisterInstruction)?.registerA
+            ?: throw PatchException("Restart callback flags result is missing")
+    if (
+        flagsHelper.definingClass != callbackClassDescriptor ||
+        flagsHelper.parameterTypes.map(CharSequence::toString) !=
+        listOf(callbackClassDescriptor) ||
+        flagsHelper.returnType != "I" ||
+        caseInstructions[5].registersUsed != listOf(receiverRegister) ||
+        caseInstructions[6].opcode != Opcode.MOVE_RESULT
+    ) {
+        throw PatchException("Unexpected restart callback flags calculation")
+    }
+
+    val targetCall =
+        caseInstructions[7].staticCall()
+            ?: throw PatchException("Restart callback ReduceMotionToggle call is missing")
+    val targetRegisters = caseInstructions[7].registersUsed
+    if (
+        !targetCall.sameMethodAs(source) ||
+        targetRegisters !=
+        listOf(
+            composerResult,
+            callbackRegisters.registerA,
+            flagsResult,
+            booleanRegisters.registerA,
+        )
+    ) {
+        throw PatchException(
+            "Restart callback case does not call the matched ReduceMotionToggle",
+        )
+    }
+
+    val caseExit = caseInstructions[8] as? BuilderOffsetInstruction
+        ?: throw PatchException("Restart callback case exit is missing")
+    if (
+        caseInstructions[8].opcode !in
+        setOf(Opcode.GOTO, Opcode.GOTO_16, Opcode.GOTO_32)
+    ) {
+        throw PatchException("Restart callback case does not end with a direct branch")
+    }
+    val returnInstructionIndex = caseExit.target.location.index
+    val unitRead = callbackInvoke.instructions.getOrNull(returnInstructionIndex)
+    val unitReturn = callbackInvoke.instructions.getOrNull(returnInstructionIndex + 1)
+    val unitRegister = (unitRead as? OneRegisterInstruction)?.registerA
+    val returnedRegister = (unitReturn as? OneRegisterInstruction)?.registerA
+    val unitField = (unitRead as? ReferenceInstruction)?.reference as? FieldReference
+    if (
+        unitRead?.opcode != Opcode.SGET_OBJECT ||
+        unitField == null ||
+        !unitField.type.isReferenceDescriptor() ||
+        unitReturn?.opcode != Opcode.RETURN_OBJECT ||
+        unitRegister == null ||
+        returnedRegister != unitRegister
+    ) {
+        throw PatchException("Restart callback common Unit return is missing")
+    }
+
+    val injectedRegisters =
+        listOf(
+            switchInstruction.registerA,
+            receiverRegister,
+            composerResult,
+            booleanRegisters.registerA,
+            callbackRegisters.registerA,
+            flagsResult,
+        ) + composerRegisters
+    if (
+        injectedRegisters.any { it !in 0..0xf }
+    ) {
+        throw PatchException(
+            "Restart callback dispatch requires safe local 4-bit registers; " +
+                "found $injectedRegisters",
+        )
+    }
+
+    return NewCallbackSelector(
+        selector = nextSelector,
+        callbackInvoke = callbackInvoke,
+        switchIndex = switchIndex,
+        originalSwitch = switchInstruction,
+        selectorRegister = switchInstruction.registerA,
+        receiverRegister = receiverRegister,
+        firstArgumentRegister = composerRegisters[0],
+        secondArgumentRegister = composerRegisters[1],
+        composerRegister = composerResult,
+        booleanRegister = booleanRegisters.registerA,
+        callbackRegister = callbackRegisters.registerA,
+        flagsRegister = flagsResult,
+        composerConverter = composerConverter,
+        booleanField = booleanField,
+        callbackField = callbackField,
+        flagsHelper = flagsHelper,
+        returnInstructionIndex = returnInstructionIndex,
+    )
+}
+
+private fun findCallbackClassDescriptor(
+    helper: MutableMethod,
+    helperReference: MethodReference,
+): String {
+    val helperParameters = helperReference.parameterTypes.map(CharSequence::toString)
+    if (
+        helperReference.returnType != "V" ||
+        helperParameters.size != 5 ||
+        !helperParameters[0].isReferenceDescriptor() ||
+        helperParameters.drop(1) != listOf(OBJECT_DESCRIPTOR, "I", "I", "Z")
+    ) {
+        throw PatchException("Unexpected restart callback helper signature")
+    }
+    val firstParameter = firstParameterRegister(helper)
+    val expectedConstructorRegisters =
+        listOf(
+            firstParameter + 1,
+            firstParameter + 2,
+            firstParameter + 3,
+            firstParameter + 4,
+        )
+    val newInstances =
+        helper.instructions.mapNotNull { instruction ->
+            if (instruction.opcode != Opcode.NEW_INSTANCE) return@mapNotNull null
+            val descriptor =
+                ((instruction as? ReferenceInstruction)?.reference as? TypeReference)?.type
+                    ?: return@mapNotNull null
+            val register =
+                (instruction as? OneRegisterInstruction)?.registerA
+                    ?: return@mapNotNull null
+            descriptor to register
+        }
+    val candidates =
+        newInstances.filter { (descriptor, instanceRegister) ->
+            helper.instructions.count { instruction ->
+                if (
+                    instruction.opcode !in
+                    setOf(Opcode.INVOKE_DIRECT, Opcode.INVOKE_DIRECT_RANGE)
+                ) {
+                    return@count false
+                }
+                val constructor =
+                    (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                        ?: return@count false
+                constructor.definingClass == descriptor &&
+                    constructor.name == "<init>" &&
+                    constructor.parameterTypes.map(CharSequence::toString) ==
+                    listOf(OBJECT_DESCRIPTOR, "I", "I", "Z") &&
+                    constructor.returnType == "V" &&
+                    instruction.registersUsed ==
+                    listOf(instanceRegister) + expectedConstructorRegisters
+            } == 1
+        }
+    if (candidates.size != 1) {
+        throw PatchException(
+            "Expected exactly one restart callback allocation, found ${candidates.size}",
+        )
+    }
+
+    val (callbackDescriptor, instanceRegister) = candidates.single()
+    val storedCallbacks =
+        helper.instructions.filter { instruction ->
+            if (instruction.opcode != Opcode.IPUT_OBJECT) return@filter false
+            val field =
+                (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@filter false
+            field.definingClass == helperParameters[0] &&
+                field.type.isReferenceDescriptor() &&
+                instruction.registersUsed ==
+                listOf(instanceRegister, firstParameter)
+        }
+    if (storedCallbacks.size != 1) {
+        throw PatchException(
+            "Expected exactly one restart callback scope assignment, " +
+                "found ${storedCallbacks.size}",
+        )
+    }
+    return callbackDescriptor
+}
+
+private fun findComparedSelectorValues(
+    methods: Iterable<MutableMethod>,
+    selectorField: FieldReference,
+): Set<Int> =
+    buildSet {
+        methods.filter { it.name == "<init>" }.forEach { constructor ->
+            val selectorSources =
+                constructor.instructions.mapNotNull { instruction ->
+                    if (instruction.opcode != Opcode.IPUT) return@mapNotNull null
+                    val field =
+                        (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                            ?: return@mapNotNull null
+                    if (field.toString() != selectorField.toString()) {
+                        return@mapNotNull null
+                    }
+                    (instruction as? TwoRegisterInstruction)?.registerA
+                }.toSet()
+            if (selectorSources.isEmpty()) return@forEach
+
+            constructor.instructions.zipWithNext().forEach { (literal, branch) ->
+                val literalRegister =
+                    (literal as? OneRegisterInstruction)?.registerA
+                        ?: return@forEach
+                val literalValue =
+                    (literal as? NarrowLiteralInstruction)?.narrowLiteral
+                        ?: return@forEach
+                val branchRegisters = branch.registersUsed
+                if (
+                    branch.opcode in setOf(Opcode.IF_EQ, Opcode.IF_NE) &&
+                    literalRegister in branchRegisters &&
+                    selectorSources.any { it in branchRegisters }
+                ) {
+                    add(literalValue)
+                }
+            }
+        }
+    }
+
+private fun MutableMethod.hasObjectMoveFromParameter(
+    destination: Int,
+    parameterIndex: Int,
+    beforeIndex: Int,
+): Boolean {
+    val parameterRegister = firstParameterRegister(this) + parameterIndex
+    val matches =
+        instructions.take(beforeIndex).filter { instruction ->
+            instruction.opcode in
+                setOf(
+                    Opcode.MOVE_OBJECT,
+                    Opcode.MOVE_OBJECT_FROM16,
+                    Opcode.MOVE_OBJECT_16,
+                ) &&
+                (instruction as? TwoRegisterInstruction)?.let {
+                    it.registerA == destination && it.registerB == parameterRegister
+                } == true
+        }
+    return matches.size == 1
+}
+
+private fun MethodReference.sameMethodAs(other: MethodReference): Boolean =
+    definingClass == other.definingClass &&
+        name == other.name &&
+        parameterTypes.map(CharSequence::toString) ==
+        other.parameterTypes.map(CharSequence::toString) &&
+        returnType == other.returnType
+
+private fun com.android.tools.smali.dexlib2.iface.instruction.Instruction.staticCall():
+    MethodReference? {
+    if (opcode !in setOf(Opcode.INVOKE_STATIC, Opcode.INVOKE_STATIC_RANGE)) {
+        return null
+    }
+    return (this as? ReferenceInstruction)?.reference as? MethodReference
+}
+
+private fun String.isReferenceDescriptor(): Boolean =
+    (length >= 3 && startsWith("L") && endsWith(";")) || startsWith("[")

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -71,6 +71,8 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
 
     <!-- Miscellaneous Section -->
     <string name="piko_category_misc">Misc</string>
+    <string name="piko_material_you_title">Material You</string>
+    <string name="piko_amoled_title">AMOLED</string>
     <string name="piko_disable_analytics">Disable analytics</string>
     <string name="piko_delete_analytics_cache">Delete analytic cache</string>
     <string name="piko_disable_analytics_desc">Block analytics that are sent to Instagram/Facebook servers</string>


### PR DESCRIPTION
This adds runtime material you and amoled controls to instagram's dark mode settings on android 12 and later. material you can be enabled independently, while amoled is available as an additional dark mode option and can also be combined with material you. material you uses android dynamic colors and follows instagram's effective light, dark, or system default mode. theme state is synchronized when instagram invokes its native theme callback, when an activity is recreated, and across both the compose and legacy implementations of the dark mode settings screen. the selected theme is applied through runtime resource overlays, including instagram's compose color palette. piko settings switches also follow the active material you colors while retaining their existing animation. existing instagram switches outside the added theme controls are not replaced. on android 8 through 11, the patch continues to apply either the fixed material you-style palette or the existing amoled palette selected while patching

<img width="1080" height="2340" alt="Screenshot_20260801_075232_Piko Instagram" src="https://github.com/user-attachments/assets/e63982fe-d655-4243-8137-0802c65cb5ad" />


## Testing
- `.\gradlew.bat :patches:test :extensions:instagram:compileReleaseJavaWithJavac --rerun-tasks --console=plain`
- Tested on Instagram 439.0.0.37.89 with Piko 3.9.0-dev.2
- Tested on Samsung Galaxy S26