### PR TITLE
improve(twitter): improve more profile info

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/profile/MoreProfileInfo.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/profile/MoreProfileInfo.java
@@ -38,6 +38,9 @@ public class MoreProfileInfo {
         int targetId = ResourceUtils.getIdentifier(ResourceType.ID, resourceName);
         TweetStatView tweetStatView = (TweetStatView)  rootView.findViewById(targetId);
 
+        tweetStatView.setOnTouchListener((v, event) -> true);
+        tweetStatView.setOnClickListener(v -> {});
+
         setTweetStatViewValue(context, tweetStatView, text, count);
         if(count>0)
             tweetStatView.setVisibility(View.VISIBLE);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/profile/MoreProfileInfo.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/profile/MoreProfileInfo.java
@@ -69,7 +69,7 @@ public class MoreProfileInfo {
                 setTweetStatView(context, rootView, "media_stat", text, count);
 
                 count = twitterUserEntity.getLikesCount();
-                text = str("profile_tab_title_favorites");
+                text = str("profile_tab_title_likes");
                 setTweetStatView(context, rootView, "likes_stat", text, count);
             }
         } catch (Exception e) {


### PR DESCRIPTION
## What changed
- Fix for incorrect name of likes statView
- Make stat views unclickable (`setOnTouchListener` to ignore clicks on blank areas, `setOnClickListener` to ignore clicks directly on statView)

## Problem
In piko 3.9.0-dev.7 click on one statView selects all of them, this includes clicks on blank username and stat view areas

<img width="1080" height="681" alt="photo_2026-08-13_03-31-40" src="https://github.com/user-attachments/assets/c7e8200c-7b2e-4b0f-a28c-e237e1c54eb5" />
<img width="1080" height="696" alt="photo_2026-08-13_03-31-35" src="https://github.com/user-attachments/assets/b3f9546c-76f8-4f88-89e6-a8b5d6d3c2da" />

## Testing
- `gradlew clean buildAndroid`
- Tested on Twitter 12.11.0-release.0 with Piko 3.9.0-dev.7
- Tested on POCO F5, Android 16