### PR TITLE
fix(Instagram): Refresh recommended flags after download

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/RecommendedFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/RecommendedFlags.java
@@ -19,16 +19,24 @@ import static app.morphe.extension.instagram.utils.IgStr.str;
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.entity.DeveloperOptions;
 import app.morphe.extension.instagram.entity.DeveloperOptionsItem;
-import app.morphe.extension.instagram.utils.Pref;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.InstaUtils;
 
 public class RecommendedFlags {
 
+    private static File getRecommendedFlagsFile() {
+        Context context = PikoUtils.getContext();
+        return new File(context.getFilesDir(), Constants.REC_FLAGS + ".json");
+    }
+
+    public static long getLastModified() {
+        File file = getRecommendedFlagsFile();
+        return file.exists() ? file.lastModified() : 0L;
+    }
+
     private static JSONArray readFlagsFromFileDir(){
         try{
-            Context context = PikoUtils.getContext();
-            File recFlagsFile = new File(context.getFilesDir(), Constants.REC_FLAGS+".json");
+            File recFlagsFile = getRecommendedFlagsFile();
             if (!recFlagsFile.exists()) {
                 PikoUtils.toast(str("piko_rec_flags_no_file"));
             } else {
@@ -57,15 +65,9 @@ public class RecommendedFlags {
         return flags;
     }
 
-    public static void downloadRecommendedFlagsFile() {
-        Context context = PikoUtils.getContext();
-
+    public static void downloadRecommendedFlagsFile(Runnable onComplete) {
         String filename = Constants.REC_FLAGS+".json";
         String host = Constants.PIKO_MAPPINGS_PATH;
-        File recFlagFile = new File(context.getFilesDir(), filename);
-        InstaUtils.downloadFile(host, filename, recFlagFile, ()->{
-            long lastModified = recFlagFile.lastModified();
-            Pref.setLastRecommendedFlagDownloadTimestamp(lastModified);
-        });
+        InstaUtils.downloadFile(host, filename, getRecommendedFlagsFile(), onComplete);
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -18,7 +18,6 @@ public class Settings {
             new BooleanSetting("instagram_theme_mode_synchronized", false);
     // It should be true always. It will be handled upon opening the piko settings for the first time.
     public static final BooleanSetting FIRST_TIME_PIKO = new BooleanSetting("first_time_piko", true);
-    public static final StringSetting LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP = new StringSetting("last_recommended_flag_download_timestamp", "0");
 
     public static final BooleanSetting DISABLE_ADS = new BooleanSetting("disable_ads", true);
     public static final BooleanSetting OPEN_LINKS_EXTERNALLY = new BooleanSetting("open_links_externally", true);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -13,13 +13,13 @@ import android.content.Context;
 import android.preference.PreferenceScreen;
 import android.preference.Preference;
 import android.preference.PreferenceCategory;
+import android.text.format.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.TreeMap;
 import java.util.Map;
 import java.util.List;
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 import  app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
 import  app.morphe.extension.instagram.patches.devFlags.Flag;
@@ -833,11 +833,15 @@ public class ScreenBuilder {
 
     public void buildRecommendedFlagsSection() {
 
-        long lastModified = Pref.getLastRecommendedFlagDownloadTimestamp();
-        LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(lastModified), ZoneId.systemDefault());
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE MMM dd, yyyy hh:mm:ss a");
-        String formattedDate = dateTime.format(formatter);
-        String lastModifiedAtString = String.format(str("piko_rec_flags_last_modified_at"), formattedDate);
+        long lastModified = RecommendedFlags.getLastModified();
+        String lastModifiedAtString = "";
+        if (lastModified > 0L) {
+            Locale locale = context.getResources().getConfiguration().getLocales().get(0);
+            String skeleton = DateFormat.is24HourFormat(context) ? "yMMMEdHm" : "yMMMEdhm";
+            String pattern = DateFormat.getBestDateTimePattern(locale, skeleton);
+            String formattedDate = new SimpleDateFormat(pattern, locale).format(new Date(lastModified));
+            lastModifiedAtString = String.format(str("piko_rec_flags_last_modified_at"), formattedDate);
+        }
         addPreference(
             helper.buttonPreference(
                     str("piko_rec_flags_refresh_file"),

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -13,6 +13,8 @@ import android.util.AttributeSet;
 import android.view.View;
 import android.view.ViewGroup;
 
+import java.lang.ref.WeakReference;
+
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.Logger;
 import app.morphe.extension.instagram.settings.ActivityHook;
@@ -83,7 +85,9 @@ public class ButtonPref extends Preference {
                         FragmentHook.startFragment(key);
 
                     } else if (key.equals("piko_rec_flags_refresh_file")) {
-                        RecommendedFlags.downloadRecommendedFlagsFile();
+                        RecommendedFlags.downloadRecommendedFlagsFile(
+                                recreateActivityOnComplete(context)
+                        );
                     }
                 } catch (Exception e) {
                     Utils.showToastShort(e.getMessage());
@@ -92,6 +96,19 @@ public class ButtonPref extends Preference {
                 return true;
             }
         });
+    }
+
+    private static Runnable recreateActivityOnComplete(Context context) {
+        if (!(context instanceof Activity)) {
+            return null;
+        }
+        WeakReference<Activity> activityReference = new WeakReference<>((Activity) context);
+        return () -> {
+            Activity activity = activityReference.get();
+            if (activity != null && !activity.isFinishing() && !activity.isDestroyed()) {
+                activity.recreate();
+            }
+        };
     }
 
     @Override

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/InstaUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/InstaUtils.java
@@ -96,9 +96,13 @@ public class InstaUtils {
                 HttpURLConnection connection = Requester.getConnectionFromRoute(host, route);
                 String response = Requester.parseString(connection);
 
-                PikoUtils.writeFile(outputFile, response.getBytes(), false);
+                boolean fileWritten = PikoUtils.writeFile(outputFile, response.getBytes(), false);
 
                 new Handler(Looper.getMainLooper()).post(() -> {
+                    if (!fileWritten) {
+                        PikoUtils.toast(str("piko_download_failed_media") + outputFile.getName());
+                        return;
+                    }
                     PikoUtils.toast(str("piko_downloaded_media") + outputFile.getName());
 
                     if (onComplete != null) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -322,14 +322,5 @@ public class Pref {
         return Integer.valueOf(SharedPref.getStringPref(Settings.FILTER_STORY_MAX_STORY_ITEMS));
     }
 
-    public static Long getLastRecommendedFlagDownloadTimestamp() {
-        return Long.valueOf(SharedPref.getStringPref(Settings.LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP));
-    }
-
-    public static void setLastRecommendedFlagDownloadTimestamp(Long timestamp) {
-        String ts = String.valueOf(timestamp);
-        SharedPref.setStringPref(Settings.LAST_RECOMMENDED_FLAG_DOWNLOAD_TIMESTAMP.key,ts);
-    }
-
     //end
 }


### PR DESCRIPTION
The settings screen was not recreated after recommended flags were updated. it is now recreated only after the download and file write succeed, the updated flags are shown immediately. the last updated date uses the json file's modification time and follows the device locale and 12/24-hour setting

## Testing
- `.\gradlew.bat test --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v426.0.0.37.68 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26