### PR TITLE
fix(Instagram): Prevent notification registration crash

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/notification/FixNotificationRegistrationCrashPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/notification/FixNotificationRegistrationCrashPatch.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.notification
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.util.getFreeRegisterProvider
+import app.morphe.util.getReference
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+
+private const val PENDING_INTENT_CLASS = "Landroid/app/PendingIntent;"
+private const val FLAG_IMMUTABLE = 0x04000000
+private val GET_BROADCAST_PARAMETERS =
+    listOf(
+        "Landroid/content/Context;",
+        "I",
+        "Landroid/content/Intent;",
+        "I",
+    )
+
+private object NotificationTokenRegistrationFingerprint : Fingerprint(
+    returnType = "Landroid/os/Bundle;",
+    strings =
+        listOf(
+            "com.google.iid.TOKEN_REQUEST",
+            "com.google.example.invalidpackage",
+        ),
+    filters =
+        listOf(
+            methodCall(
+                opcode = Opcode.INVOKE_STATIC,
+                definingClass = PENDING_INTENT_CLASS,
+                name = "getBroadcast",
+                parameters = GET_BROADCAST_PARAMETERS,
+                returnType = PENDING_INTENT_CLASS,
+            ),
+        ),
+)
+
+@Suppress("unused")
+val fixNotificationRegistrationCrashPatch =
+    bytecodePatch(
+        name = "Fix notification crash",
+        description =
+            "Prevents Instagram from crashing on launch while setting up push notifications on Android 12 and later.",
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            NotificationTokenRegistrationFingerprint
+                .matchAll(1..1)
+                .single()
+                .method
+                .apply {
+                    val calls =
+                        instructions.mapIndexedNotNull { index, instruction ->
+                            if (instruction.opcode != Opcode.INVOKE_STATIC) return@mapIndexedNotNull null
+                            val reference =
+                                instruction.getReference<MethodReference>() ?: return@mapIndexedNotNull null
+                            if (
+                                reference.definingClass == PENDING_INTENT_CLASS &&
+                                reference.name == "getBroadcast" &&
+                                reference.parameterTypes == GET_BROADCAST_PARAMETERS &&
+                                reference.returnType == PENDING_INTENT_CLASS
+                            ) {
+                                IndexedValue(index, reference)
+                            } else {
+                                null
+                            }
+                        }
+                    if (calls.size != 1) {
+                        throw PatchException(
+                            "Expected one PendingIntent.getBroadcast call, found ${calls.size}",
+                        )
+                    }
+
+                    val (callIndex, reference) = calls.single()
+                    val registers = getInstruction(callIndex).registersUsed
+                    if (registers.size != GET_BROADCAST_PARAMETERS.size) {
+                        throw PatchException(
+                            "PendingIntent.getBroadcast register count does not match its parameters",
+                        )
+                    }
+                    if (registers[1] != registers[3]) {
+                        throw PatchException(
+                            "Expected notification registration request code and flags to share a register",
+                        )
+                    }
+
+                    val zeroInstruction = getInstruction(callIndex - 1)
+                    if (
+                        zeroInstruction.opcode != Opcode.CONST_4 ||
+                        (zeroInstruction as? OneRegisterInstruction)?.registerA != registers[3] ||
+                        (zeroInstruction as? NarrowLiteralInstruction)?.narrowLiteral != 0
+                    ) {
+                        throw PatchException(
+                            "Expected PendingIntent flags to be initialized to zero immediately before the call",
+                        )
+                    }
+
+                    val flagsRegister =
+                        getFreeRegisterProvider(
+                            index = callIndex,
+                            numberOfFreeRegistersNeeded = 1,
+                            *registers.toIntArray(),
+                        ).getFreeRegister()
+                    if (flagsRegister > 0xF) {
+                        throw PatchException("PendingIntent flags require a 4-bit register")
+                    }
+
+                    replaceInstruction(
+                        callIndex,
+                        "invoke-static {v${registers[0]}, v${registers[1]}, " +
+                            "v${registers[2]}, v$flagsRegister}, $reference",
+                    )
+                    addInstruction(callIndex, "const v$flagsRegister, $FLAG_IMMUTABLE")
+                }
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/notification/FixNotificationRegistrationCrashPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/notification/FixNotificationRegistrationCrashPatch.kt
@@ -55,7 +55,6 @@ private object NotificationTokenRegistrationFingerprint : Fingerprint(
 @Suppress("unused")
 val fixNotificationRegistrationCrashPatch =
     bytecodePatch(
-        name = "Fix notification crash",
         description =
             "Prevents Instagram from crashing on launch while setting up push notifications on Android 12 and later.",
     ) {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsPatch.kt
@@ -13,6 +13,7 @@ import app.crimera.patches.instagram.misc.actionBar.mainFeedActionBarButton.main
 import app.crimera.patches.instagram.misc.extension.hooks.instagramInitHook
 import app.crimera.patches.instagram.misc.extension.sharedExtensionPatch
 import app.crimera.patches.instagram.misc.hookFlags.hookFlagsPatch
+import app.crimera.patches.instagram.misc.notification.fixNotificationRegistrationCrashPatch
 import app.crimera.patches.instagram.misc.userProfile.userProfileButtonPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.CONSTANTS_DESCRIPTOR
@@ -45,6 +46,7 @@ val settingsPatch =
             mainFeedActionBarButtonPatch,
             userProfileButtonPatch,
             hookFlagsPatch,
+            fixNotificationRegistrationCrashPatch,
             profileInfoEntity,
             instagramButtonEntity,
             developerOptionsEntity,


### PR DESCRIPTION
Fixes a startup crash on Android 12 and later when instagram registers or refreshes its push notification token. instagram passes 0 to the flags argument of PendingIntent.getBroadcast(), but Android requires either FLAG_IMMUTABLE or FLAG_MUTABLE. adds the Fix notification crash compatibility patch, preserving the original request code and Intent while passing FLAG_IMMUTABLE through a separate register. the target method, API signature, register layout, and original zero value are validated before modifying the bytecode

## Testing
- `.\gradlew.bat :patches:check --rerun-tasks --console=plain`
- `.\gradlew.bat :patches:clean :patches:buildAndroid --console=plain`
- Tested on Instagram 439.0.0.37.89 with Piko 3.9.0-dev.7
- Confirmed the startup crash is fixed on an affected Samsung device running Android 16

Closes #1425 