### PR TITLE
feat(Instagram): add master switch to enable/disable recommended flags

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/HookFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/HookFlags.java
@@ -78,6 +78,7 @@ public class HookFlags {
     }
 
     private static void addRecommendedFlags(){
+        if (!Pref.enableRecommendedFlags()) return;
         Map<String, Boolean> recFlags = FlagsSharedPref.getAll();
         BOOL_FLAGS.putAll(recFlags);
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -17,6 +17,7 @@ public class Settings {
     // It should be true always. It will be handled upon opening the piko settings for the first time.
     public static final BooleanSetting FIRST_TIME_PIKO = new BooleanSetting("first_time_piko", true);
     public static final StringSetting LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP = new StringSetting("last_recommended_flag_download_timestamp", "0");
+    public static final BooleanSetting ENABLE_RECOMMENDED_FLAGS = new BooleanSetting("enable_recommended_flags", false);
 
     public static final BooleanSetting DISABLE_ADS = new BooleanSetting("disable_ads", true);
     public static final BooleanSetting OPEN_LINKS_EXTERNALLY = new BooleanSetting("open_links_externally", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -814,6 +814,14 @@ public class ScreenBuilder {
 
     public void buildRecommendedFlagsSection() {
 
+        addPreference(
+                helper.switchPreference(
+                        str("piko_enable_rec_flags"),
+                        str("piko_enable_rec_flags_desc"),
+                        Settings.ENABLE_RECOMMENDED_FLAGS
+                )
+        );
+
         long lastModified = Pref.getLastRecommendedFlagDownloadTimestamp();
         LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastModified), ZoneId.systemDefault());
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd, yyyy hh:mm:ss a");

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -322,6 +322,10 @@ public class Pref {
         return Integer.valueOf(SharedPref.getStringPref(Settings.FILTER_STORY_MAX_STORY_ITEMS));
     }
 
+    public static boolean enableRecommendedFlags() {
+        return SharedPref.getBooleanPref(Settings.ENABLE_RECOMMENDED_FLAGS);
+    }
+
     public static Long getLastRecommendedFlagDownloadTimestamp() {
         return Long.valueOf(SharedPref.getStringPref(Settings.LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP));
     }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -248,6 +248,8 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
     <string name="piko_settings_on_action_bar_desc">Move Piko settings entry point to main feed action bar</string>
 
     <!-- Developer Options Section -->
+    <string name="piko_enable_rec_flags">Enable recommended flags</string>
+    <string name="piko_enable_rec_flags_desc">Applies the community-recommended flags. Turn off to ignore them entirely, even if individually enabled in a restored backup</string>
     <string name="piko_category_rec_flags">Recommended flags</string>
     <string name="piko_category_rec_flags_desc">Developer flags suggested by the community</string>
     <string name="piko_rec_flags_read_error">Failed to read cached flags file</string>


### PR DESCRIPTION
## Problem
Restoring an old preferences backup could leave community-recommended
flags in a state that no longer matched the current recommended list,
with no easy way to fix it without toggling each flag individually.

## Solution
Added a master switch at the top of the Recommended Flags screen.
Off by default: no recommended flags are applied, regardless of their
individual saved state. On: recommended flags are applied as usual,
respecting each individual toggle.

The switch is stored in the main settings file, separate from the
recommended flags file, so it's unaffected by community flags backups.

## Changes
- `Settings.java`: new `ENABLE_RECOMMENDED_FLAGS` setting (default `false`)
- `Pref.java`: new `enableRecommendedFlags()` getter
- `HookFlags.java`: `addRecommendedFlags()` early-returns when disabled
- `ScreenBuilder.java`: new switch preference in `buildRecommendedFlagsSection()`
- `strings.xml`: new strings for the switch title/description

<img width="300" alt="image" src="https://github.com/user-attachments/assets/878a73a4-10d8-4e3f-bc40-63e14e671516" />