### PR TITLE
improve(Instagram): Improve piko settings

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -53,6 +53,10 @@ public class UI {
     public static final String DRAWABLE_EYE_ICON = "design_ic_visibility";
     public static final String DRAWABLE_SHARE_TO_DIRECT = "gallery_share_to_direct_button";
     public static final String DRAWABLE_SHARE_TO_REEL = "gallery_share_to_reels_button";
+    public static final String DRAWABLE_CHEVRON_RIGHT =
+            "instagram_chevron_right_outline_16";
+    public static final String DRAWABLE_CHEVRON_RIGHT_RTL =
+            "instagram_chevron_right_outline_rtl_16";
 
     public static int getThemedColour(String attrName) {
         Context context = Utils.getContext();
@@ -67,10 +71,21 @@ public class UI {
     }
 
     public static void setThemedIcon(ImageView imageView, String drawableAttr) {
+        setThemedIcon(imageView, drawableAttr, "igds_color_primary_icon");
+    }
+
+    public static void setThemedIcon(
+            ImageView imageView,
+            String drawableAttr,
+            String colorAttr
+    ) {
         try {
             Drawable drawable = ResourceUtils.getDrawable(drawableAttr);
             imageView.setImageDrawable(drawable);
-            imageView.setColorFilter(new PorterDuffColorFilter(getThemedColour("igds_color_primary_icon"), PorterDuff.Mode.SRC_ATOP));
+            imageView.setColorFilter(new PorterDuffColorFilter(
+                    getThemedColour(colorAttr),
+                    PorterDuff.Mode.SRC_ATOP
+            ));
 
         } catch (Exception ex) {
             Logger.printException(() -> "Failed setThemedIcon: ", ex);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -53,6 +53,8 @@ public class UI {
     public static final String DRAWABLE_EYE_ICON = "design_ic_visibility";
     public static final String DRAWABLE_SHARE_TO_DIRECT = "gallery_share_to_direct_button";
     public static final String DRAWABLE_SHARE_TO_REEL = "gallery_share_to_reels_button";
+    public static final String DRAWABLE_ARROW_BACK =
+            "instagram_arrow_left_pano_outline_24";
     public static final String DRAWABLE_CHEVRON_RIGHT =
             "instagram_chevron_right_outline_16";
     public static final String DRAWABLE_CHEVRON_RIGHT_RTL =

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -101,6 +101,7 @@ public class SettingsActivity extends Activity {
         ImageView back = new ImageView(this);
         UI.setThemedIcon(back, UI.DRAWABLE_ARROW_BACK);
         back.setScaleType(ImageView.ScaleType.CENTER);
+        back.setPaddingRelative(0, 0, InstagramPreferenceStyle.dp(this, 16), 0);
         LinearLayout.LayoutParams backParams = new LinearLayout.LayoutParams(iconSize, iconSize);
         backParams.gravity = android.view.Gravity.CENTER_VERTICAL;
         back.setLayoutParams(backParams);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsActivity.java
@@ -11,9 +11,7 @@ import static app.morphe.extension.instagram.utils.IgStr.str;
 import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.Canvas;
 import android.graphics.Color;
-import android.graphics.Paint;
 import android.graphics.Typeface;
 import android.graphics.drawable.ColorDrawable;
 import android.os.Bundle;
@@ -24,6 +22,7 @@ import android.preference.PreferenceScreen;
 import android.util.TypedValue;
 import android.view.View;
 import android.view.WindowInsets;
+import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -99,7 +98,9 @@ public class SettingsActivity extends Activity {
 
         int iconSize = InstagramPreferenceStyle.dp(this, 44);
 
-        BackArrowView back = new BackArrowView(this);
+        ImageView back = new ImageView(this);
+        UI.setThemedIcon(back, UI.DRAWABLE_ARROW_BACK);
+        back.setScaleType(ImageView.ScaleType.CENTER);
         LinearLayout.LayoutParams backParams = new LinearLayout.LayoutParams(iconSize, iconSize);
         backParams.gravity = android.view.Gravity.CENTER_VERTICAL;
         back.setLayoutParams(backParams);
@@ -178,36 +179,6 @@ public class SettingsActivity extends Activity {
 
     public LinearLayout getCustomContainer() {
         return customContainer;
-    }
-
-    // (Keep original BackArrowView & applySystemBarStyle methods unchanged)
-    private static class BackArrowView extends View {
-        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
-
-        BackArrowView(Context context) {
-            super(context);
-        }
-
-        @Override
-        protected void onDraw(Canvas canvas) {
-            super.onDraw(canvas);
-
-            float centerY = getHeight() / 2f;
-            float tipX = InstagramPreferenceStyle.dp(getContext(), 2);
-            float endX = InstagramPreferenceStyle.dp(getContext(), 21);
-            float headEndX = InstagramPreferenceStyle.dp(getContext(), 10);
-            float headOffset = InstagramPreferenceStyle.dp(getContext(), 7);
-
-            paint.setStyle(Paint.Style.STROKE);
-            paint.setStrokeWidth(InstagramPreferenceStyle.dp(getContext(), 1.9f));
-            paint.setStrokeCap(Paint.Cap.ROUND);
-            paint.setStrokeJoin(Paint.Join.ROUND);
-            paint.setColor(InstagramPreferenceStyle.primaryTextColor());
-
-            canvas.drawLine(tipX, centerY, endX, centerY, paint);
-            canvas.drawLine(tipX, centerY, headEndX, centerY - headOffset, paint);
-            canvas.drawLine(tipX, centerY, headEndX, centerY + headOffset, paint);
-        }
     }
 
     private void applySystemBarStyle() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -79,7 +79,7 @@ public class ButtonPref extends Preference {
                     } else if (key.equals("piko_download_id_mapping")) {
                         DownloadMapping.downloadMapping();
 
-                    } else if (key.startsWith("piko_frag_")) {
+                    } else if (isFragmentNavigation(key)) {
                         FragmentHook.startFragment(key);
 
                     } else if (key.equals("piko_rec_flags_refresh_file")) {
@@ -101,12 +101,22 @@ public class ButtonPref extends Preference {
 
     @Override
     protected void onBindView(View view) {
+        String key = getKey();
         InstagramPreferenceStyle.bindText(this, view);
-        InstagramPreferenceStyle.setTrailingVisible(view, hasVisibleTrail(getKey()));
+        InstagramPreferenceStyle.setTrailingVisible(view, hasVisibleTrail(key));
+        InstagramPreferenceStyle.setPressedHighlightEnabled(
+                view,
+                hasPressedHighlight(key)
+        );
     }
 
-    private boolean hasVisibleTrail(String key) {
-        return key != null
+    private static boolean isFragmentNavigation(String key) {
+        return key != null && key.startsWith("piko_frag_");
+    }
+
+    private static boolean hasVisibleTrail(String key) {
+        return isFragmentNavigation(key)
+                || (key != null
                 && (key.equals("piko_export_dev_overrides")
                 || key.equals("piko_import_dev_overrides")
                 || key.equals("piko_import_id_mapping")
@@ -118,7 +128,12 @@ public class ButtonPref extends Preference {
                 || key.equals("piko_export_experiment_list")
                 || key.equals("piko_export_experiment_mappings")
                 || key.equals("piko_download_id_mapping")
-                || key.equals("piko_rec_flags_refresh_file"));
+                || key.equals("piko_rec_flags_refresh_file")));
+    }
+
+    private static boolean hasPressedHighlight(String key) {
+        return isFragmentNavigation(key)
+                && !Constants.PIKO_FRAGMENT_REC_FLAGS.equals(key);
     }
 
     private String getIconResourceName(String key) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -9,8 +9,9 @@ package app.morphe.extension.instagram.settings.preference.widgets;
 import android.content.Context;
 import android.content.res.Configuration;
 import android.graphics.Canvas;
-import android.graphics.Color;
 import android.graphics.Paint;
+import android.graphics.PorterDuff;
+import android.graphics.PorterDuffColorFilter;
 import android.graphics.Rect;
 import android.preference.Preference;
 import android.text.TextUtils;
@@ -44,6 +45,20 @@ public final class InstagramPreferenceStyle {
     private InstagramPreferenceStyle() {
     }
 
+    private static String chevronDrawableName(int layoutDirection) {
+        return layoutDirection == View.LAYOUT_DIRECTION_RTL
+                ? UI.DRAWABLE_CHEVRON_RIGHT_RTL
+                : UI.DRAWABLE_CHEVRON_RIGHT;
+    }
+
+    private static int topPaddingDp(int trailingType, boolean hasSummary) {
+        return hasSummary || trailingType == TRAILING_SWITCH ? 10 : 15;
+    }
+
+    private static int bottomPaddingDp(int trailingType, boolean hasSummary) {
+        return hasSummary || trailingType == TRAILING_SWITCH ? 20 : 15;
+    }
+
     public static int dp(Context context, float value) {
         return (int) TypedValue.applyDimension(
                 TypedValue.COMPLEX_UNIT_DIP,
@@ -69,13 +84,8 @@ public final class InstagramPreferenceStyle {
     }
 
     public static int pressedBackgroundColor() {
-        int secondaryBackground = UI.getThemedColour("igds_color_secondary_background");
-
-        if (!UI.isDarkMode() || backgroundColor() == Color.BLACK) {
-            return secondaryBackground;
-        }
-
-        return ResourceUtils.getColor("igds_prism_gray_09", secondaryBackground);
+        int fallback = UI.getThemedColour("igds_color_secondary_background");
+        return ResourceUtils.getColor("igds_elevated_highlight_background", fallback);
     }
 
     public static int primaryTextColor() {
@@ -190,8 +200,16 @@ public final class InstagramPreferenceStyle {
         ));
 
         if (trailingType == TRAILING_CHEVRON) {
-            ChevronView trailing = new ChevronView(context);
+            ImageView trailing = new ImageView(context);
             trailing.setTag(TAG_TRAILING);
+            UI.setThemedIcon(
+                    trailing,
+                    chevronDrawableName(
+                            context.getResources().getConfiguration().getLayoutDirection()
+                    ),
+                    "igds_color_secondary_icon"
+            );
+            trailing.setScaleType(ImageView.ScaleType.CENTER);
             row.addView(trailing, new LinearLayout.LayoutParams(dp(context, 22), dp(context, 34)));
         }
 
@@ -229,6 +247,15 @@ public final class InstagramPreferenceStyle {
 
         if (trailing != null) {
             trailing.setEnabled(enabled);
+            if (trailing instanceof ImageView) {
+                int trailingColor = enabled
+                        ? UI.getThemedColour("igds_color_secondary_icon")
+                        : disabledTextColor();
+                ((ImageView) trailing).setColorFilter(new PorterDuffColorFilter(
+                        trailingColor,
+                        PorterDuff.Mode.SRC_ATOP
+                ));
+            }
             trailing.invalidate();
         }
 
@@ -240,6 +267,12 @@ public final class InstagramPreferenceStyle {
         if (trailing != null) {
             trailing.setVisibility(visible ? View.VISIBLE : View.GONE);
             trailing.invalidate();
+        }
+    }
+
+    public static void setPressedHighlightEnabled(View view, boolean enabled) {
+        if (view instanceof PreferenceRow) {
+            ((PreferenceRow) view).setPressedHighlightEnabled(enabled);
         }
     }
 
@@ -309,6 +342,7 @@ public final class InstagramPreferenceStyle {
         private final Rect switchHitRect = new Rect();
         private final int trailingType;
         private View highlightView;
+        private boolean pressedHighlightEnabled;
         private boolean pressedHighlightAllowed;
         private boolean switchClickAllowed = true;
         private boolean drawPressedHighlight;
@@ -351,6 +385,15 @@ public final class InstagramPreferenceStyle {
 
         void setHighlightView(View highlightView) {
             this.highlightView = highlightView;
+            pressedHighlightEnabled = true;
+        }
+
+        void setPressedHighlightEnabled(boolean enabled) {
+            pressedHighlightEnabled = enabled;
+            if (!enabled) {
+                pressedHighlightAllowed = false;
+                setDrawPressedHighlight(false);
+            }
         }
 
         void setSwitchAccessibilityChecked(boolean checked) {
@@ -358,8 +401,8 @@ public final class InstagramPreferenceStyle {
         }
 
         void setHasSummary(boolean hasSummary) {
-            int topPadding = dp(getContext(), 10);
-            int bottomPadding = dp(getContext(), 20);
+            int topPadding = dp(getContext(), topPaddingDp(trailingType, hasSummary));
+            int bottomPadding = dp(getContext(), bottomPaddingDp(trailingType, hasSummary));
             setMinimumHeight(dp(getContext(), hasSummary ? 80 : 62));
             setPadding(getPaddingLeft(), topPadding, getPaddingRight(), bottomPadding);
         }
@@ -385,9 +428,13 @@ public final class InstagramPreferenceStyle {
 
         @Override
         public boolean dispatchTouchEvent(MotionEvent event) {
-            if (event.getActionMasked() == MotionEvent.ACTION_DOWN) {
+            int action = event.getActionMasked();
+            if (action == MotionEvent.ACTION_DOWN) {
                 pressedHighlightAllowed = shouldDrawPressedHighlight(event.getX(), event.getY());
                 switchClickAllowed = shouldHandleSwitchClick(event.getY());
+            } else if (action == MotionEvent.ACTION_CANCEL) {
+                pressedHighlightAllowed = false;
+                setDrawPressedHighlight(false);
             }
             return super.dispatchTouchEvent(event);
         }
@@ -403,22 +450,24 @@ public final class InstagramPreferenceStyle {
 
         @Override
         protected void dispatchDraw(Canvas canvas) {
-            if (drawPressedHighlight && highlightView != null) {
+            if (drawPressedHighlight) {
                 pressedPaint.setStyle(Paint.Style.FILL);
                 pressedPaint.setColor(pressedBackgroundColor());
-                int top = highlightTop();
-                int bottom = highlightBottom();
-                canvas.drawRect(0, top, getWidth(), bottom, pressedPaint);
+                canvas.drawRect(0, highlightTop(), getWidth(), highlightBottom(), pressedPaint);
             }
             super.dispatchDraw(canvas);
         }
 
         private boolean shouldDrawPressedHighlight(float x, float y) {
-            if (trailingType != TRAILING_SWITCH || !isEnabled() || highlightView == null) {
+            if (!pressedHighlightEnabled || !isEnabled()) {
                 return false;
             }
 
-            if (y < highlightTop() || y > highlightBottom()) {
+            if (trailingType != TRAILING_SWITCH) {
+                return true;
+            }
+
+            if (highlightView == null || y < highlightTop() || y > highlightBottom()) {
                 return false;
             }
 
@@ -454,7 +503,7 @@ public final class InstagramPreferenceStyle {
 
         private int highlightBottom() {
             if (highlightView == null) {
-                return 0;
+                return getHeight();
             }
             return Math.min(getHeight(), highlightView.getBottom() + dp(getContext(), 10));
         }
@@ -465,33 +514,6 @@ public final class InstagramPreferenceStyle {
             }
             this.drawPressedHighlight = drawPressedHighlight;
             invalidate();
-        }
-    }
-
-    private static class ChevronView extends View {
-        private final Paint paint = new Paint(Paint.ANTI_ALIAS_FLAG);
-
-        ChevronView(Context context) {
-            super(context);
-        }
-
-        @Override
-        protected void onDraw(Canvas canvas) {
-            super.onDraw(canvas);
-
-            float centerY = getHeight() / 2f;
-            float tipX = getWidth() - dp(getContext(), 1.25f);
-            float armX = getWidth() - dp(getContext(), 6.75f);
-            float armOffset = dp(getContext(), 6.25f);
-
-            paint.setStyle(Paint.Style.STROKE);
-            paint.setStrokeWidth(dp(getContext(), 1.9f));
-            paint.setStrokeCap(Paint.Cap.ROUND);
-            paint.setStrokeJoin(Paint.Join.ROUND);
-            paint.setColor(isEnabled() ? secondaryTextColor() : disabledTextColor());
-
-            canvas.drawLine(armX, centerY - armOffset, tipX, centerY, paint);
-            canvas.drawLine(tipX, centerY, armX, centerY + armOffset, paint);
         }
     }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
@@ -155,7 +155,7 @@ private val materialYouThemeMappings =
         "igds_primary_background" to "@color/piko_dynamic_background",
         "igds_secondary_background" to "@color/piko_dynamic_background",
         "igds_elevated_background" to "@color/piko_dynamic_background",
-        "igds_elevated_highlight_background" to "@color/piko_dynamic_background",
+        "igds_elevated_highlight_background" to "@color/piko_dynamic_pressed_background",
         "igds_elevated_separator" to "@color/piko_dynamic_outline_variant",
         "igds_separator" to "@color/piko_dynamic_outline_variant",
         "igds_stroke" to "@color/piko_dynamic_outline",


### PR DESCRIPTION
Improves navigation and pressed feedback in Piko settings
- Uses Instagram's native LTR and RTL chevrons for category rows
- Adds full-row pressed feedback to top-level categories
- Restores distinct pressed background colors with Light, Dark, and Amoled Material You themes

## Testing
- `.\gradlew.bat :extensions:instagram:compileDebugJavaWithJavac :patches:compileKotlin --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26