### PR TITLE
fix(Twitter): Align compatibility name with changelog scope

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
@@ -22,7 +22,7 @@ val bringBackTwitterPatch =
     resourcePatch(
         name = "Bring back twitter",
         description = "Bring back old twitter logo and name",
-        default = false,
+        default = true,
     ) {
         compatibleWith(COMPATIBILITY_X)
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/bringbacktwitter/BringBackTwitterPatch.kt
@@ -22,7 +22,7 @@ val bringBackTwitterPatch =
     resourcePatch(
         name = "Bring back twitter",
         description = "Bring back old twitter logo and name",
-        default = true,
+        default = false,
     ) {
         compatibleWith(COMPATIBILITY_X)
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/Constants.kt
@@ -7,7 +7,7 @@ import app.morphe.patcher.patch.Compatibility
 object Constants {
     val COMPATIBILITY_X =
         Compatibility(
-            name = "X",
+            name = "Twitter",
             packageName = "com.twitter.android",
             apkFileType = ApkFileType.APKM,
             appIconColor = 0x000000,


### PR DESCRIPTION
Morphe manager compares changelog scopes with a patch's compatibility name when deciding whether an update is available. piko's X compatibility name was X, while its existing changelog entries use Twitter. because the names did not match, manager could fail to show piko updates on the home screen. rename the compatibility entry to Twitter and enable bring back twitter patch by default. this aligns the compatibility name, initial app label, and changelog scope, morphe manager can find matching updates