### PR TITLE
perf(Instagram - Disable analytics): Turn off by default, state the side effect to description

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -31,7 +31,7 @@ public class Settings {
     public static final BooleanSetting DISABLE_DISCOVER_PEOPLE = new BooleanSetting("disable_discover_people", true);
     public static final BooleanSetting LIMIT_FOLLOWING_FEED = new BooleanSetting("limit_following_feed", false);
     public static final BooleanSetting REMOVE_BUILD_EXPIRE_POPUP = new BooleanSetting("remove_build_expire_popup", true);
-    public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", true);
+    public static final BooleanSetting DISABLE_ANALYTICS = new BooleanSetting("disable_analytics", false);
     public static final BooleanSetting TURN_ON_ALL_GHOST_MODES = new BooleanSetting("turn_on_all_ghost_modes", false);
     public static final BooleanSetting VIEW_STORIES_ANONYMOUSLY = new BooleanSetting("view_stories_anonymously", false);
     public static final BooleanSetting VIEW_LIVE_ANONYMOUSLY = new BooleanSetting("view_live_anonymously", true);

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -75,7 +75,8 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
     <string name="piko_amoled_title">AMOLED</string>
     <string name="piko_disable_analytics">Disable analytics</string>
     <string name="piko_delete_analytics_cache">Delete analytic cache</string>
-    <string name="piko_disable_analytics_desc">Block analytics that are sent to Instagram/Facebook servers</string>
+    <string name="piko_disable_analytics_desc">"Block analytics that are sent to Instagram/Facebook servers.
+Side effect: A popup requesting permission for location and contacts keeps reappearing even after you have allowed or skipped it. To prevent this, enable this feature only after you have allowed or skipped it.</string>
     <string name="piko_disable_discover_people">Disable discover people</string>
     <string name="piko_disable_discover_people_desc">Disables discover people section on user profile</string>
     <string name="piko_follow_back_indicator">Enable friendship status indicator</string>


### PR DESCRIPTION
Change the default value for the "Disable analytics" setting to off.

This feature is not a fundamental one that everyone wants like hiding ads, so it does not need to be enabled by default.
And this feature has a known issue that are difficult to fix. (An onboarding popup requesting permission for location and contacts keeps reappearing even after users have allowed or skipped it)
So, it would be best to make it optional, opt-in.

Moreover, this approach actually mitigates that issue.
It is caused by information that the popup has already been viewed is not sent to server, so it does not occur if the user views the dialog, chooses to skip or allow it, and then turns on "Disable analytics."
By turning this off by default, users will only enable it after seeing the onboarding screen once.
Therefore, this change is also useful for people who actually want to block analytics.