### PR TITLE
fix(Instagram): fix Material You toggle title and crash after accessibility settings redesign

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -17,7 +17,7 @@ import android.os.Looper;
 import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 
-import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.crimera.sharedPreference.SharedPref;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.utils.IgStr;
 import app.morphe.extension.shared.Logger;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -17,7 +17,7 @@ import android.os.Looper;
 import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 
-import app.morphe.extension.crimera.SharedPref;
+import app.morphe.extension.shared.SharedPref;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.utils.IgStr;
 import app.morphe.extension.shared.Logger;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -17,7 +17,7 @@ import android.os.Looper;
 import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 
-import app.morphe.extension.shared.SharedPref;
+import app.morphe.extension.crimera.SharedPref;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.utils.IgStr;
 import app.morphe.extension.shared.Logger;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -17,7 +17,7 @@ import android.os.Looper;
 import android.widget.CompoundButton;
 import android.widget.RadioGroup;
 
-import app.morphe.extension.crimera.sharedPreference.SharedPref;
+import app.morphe.extension.crimera.SharedPref;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.utils.IgStr;
 import app.morphe.extension.shared.Logger;
@@ -219,7 +219,24 @@ public final class MaterialYouTheme {
             Function1<Integer, Unit> callback
     ) {
         Function1<Integer, Unit> nativeCallback = unwrapNativeThemeCallback(callback);
-        return () -> {
+        // Implemented as an explicit class (not a bare lambda) so D8/R8 cannot
+        // fold this Function0 into another synthetic $$ExternalSyntheticLambda
+        // class of matching erased shape (e.g. the Logger.printException
+        // message supplier below). That collision is what produced the
+        // AbstractMethodError on Function0.invoke() when tapping the AMOLED
+        // radio item.
+        return new AmoledRadioCallback(nativeCallback);
+    }
+
+    private static final class AmoledRadioCallback implements Function0<Unit> {
+        private final Function1<Integer, Unit> nativeCallback;
+
+        private AmoledRadioCallback(Function1<Integer, Unit> nativeCallback) {
+            this.nativeCallback = nativeCallback;
+        }
+
+        @Override
+        public Unit invoke() {
             ThemeMode targetMode = MaterialYouState.modeForAmoledToggle(
                     true,
                     currentModeForRequest()
@@ -231,7 +248,7 @@ public final class MaterialYouTheme {
                     () -> nativeCallback.invoke(NATIVE_THEME_DARK)
             );
             return Unit.INSTANCE;
-        };
+        }
     }
 
     public static RadioGroup.OnCheckedChangeListener wrapLegacyNativeThemeListener(
@@ -290,6 +307,10 @@ public final class MaterialYouTheme {
 
     public static String getAmoledTitle() {
         return "AMOLED";
+    }
+
+    public static String getMaterialYouTitle() {
+        return "Material You";
     }
 
     public static String resolveLegacyRadioTitle(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeBytecode.kt
@@ -166,19 +166,10 @@ internal fun installSystemDefaultUiModeHook() {
 
 context(patchContext: BytecodePatchContext)
 
-internal fun installMaterialYouToggle(
-    titleId: Int,
-    amoledTitleId: Int,
-) {
-    if (titleId == 0 || amoledTitleId == 0) {
-        throw PatchException("Theme string resource ids must be non-zero")
-    }
-
-    installLegacyAmoledRadio(amoledTitleId)
+internal fun installMaterialYouToggle() {
+    installLegacyAmoledRadio()
     installLegacyMaterialYouToggle()
-    installComposeMaterialYouToggle(
-        titleId = titleId,
-    )
+    installComposeMaterialYouToggle()
 }
 
 internal fun MutableMethod.invokeCalls(): List<InvokeCall> =

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeComposeBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeComposeBytecode.kt
@@ -60,9 +60,7 @@ private data class ComposeRadioBinding(
 )
 
 context(patchContext: BytecodePatchContext)
-internal fun installComposeMaterialYouToggle(
-    titleId: Int,
-) {
+internal fun installComposeMaterialYouToggle() {
     val darkModeMatch = DarkModeSectionFingerprint.matchAll(1..1).single()
     val reduceMotionMatch = ReduceMotionToggleFingerprint.matchAll(1..1).single()
     val darkModeSection = darkModeMatch.method
@@ -139,7 +137,11 @@ internal fun installComposeMaterialYouToggle(
 
     copy.replaceInstruction(
         stringCalls[0].literalIndex,
-        "const v${stringCalls[0].resourceRegister}, $titleId",
+        "nop",
+    )
+    copy.replaceInstruction(
+        stringCalls[0].literalIndex + 1,
+        "invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getMaterialYouTitle()Ljava/lang/String;",
     )
     replaceStringResourceResultWithNull(
         method = copy,
@@ -485,7 +487,7 @@ internal fun replaceStringResourceResultWithNull(
 
     method.replaceInstruction(
         resultIndex,
-        "const/4 v$resultRegister, 0x0",
+        "const-string v$resultRegister, \"\"",
     )
 }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
@@ -36,6 +36,7 @@ private data class LegacyRadioItemBinding(
     val darkId: Int,
     val systemId: Int,
     val amoledId: Int,
+    val nativeTitleId: Int,
 )
 
 private data class LegacyTitleBinding(
@@ -62,7 +63,7 @@ private data class LegacyItemRecord(
 )
 
 context(patchContext: BytecodePatchContext)
-internal fun installLegacyAmoledRadio(titleId: Int) {
+internal fun installLegacyAmoledRadio() {
     val fragmentConstructor =
         LegacyDarkModeFragmentConstructorFingerprint
             .matchAll(1..1)
@@ -106,7 +107,7 @@ internal fun installLegacyAmoledRadio(titleId: Int) {
     installLegacyOnCreateAmoledItem(
         binding = onCreateBinding,
         itemBinding = itemBinding,
-        titleId = titleId,
+        titleId = itemBinding.nativeTitleId,
     )
 }
 
@@ -410,6 +411,7 @@ private fun deriveLegacyRadioItemBinding(itemType: String): LegacyRadioItemBindi
         darkId = darkId,
         systemId = systemId,
         amoledId = amoledId,
+        nativeTitleId = intValues.getValue(titleField).first(),
     )
 }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
@@ -180,6 +180,162 @@ private fun createLegacyMaterialYouHelper(
 ): MutableMethod {
     val switchConstructor = switchBinding.constructor
     val switchType = switchConstructor.definingClass
+    val implementationBuilder = MethodImplementationBuilder(7)
+    implementationBuilder.addInstruction(
+        """
+        invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isAvailable()Z
+        """.trimIndent().toInstruction(),
+    )
+    implementationBuilder.addInstruction("move-result v0".toInstruction())
+    implementationBuilder.addInstruction(
+        BuilderInstruction21t(
+            Opcode.IF_EQZ,
+            0,
+            implementationBuilder.getLabel("piko_material_you_unavailable"),
+        ),
+    )
+    """
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getLegacyToggleListener()Landroid/widget/CompoundButton${'$'}OnCheckedChangeListener;
+    move-result-object v1
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getMaterialYouTitle()Ljava/lang/String;
+    move-result-object v2
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isEnabled()Z
+    move-result v3
+    new-instance v4, $switchType
+    invoke-direct {v4, v1, v2, v3}, $switchConstructor
+    invoke-interface {v6, v4}, Ljava/util/Collection;->add(Ljava/lang/Object;)Z
+    """.trimIndent().lineSequence().forEach { instruction ->
+        implementationBuilder.addInstruction(instruction.toInstruction())
+    }
+    implementationBuilder.addLabel("piko_material_you_unavailable")
+    implementationBuilder.addInstruction("return-void".toInstruction())
+
+    val accessFlags =
+        AccessFlags.PRIVATE.value or
+            AccessFlags.STATIC.value or
+            AccessFlags.FINAL.value
+    val helper =
+        MutableMethod(
+            ImmutableMethod(
+                owner,
+                MATERIAL_YOU_LEGACY_HELPER_NAME,
+                listOf(
+                    ImmutableMethodParameter(COLLECTION_DESCRIPTOR, emptySet(), null),
+                ),
+                "V",
+                accessFlags,
+                emptySet(),
+                emptySet(),
+                implementationBuilder.methodImplementation,
+            ),
+        )
+    if (
+        helper.definingClass != owner ||
+        helper.name != MATERIAL_YOU_LEGACY_HELPER_NAME ||
+        helper.parameterTypes.map(CharSequence::toString) != listOf(COLLECTION_DESCRIPTOR) ||
+        helper.returnType != "V" ||
+        !AccessFlags.PRIVATE.isSet(helper.accessFlags) ||
+        !AccessFlags.STATIC.isSet(helper.accessFlags) ||
+        helper.implementation?.registerCount != 7 ||
+        firstParameterRegister(helper) != 6 ||
+        helper.instructions.count { it.opcode == Opcode.IF_EQZ } != 1 ||
+        helper.instructions.any { instruction ->
+            instruction.registersUsed.any { it !in 0..0xf }
+        }
+    ) {
+        throw PatchException("Invalid legacy Material You SwitchItem helper")
+    }
+
+    return helper
+}
+
+context(patchContext: BytecodePatchContext)
+private fun deriveSwitchItemBinding(): LegacySwitchItemBinding {
+    val constructor =
+        SwitchItemConstructorFingerprint
+            .matchAll(1..1)
+            .single()
+            .method
+    val switchType = constructor.definingClass
+    if (
+        constructor.name != "<init>" ||
+        constructor.returnType != "V" ||
+        constructor.parameterTypes.map(CharSequence::toString) !=
+        listOf(
+            COMPOUND_BUTTON_LISTENER_DESCRIPTOR,
+            "Ljava/lang/CharSequence;",
+            "Z",
+        ) ||
+        !switchType.isObjectDescriptor()
+    ) {
+        throw PatchException(
+            "Invalid derived SwitchItem listener/title/checked constructor: " +
+                "$switchType->${constructor.name}(${constructor.parameterTypes.joinToString()})" +
+                constructor.returnType,
+        )
+    }
+
+    val switchClass = patchContext.mutableClassDefBy(switchType)
+    if (switchClass.type != switchType) {
+        throw PatchException(
+            "Derived SwitchItem constructor owner mismatch: " +
+                "${switchClass.type} != $switchType",
+        )
+    }
+    val charSequenceFields =
+        switchClass.fields.filter { it.type == "Ljava/lang/CharSequence;" }
+    if (charSequenceFields.size != 2) {
+        throw PatchException(
+            "Expected exactly two SwitchItem CharSequence fields, " +
+                "found ${charSequenceFields.size}",
+        )
+    }
+
+    val constructorCharSequenceFields =
+        constructor.instructions.mapNotNull { instruction ->
+            if (instruction.opcode != Opcode.IPUT_OBJECT) {
+                return@mapNotNull null
+            }
+            val reference =
+                (instruction as? ReferenceInstruction)?.reference as? FieldReference
+                    ?: return@mapNotNull null
+            reference.takeIf {
+                it.definingClass == switchType &&
+                    it.type == "Ljava/lang/CharSequence;"
+            }
+        }.distinctBy { Triple(it.definingClass, it.name, it.type) }
+    if (constructorCharSequenceFields.size != 1) {
+        throw PatchException(
+            "Expected the derived SwitchItem constructor to assign one CharSequence field, " +
+                "found ${constructorCharSequenceFields.size}",
+        )
+    }
+    val titleField = constructorCharSequenceFields.single()
+    val descriptionFields =
+        charSequenceFields.filterNot {
+            it.definingClass == titleField.definingClass &&
+                it.name == titleField.name &&
+                it.type == titleField.type
+        }
+    if (descriptionFields.size != 1) {
+        throw PatchException(
+            "Expected one derived SwitchItem description CharSequence field, " +
+                "found ${descriptionFields.size}",
+        )
+    }
+
+    return LegacySwitchItemBinding(
+        constructor = constructor,
+        descriptionField = descriptionFields.single(),
+    )
+}
+
+private fun createLegacyMaterialYouHelper(
+    owner: String,
+    switchBinding: LegacySwitchItemBinding,
+): MutableMethod {
+    val switchConstructor = switchBinding.constructor
+    val switchType = switchConstructor.definingClass
     val implementationBuilder = MethodImplementationBuilder(6)
     implementationBuilder.addInstruction(
         """

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacySwitchBytecode.kt
@@ -197,8 +197,7 @@ private fun createLegacyMaterialYouHelper(
     """
     invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getLegacyToggleListener()Landroid/widget/CompoundButton${'$'}OnCheckedChangeListener;
     move-result-object v1
-    const-string v2, "piko_material_you_title"
-    invoke-static {v2}, Lapp/morphe/extension/instagram/utils/IgStr;->str(Ljava/lang/String;)Ljava/lang/String;
+    invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->getMaterialYouTitle()Ljava/lang/String;
     move-result-object v2
     invoke-static {}, Lapp/morphe/extension/instagram/theme/MaterialYouTheme;->isEnabled()Z
     move-result v0

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -60,15 +60,6 @@ val themePatch =
                 restoreApi31Base(
                     snapshot = originalApi31Base,
                 )
-                val materialYouStringIds =
-                    reservePublicStringIds(
-                        publicXml = get("res/values/public.xml"),
-                        names =
-                            listOf(
-                                "piko_material_you_title",
-                                "piko_amoled_title",
-                            ),
-                    )
                 writeMaterialYouOverlay(night = false)
                 writeMaterialYouOverlay(night = true)
                 writeAmoledOverlay(originalApi31Base)
@@ -78,10 +69,7 @@ val themePatch =
                     installComposePrismBlackRuntime(legacyAmoled = amoled == true)
                     installSystemDefaultUiModeHook()
                     installThemeLifecycleHooks()
-                    installMaterialYouToggle(
-                        titleId = materialYouStringIds.getValue("piko_material_you_title"),
-                        amoledTitleId = materialYouStringIds.getValue("piko_amoled_title"),
-                    )
+                    installMaterialYouToggle()
                 }
             } finally {
                 bytecodePatchContext = null

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -71,8 +71,6 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
 
     <!-- Miscellaneous Section -->
     <string name="piko_category_misc">Misc</string>
-    <string name="piko_material_you_title">Material You</string>
-    <string name="piko_amoled_title">AMOLED</string>
     <string name="piko_disable_analytics">Disable analytics</string>
     <string name="piko_delete_analytics_cache">Delete analytic cache</string>
     <string name="piko_disable_analytics_desc">Block analytics that are sent to Instagram/Facebook servers</string>


### PR DESCRIPTION
The `clips closed captions h1 2026 redesign accessibility global setting` moved Instagram's Accessibility
screen to a new Compose-based fragment (AccessibilityOptionsComposeFragment),
which changed nullability and resource-resolution behavior enough to expose
existing bugs in the Material You/AMOLED toggle that the old screen never hit.

- Add MaterialYouTheme.getMaterialYouTitle(), mirroring the existing
  hardcoded getAmoledTitle(), since neither string is translated
- Legacy switch (Android 8-11) now calls getMaterialYouTitle() instead of
  IgStr.str("piko_material_you_title"), which resolved to an unrelated
  native string ("No, thanks") since that resource name was never backed
  by a real value, only a reserved public id
- Compose toggle (Android 12+) now calls getMaterialYouTitle() instead of
  embedding that same unset resource id directly
- Compose toggle description is set to an empty string instead of null,
  fixing a NullPointerException on IG 439.0.0+ where the redesigned row
  builder now requires a non-null description
- Legacy AMOLED radio reuses an existing native title resource id instead
  of reserving its own, since the displayed text is always overridden by
  getLegacyRadioTitle() regardless of that id's value
- Remove the now-unused piko_material_you_title/piko_amoled_title public
  string reservation and strings.xml entries. They aren't necessary because there is no translation for those two words.
  
  `Obviously, it was much easier to disable the flag, but I realized there was a fix for it.`
  
  
<img width="300" height="650" alt="image" src="https://github.com/user-attachments/assets/9236377c-ac26-4748-a4fe-57bfb26b9427" />
