### PR TITLE
fix(Instagram): block permission onboarding screens

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -27,6 +27,10 @@ import app.morphe.extension.instagram.settings.ActivityHook;
 
 @SuppressWarnings("unused")
 public class Links {
+    private static final String NDX_CONTACT_IMPORT_SCREEN =
+            "com.bloks.www.bloks.ig.ndx.ci.entry.screen";
+    private static final String NDX_LOCATION_SERVICES_SCREEN =
+            "com.bloks.www.bloks.ig.ndx.ls.entry.screen";
     private static final boolean DISABLE_ANALYTICS;
     private static final boolean DISABLE_STORIES;
     private static final boolean DISABLE_EXPLORE;
@@ -67,6 +71,15 @@ public class Links {
 
     public static boolean setStorySeen(boolean seenStatus){
         return Pref.viewStoriesAnonymously() ? true:seenStatus;
+    }
+
+    public static boolean shouldBlockOnboardingScreen(String appId) {
+        if (!DISABLE_ONBOARDING_PERMISSION_PROMPTS || appId == null) {
+            return false;
+        }
+
+        return NDX_CONTACT_IMPORT_SCREEN.equals(appId)
+                || NDX_LOCATION_SERVICES_SCREEN.equals(appId);
     }
 
     public static boolean openExternally(String url) {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/onboarding/DisableOnboardingPermissionPromptsPatch.kt
@@ -9,15 +9,35 @@ package app.crimera.patches.instagram.misc.onboarding
 import app.crimera.patches.instagram.links.interceptUriPatch
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.LINKS_DESCRIPTOR
 import app.crimera.patches.instagram.utils.addFlags
 import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+
+private object IgBloksFullScreenOpenFingerprint : Fingerprint(
+    returnType = "V",
+    parameters =
+        listOf(
+            "Landroid/content/Context;",
+            "Lcom/instagram/bloks/hosting/IgBloksScreenConfig;",
+        ),
+    strings = listOf("BKDataFetcher.fetch"),
+)
 
 @Suppress("unused")
 val disableOnboardingPermissionPromptsPatch =
     bytecodePatch(
         name = "Disable onboarding permission prompts",
-        description = "Prevents contacts and location permission onboarding prompts from appearing on launch.",
+        description = "Prevents contacts and location permission onboarding prompts from appearing.",
         default = true,
     ) {
         dependsOn(settingsPatch, interceptUriPatch)
@@ -26,5 +46,38 @@ val disableOnboardingPermissionPromptsPatch =
         execute {
             addFlags("onboardingPermissionPromptFlags")
             enableSettings("disableOnboardingPermissionPrompts")
+
+            IgBloksFullScreenOpenFingerprint.apply {
+                val openerClass = classDef.type
+                method.apply {
+                    check(!AccessFlags.STATIC.isSet(accessFlags)) {
+                        "Bloks full-screen opener is static"
+                    }
+
+                    val appIdField =
+                        instructions
+                            .asSequence()
+                            .filter { it.opcode == Opcode.IGET_OBJECT }
+                            .mapNotNull {
+                                (it as? ReferenceInstruction)?.reference as? FieldReference
+                            }.firstOrNull {
+                                it.definingClass == openerClass &&
+                                    it.type == "Ljava/lang/String;"
+                            } ?: error("Bloks full-screen opener app ID field not found")
+
+                    addInstructionsWithLabels(
+                        0,
+                        """
+                        move-object/from16 v0, p0
+                        iget-object v0, v0, $appIdField
+                        invoke-static {v0}, $LINKS_DESCRIPTOR->shouldBlockOnboardingScreen(Ljava/lang/String;)Z
+                        move-result v0
+                        if-eqz v0, :piko_continue
+                        return-void
+                        """.trimIndent(),
+                        ExternalLabel("piko_continue", getInstruction(0)),
+                    )
+                }
+            }
         }
     }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -73,7 +73,7 @@
     <string name="piko_amoled_title">AMOLED</string>
     <string name="piko_disable_analytics">Disable analytics</string>
     <string name="piko_delete_analytics_cache">Delete analytic cache</string>
-    <string name="piko_disable_analytics_desc">Block analytics that are sent to Instagram/Facebook servers. Side effect: A popup requesting permission for location and contacts keeps reappearing even after you have allowed or skipped it. To prevent this, enable this feature only after you have allowed or skipped it.</string>
+    <string name="piko_disable_analytics_desc">Block analytics that are sent to Instagram/Facebook servers.</string>
     <string name="piko_disable_discover_people">Disable discover people</string>
     <string name="piko_disable_discover_people_desc">Disables discover people section on user profile</string>
     <string name="piko_follow_back_indicator">Enable friendship status indicator</string>


### PR DESCRIPTION
## What changed

- Block the contact-import and location-services NDX Bloks screens at the full-screen opener.
- Match only the two observed onboarding app IDs, leaving unrelated Bloks screens unchanged.
- Keep the existing experiment-flag and legacy consent-URI protections in place.
- Update the patch description because these prompts can appear during normal use, not only on launch.

## Root cause

On Instagram 439, these prompts can arrive through a server-driven quick-promotion action instead of the consent URI paths already handled by the patch:

```text
QuickPromotionSurfaceQueryV3
-> com.bloks.www.qp.async.bloks_action
-> Bloks full-screen opener
-> BKDataFetcher.fetch
-> ModalActivity
```

The resulting screens use these app IDs:

```text
com.bloks.www.bloks.ig.ndx.ci.entry.screen
com.bloks.www.bloks.ig.ndx.ls.entry.screen
```

The existing flags and URI interception therefore do not cover this entry route. Returning later in the fetch path is also too late because modal navigation may already have been scheduled, leaving an indefinitely loading screen.

The new guard runs at the full-screen opener entry and returns before the data fetch or modal navigation begins.

## User impact

The random contacts/location setup screens are suppressed while other Bloks screens continue normally.

## Validation

- `./gradlew :patches:build --stacktrace`
- Patched Instagram `439.0.0.37.89` (`384510827`, arm64-v8a): all patching, rebuilding, and signing steps succeeded; 55 patches applied and none failed.
- Captured both NDX app IDs from natural prompt occurrences and confirmed they use the same full-screen opener.
- Used a temporary diagnostic build that showed a toast only after the exact production predicate matched. A natural contacts prompt produced the confirmation toast while the onboarding screen did not open.
- Built and installed a final artifact without the diagnostic patch, log tags, or toast strings; Instagram launched without an AndroidRuntime crash.
