### PR TITLE
fix(Instagram): handle missing context for comment media downloads

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/comment/HandleCommentButton.java
@@ -80,7 +80,7 @@ public class HandleCommentButton {
             } else if (button.equals(SaveMediaButton.A00)) {
                     CommentData commentData = new CommentData(commentObject);
 
-                    Context context = (Context) Utils.getActivity();
+                    Context context = Utils.getContext();
                     if (commentData.hasGifMedia()) {
                         String gifUrl = commentData.getGifUrl();
                         String fileName = commentData.getGifDownloadName();

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MediaDownloader.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MediaDownloader.java
@@ -31,6 +31,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 
 import app.morphe.extension.crimera.constants.ExtensionStrings;
 import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.shared.Utils;
 
 public class MediaDownloader {
     private static final String CHANNEL_ID = "media_download_channel";
@@ -42,8 +43,17 @@ public class MediaDownloader {
     private boolean isDownloading = false;
 
     public MediaDownloader(Context context) {
-        this.context = context;
-        this.notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        Context resolvedContext = context != null ? context : Utils.getContext();
+        if (resolvedContext == null) {
+            throw new IllegalStateException("Download context is unavailable");
+        }
+
+        Context applicationContext = resolvedContext.getApplicationContext();
+        this.context = applicationContext != null ? applicationContext : resolvedContext;
+        this.notificationManager = this.context.getSystemService(NotificationManager.class);
+        if (notificationManager == null) {
+            throw new IllegalStateException("Notification service is unavailable");
+        }
         createNotificationChannel();
     }
 


### PR DESCRIPTION
## Problem

Saving an image or GIF attached to a comment could intermittently fail with this error:

```text
Attempt to invoke virtual method 'java.lang.Object android.content.Context.getSystemService(java.lang.String)' on a null object reference
```

This happened when opening the comment actions and selecting the option to save the attached media.

## Root cause

The comment-media handler used `Utils.getActivity()` as the download context. That activity reference can be temporarily unavailable while the comment action UI is changing state. The null context was passed through `DownloadUtils.downloadMediaUrl()` to `MediaDownloader`, which immediately dereferenced it while obtaining `NotificationManager`.

## Changes

- use the application context for comment image and GIF downloads
- fall back to the current application context at the downloader boundary
- retain an application context instead of an activity in `MediaDownloader`
- validate the download context and notification service before use

## Impact

Comment images and GIFs can be saved without depending on the transient activity reference. Other downloader callers also fail with a clear error instead of a null dereference if no context or notification service is available.

## Validation

- manually tested the comment-media download flow on-device with the context fallback applied
- `./gradlew clean buildAndroid --no-daemon`
- `git diff --check upstream/dev...HEAD`