### PR TITLE
feat(Instagram): add master switch to enable/disable recommended flags

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/HookFlags.java
@@ -5,7 +5,7 @@
  */
 
 
-package app.morphe.extension.instagram.patches;
+package app.morphe.extension.instagram.patches.devFlags;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -49,8 +49,8 @@ public class HookFlags {
     private static void suggestedContentFlags() {
         BOOL_FLAGS.put("111509::3", false); //ig_search_ta_nullstate_suggestions::is_android_enabled
         BOOL_FLAGS.put("82771::0", false); //igx_foundation_litho_stories_tray::is_litho_stories_tray_enabled
-        BOOL_FLAGS.put("109730", false); //ig_android_ai_discovery_menu
-        BOOL_FLAGS.put("80654", false); //ig_meta_ai_cdd_reels_viewer
+//        BOOL_FLAGS.put("109730", false); //ig_android_ai_discovery_menu
+//        BOOL_FLAGS.put("80654", false); //ig_meta_ai_cdd_reels_viewer
     }
 
     private static void profileActionBarFlags() {
@@ -77,7 +77,14 @@ public class HookFlags {
         }
     }
 
+    private static void addRecommendedFlags(){
+        if (!Pref.enableRecommendedFlags()) return;
+        Map<String, Boolean> recFlags = FlagsSharedPref.getAll();
+        BOOL_FLAGS.putAll(recFlags);
+    }
+
     public static void load() {
+        addRecommendedFlags();
     }
 
     public static Boolean handleBoolFlags(long mobileConfigSpecifier) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -16,6 +16,8 @@ public class Settings {
             new StringSetting("instagram_theme_mode", "-1");
     // It should be true always. It will be handled upon opening the piko settings for the first time.
     public static final BooleanSetting FIRST_TIME_PIKO = new BooleanSetting("first_time_piko", true);
+    public static final StringSetting LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP = new StringSetting("last_recommended_flag_download_timestamp", "0");
+    public static final BooleanSetting ENABLE_RECOMMENDED_FLAGS = new BooleanSetting("enable_recommended_flags", false);
 
     public static final BooleanSetting DISABLE_ADS = new BooleanSetting("disable_ads", true);
     public static final BooleanSetting OPEN_LINKS_EXTERNALLY = new BooleanSetting("open_links_externally", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -15,6 +15,14 @@ import android.preference.Preference;
 import android.preference.PreferenceCategory;
 import java.util.TreeMap;
 import java.util.Map;
+import java.util.List;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+import  app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
+import  app.morphe.extension.instagram.patches.devFlags.Flag;
 
 import app.morphe.extension.crimera.downloader.StorageUtils;
 import app.morphe.extension.instagram.settings.SettingsStatus;
@@ -84,6 +92,15 @@ public class ScreenBuilder {
         if (!(SettingsStatus.developerOptionsSection())) return;
 
         // PreferenceCategory category= addCategory(str("piko_category_dev_options"));
+
+        addPreference(
+                helper.buttonPreference(
+                        str("piko_category_rec_flags"),
+                        str("piko_category_rec_flags_desc"),
+                        Constants.PIKO_FRAGMENT_REC_FLAGS
+                )
+        );
+
 
         if (SettingsStatus.removeBuildExpirePopup) {
             addPreference(
@@ -795,6 +812,44 @@ public class ScreenBuilder {
         );
     }
 
+    public void buildRecommendedFlagsSection() {
+
+        addPreference(
+                helper.switchPreference(
+                        str("piko_enable_rec_flags"),
+                        str("piko_enable_rec_flags_desc"),
+                        Settings.ENABLE_RECOMMENDED_FLAGS
+                )
+        );
+
+        long lastModified = Pref.getLastRecommendedFlagDownloadTimestamp();
+        LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastModified), ZoneId.systemDefault());
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd, yyyy hh:mm:ss a");
+        String formattedDate = dateTime.format(formatter);
+        String lastModifiedAtString = String.format(str("piko_rec_flags_last_modified_at"), formattedDate);
+        addPreference(
+            helper.buttonPreference(
+                    str("piko_rec_flags_refresh_file"),
+                    lastModifiedAtString,
+                    "piko_rec_flags_refresh_file"
+            )
+        );
+        List<Flag> recFlags = RecommendedFlags.getFlags();
+        // The flag names will be English only,
+        // as I want to keep it as a live service
+        // rather than triggering new build
+        // for every a new flag.
+        for(Flag flag : recFlags) {
+            addPreference(
+                    helper.switchPreference(
+                            flag.getName(),
+                            flag.getDesc(),
+                            flag.getCode()
+                    )
+            );
+        }
+    }
+
     public void aboutSection(TreeMap<String, Boolean> flags) {
 
         String appVersionText = String.format(str("piko_app_version"), Utils.getAppVersionName());
@@ -976,7 +1031,6 @@ public class ScreenBuilder {
                     )
             );
         }
-
 
         addPreference(
                 helper.buttonPreference(

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -322,5 +322,18 @@ public class Pref {
         return Integer.valueOf(SharedPref.getStringPref(Settings.FILTER_STORY_MAX_STORY_ITEMS));
     }
 
+    public static boolean enableRecommendedFlags() {
+        return SharedPref.getBooleanPref(Settings.ENABLE_RECOMMENDED_FLAGS);
+    }
+
+    public static Long getLastRecommendedFlagDownloadTimestamp() {
+        return Long.valueOf(SharedPref.getStringPref(Settings.LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP));
+    }
+
+    public static void setLastRecommendedFlagDownloadTimestamp(Long timestamp) {
+        String ts = String.valueOf(timestamp);
+        SharedPref.setStringPref(Settings.LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP.key,ts);
+    }
+
     //end
 }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -108,6 +108,11 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
     <string name="piko_copy_full_name">Copy full name</string>
     <string name="piko_copy_user_id">Copy user id</string>
     <string name="piko_copy_bio">Copy bio</string>
+    <string name="piko_view_profile_picture">View profile picture</string>
+    <string name="piko_copy_profile_link">Copy profile link</string>
+    <string name="piko_share_this_profile">Share this profile</string>
+    <string name="piko_copy_links_from_bio">Copy links from bio</string>
+    <string name="piko_no_links_in_bio">No links in this bio</string>
     <string name="piko_download_profile_picture">Download profile picture</string>
     <string name="piko_copied">Copied</string>
     <string name="piko_more_profile_options">More profile options</string>
@@ -241,6 +246,17 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
 
     <string name="piko_settings_on_action_bar">Piko settings on action bar</string>
     <string name="piko_settings_on_action_bar_desc">Move Piko settings entry point to main feed action bar</string>
+
+    <!-- Developer Options Section -->
+    <string name="piko_enable_rec_flags">Enable recommended flags</string>
+    <string name="piko_enable_rec_flags_desc">Applies the community-recommended flags. Turn off to ignore them entirely, even if individually enabled in a restored backup</string>
+    <string name="piko_category_rec_flags">Recommended flags</string>
+    <string name="piko_category_rec_flags_desc">Developer flags suggested by the community</string>
+    <string name="piko_rec_flags_read_error">Failed to read cached flags file</string>
+    <string name="piko_rec_flags_no_file">Recommended flags file not found</string>
+    <string name="piko_rec_flags_refresh_file">Refresh flags</string>
+    <string name="piko_rec_flags_last_modified_at">Last modified: %s</string>
+
 
     <!-- Story filters -->
     <string name="piko_category_filter_content">Filter content</string>


### PR DESCRIPTION
## Problem
Restoring an old preferences backup could leave community-recommended
flags in a state that no longer matched the current recommended list,
with no easy way to fix it without toggling each flag individually.

## Solution
Added a master switch at the top of the Recommended Flags screen.
Off by default: no recommended flags are applied, regardless of their
individual saved state. On: recommended flags are applied as usual,
respecting each individual toggle.

The switch is stored in the main settings file, separate from the
recommended flags file, so it's unaffected by community flags backups.

## Changes
- `Settings.java`: new `ENABLE_RECOMMENDED_FLAGS` setting (default `false`)
- `Pref.java`: new `enableRecommendedFlags()` getter
- `HookFlags.java`: `addRecommendedFlags()` early-returns when disabled
- `ScreenBuilder.java`: new switch preference in `buildRecommendedFlagsSection()`
- `strings.xml`: new strings for the switch title/description

<img width="300" alt="image" src="https://github.com/user-attachments/assets/878a73a4-10d8-4e3f-bc40-63e14e671516" />