### PR TITLE
Some fixes for settings

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/Helper.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/Helper.java
@@ -38,7 +38,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(setting.key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -50,7 +49,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -59,7 +57,6 @@ public class Helper {
         preference.setTitle(title);
         preference.setSummary(summary);
         preference.setKey(setting);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -70,14 +67,12 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(setting.key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
     public Preference editTextNumPreference(String title, String summary, StringSetting setting) {
         EditTextPref preference = (EditTextPref)editTextPreference(title,summary,setting);
         preference.setNumericOnly(true);
-        preference.setSingleLineTitle(false);
         return preference;
     }
     public Preference multiSelectListPref(String title, String summary, StringSetting setting) {
@@ -88,7 +83,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(key);
         preference.setInitialValue(key);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/FeatureSwitchPatch.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/FeatureSwitchPatch.java
@@ -67,29 +67,32 @@ public class FeatureSwitchPatch {
     }
 
     private static void removePremiumUpsell() {
-        boolean flag = Pref.removePremiumUpsell();
-        addFlag("subscriptions_enabled", flag);
-        addFlag("subscriptions_upsells_get_verified_profile", flag);
-        addFlag("subscriptions_upsells_get_verified_drawer_discount_enabled", flag);
-        addFlag("subscriptions_upsells_get_verified_profile_fatigue_enabled", flag);
-        addFlag("subscriptions_upsells_api_enabled", flag);
-        addFlag("subscriptions_upsells_user_profile_name_migration_enabled", flag);
-        addFlag("subscriptions_upsells_profile_card_enable", flag);
-        addFlag("subscriptions_upsells_get_verified_drawer_card_enabled", flag);
-        addFlag("subscriptions_upsells_get_verified_profile_discount_visitor_enabled", flag);
-        addFlag("subscriptions_upsells_analytics_profile_enabled", flag);
-        addFlag("subscriptions_upsells_articles_post_composer_promo_variant_enabled", flag);
-        addFlag("subscriptions_upsells_bookmark_folders_enabled", flag);
-        addFlag("subscriptions_upsells_verified_profile_visitor_upsell_enabled", flag);
-        addFlag("subscriptions_upsells_verified_profile_visitor_upsell_redesign_enabled", flag);
-        addFlag("subscriptions_upsells_get_verified_profile_card", flag);
-        addFlag("subscriptions_upsells_get_verified_profile_discount_own_enabled", flag);
-        addFlag("subscriptions_upsells_get_verified_profile_rotation_enabled", flag);
-        addFlag("subscriptions_upsells_home_nav_migration_enabled", flag);
-        addFlag("subscriptions_upsells_profile_card_enabled", flag);
-        addFlag("subscriptions_upsells_quick_display_settings", flag);
-        addFlag("subscriptions_upsells_track_interactions_enabled", flag);
-        addFlag("subscriptions_upsells_user_profile_header_migration_enabled", flag);
+        boolean isDisabled = Pref.removePremiumUpsell(); // The return value is inverted
+        if (isDisabled) {
+            return;
+        }
+        addFlag("subscriptions_enabled", false);
+        addFlag("subscriptions_upsells_get_verified_profile", false);
+        addFlag("subscriptions_upsells_get_verified_drawer_discount_enabled", false);
+        addFlag("subscriptions_upsells_get_verified_profile_fatigue_enabled", false);
+        addFlag("subscriptions_upsells_api_enabled", false);
+        addFlag("subscriptions_upsells_user_profile_name_migration_enabled", false);
+        addFlag("subscriptions_upsells_profile_card_enable", false);
+        addFlag("subscriptions_upsells_get_verified_drawer_card_enabled", false);
+        addFlag("subscriptions_upsells_get_verified_profile_discount_visitor_enabled", false);
+        addFlag("subscriptions_upsells_analytics_profile_enabled", false);
+        addFlag("subscriptions_upsells_articles_post_composer_promo_variant_enabled", false);
+        addFlag("subscriptions_upsells_bookmark_folders_enabled", false);
+        addFlag("subscriptions_upsells_verified_profile_visitor_upsell_enabled", false);
+        addFlag("subscriptions_upsells_verified_profile_visitor_upsell_redesign_enabled", false);
+        addFlag("subscriptions_upsells_get_verified_profile_card", false);
+        addFlag("subscriptions_upsells_get_verified_profile_discount_own_enabled", false);
+        addFlag("subscriptions_upsells_get_verified_profile_rotation_enabled", false);
+        addFlag("subscriptions_upsells_home_nav_migration_enabled", false);
+        addFlag("subscriptions_upsells_profile_card_enabled", false);
+        addFlag("subscriptions_upsells_quick_display_settings", false);
+        addFlag("subscriptions_upsells_track_interactions_enabled", false);
+        addFlag("subscriptions_upsells_user_profile_header_migration_enabled", false);
 
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ButtonPref.java
@@ -73,6 +73,7 @@ public class ButtonPref extends Preference {
 
 
     private void init() {
+        setSingleLineTitle(false);
         if (iconName != null) {
             int resId = ResourceUtils.getIdentifier(ResourceType.DRAWABLE, iconName);
             Drawable icon = context.getResources().getDrawable(resId);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/EditTextPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/EditTextPref.java
@@ -43,6 +43,7 @@ public class EditTextPref extends EditTextPreference {
     }
 
     private void init() {
+        setSingleLineTitle(false);
         setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/Helper.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/Helper.java
@@ -36,14 +36,12 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(setting.key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
     public Preference editTextNumPreference(String title, String summary, StringSetting setting) {
         EditTextPref preference = (EditTextPref)editTextPreference(title,summary,setting);
         preference.setNumericOnly(true);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -53,7 +51,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(setting.key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -62,7 +59,6 @@ public class Helper {
         preference.setTitle(title);
         preference.setSummary(summary);
         preference.setKey(setting);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -78,7 +74,6 @@ public class Helper {
         }
         preference.setSummary(summary);
         preference.setKey(setting);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -90,7 +85,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(key);
         preference.setDefaultValue(setting.defaultValue);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 
@@ -102,7 +96,6 @@ public class Helper {
         preference.setSummary(summary);
         preference.setKey(key);
         preference.setInitialValue(key);
-        preference.setSingleLineTitle(false);
         return preference;
     }
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ListPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/ListPref.java
@@ -40,6 +40,7 @@ public class ListPref extends ListPreference {
     }
 
     private void init() {
+        setSingleLineTitle(false);
         setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/MultiSelectListPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/MultiSelectListPref.java
@@ -38,6 +38,7 @@ public class MultiSelectListPref extends MultiSelectListPreference {
     }
 
     private void init() {
+        setSingleLineTitle(false);
         setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/SwitchPref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/widgets/SwitchPref.java
@@ -35,7 +35,7 @@ public class SwitchPref extends SwitchPreference {
     }
 
     private void init() {
-        // Set the OnPreferenceChangeListener
+        setSingleLineTitle(false);
         setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -177,10 +177,10 @@
     <string name="piko_pref_show_poll_result">Show poll results</string>
     <string name="piko_pref_show_poll_result_desc">View poll results without voting</string>
     <string name="piko_pref_hide_community_notes">Hide community notes</string>
-    <string name="piko_pref_hide_immersive_player">Hide immersive player</string>
-    <string name="piko_pref_hide_immersive_player_desc">Removes swipe up for more videos in video player</string>
+    <string name="piko_pref_hide_immersive_player">Disable immersive player</string>
+    <string name="piko_pref_hide_immersive_player_desc">Disable the new video player that allows you to watch more videos by swiping up</string>
     <string name="piko_pref_enable_vid_auto_advance">Enable video auto scroll</string>
-    <string name="piko_pref_enable_vid_auto_advance_desc">Enables video auto scroll in immersive view</string>
+    <string name="piko_pref_enable_vid_auto_advance_desc">Enables video auto scroll in immersive player</string>
     <string name="piko_pref_hide_hidden_replies">Hide hidden replies</string>
     <string name="piko_pref_force_hd">Force HD videos</string>
     <string name="piko_pref_force_hd_desc">Videos will be played in the highest quality always</string>


### PR DESCRIPTION
### • chore(Twitter): Fix "Disable immersive player" wording

`Hide immersive player` should be called `Disable immersive player`.
When the dynamic string composition was removed, "Remove immersive player" was mistakenly changed to "Hide immersive player."
This commit fixes it.
But "Disable" is the more appropriate word for this feature than "Remove".

The string key is still `piko_pref_hide_immersive_player`, but I leave it to keep translations and because "hide" is used in many places

### • chore(Twitter / Instagram - Settings): Clean up setSingleLineTitle

For X, moved setSingleLineTitle code to the custom preference classes itself.
Therefore, even if you add a new method like editTextNumPreference in the future, you won't need to call setSingleLineTitle every time.
For Instagram, they are no longer needed because titles are set to multi lines when crating the custom views in InstagramPreferenceStyle.java.

### •  refactor(Twitter - Remove premium upsell): If the setting is off, don't apply flags

Turning off "Remove premium upsell" setting should restore the unpatched behavior