### PR TITLE
bump(Instagram): add 442.0.0.46.79 compatibility

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -16,8 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
+          # Make sure the release step uses its own credentials:
+          # https://github.com/cycjimmy/semantic-release-action#private-packages
           persist-credentials: false
           fetch-depth: 0
 
@@ -28,10 +30,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean buildAndroid
-
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: extension-release
-          path: "**/*.mpp"
-          if-no-files-found: warn

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: app-release
-          path: "**/*.apk"
+          name: extension-release
+          path: "**/*.mpp"
           if-no-files-found: warn

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -1,3 +1,34 @@
+name: Test pull request
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Test pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Cache Gradle
+        uses: burrunan/gradle-cache-action@v3
+
+      - name: Build with Gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew clean buildAndroid
+
       - name: Upload Build Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -16,10 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
         with:
-          # Make sure the release step uses its own credentials:
-          # https://github.com/cycjimmy/semantic-release-action#private-packages
           persist-credentials: false
           fetch-depth: 0
 
@@ -30,3 +28,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew clean buildAndroid
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-release
+          path: "**/*.mpp"
+          if-no-files-found: warn

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -1,32 +1,6 @@
-name: Test pull request
-
-on:
-  workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-      - dev
-      
-permissions:
-  contents: read
-
-jobs:
-  release:
-    name: Test pull request
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
         with:
-          # Make sure the release step uses its own credentials:
-          # https://github.com/cycjimmy/semantic-release-action#private-packages
-          persist-credentials: false
-          fetch-depth: 0
-
-      - name: Cache Gradle
-        uses: burrunan/gradle-cache-action@v3
-
-      - name: Build with Gradle
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew clean buildAndroid
+          name: app-release
+          path: "**/*.apk"
+          if-no-files-found: warn

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/Entity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/Entity.java
@@ -9,7 +9,6 @@ package app.morphe.extension.instagram.entity;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.lang.reflect.Constructor;
 
 public class Entity {
@@ -58,6 +57,33 @@ public class Entity {
         return new Entity(object);
     }
 
+    private Method findCompatibleMethod(Class<?> clazz, String methodName, Object... params) throws NoSuchMethodException {
+        for (Method method : clazz.getDeclaredMethods()) {
+            Class<?>[] types = method.getParameterTypes();
+            if (!method.getName().equals(methodName) || types.length != params.length) {
+                continue;
+            }
+
+            boolean compatible = true;
+            for (int i = 0; i < types.length; i++) {
+                Object param = params[i];
+                if (param == null) {
+                    continue;
+                }
+                if (!types[i].isAssignableFrom(param.getClass())) {
+                    compatible = false;
+                    break;
+                }
+            }
+
+            if (compatible) {
+                method.setAccessible(true);
+                return method;
+            }
+        }
+        throw new NoSuchMethodException(clazz.getName() + "." + methodName);
+    }
+
     public Object getMethod(Object clsObj, String methodName, Class<?>[] paramTypes, Object... params) throws Exception {
         Class<?> clazz;
         if (clsObj instanceof Class<?>) {
@@ -66,10 +92,14 @@ public class Entity {
             clazz = clsObj.getClass();
         }
 
-        Method method = clazz.getDeclaredMethod(methodName, paramTypes);
-        method.setAccessible(true);
-
-        return method.invoke(null, params);
+        try {
+            Method method = clazz.getDeclaredMethod(methodName, paramTypes);
+            method.setAccessible(true);
+            return method.invoke(clsObj instanceof Class<?> ? null : clsObj, params);
+        } catch (NoSuchMethodException e) {
+            Method method = findCompatibleMethod(clazz, methodName, params);
+            return method.invoke(clsObj instanceof Class<?> ? null : clsObj, params);
+        }
     }
 
     public Object getMethod(Object clsObj, String methodName, Object... params) throws Exception {
@@ -81,15 +111,16 @@ public class Entity {
         }
 
         if (params == null || params.length == 0) {
-            return clazz.getDeclaredMethod(methodName).invoke(clsObj);
-        } else {
-            Class<?>[] paramTypes = new Class<?>[params.length];
-            for (int i = 0; i < params.length; i++) {
-                paramTypes[i] = params[i].getClass();
-            }
-            return this.getMethod(clsObj, methodName, paramTypes, params);
+            Method method = clazz.getDeclaredMethod(methodName);
+            method.setAccessible(true);
+            return method.invoke(clsObj instanceof Class<?> ? null : clsObj);
         }
 
+        Class<?>[] paramTypes = new Class<?>[params.length];
+        for (int i = 0; i < params.length; i++) {
+            paramTypes[i] = params[i] == null ? Object.class : params[i].getClass();
+        }
+        return this.getMethod(clsObj, methodName, paramTypes, params);
     }
 
     public Object getMethod(String methodName, Class<?>[] paramTypes, Object... params) throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -164,7 +164,7 @@ public class MediaData extends Entity {
     }
 
     public UserData getUserDataWithoutUserSession() throws Exception {
-        Object userData = super.getMethod(this.obj, "methodName");
+        Object userData = super.getMethod(this.getExtendedData(), "methodName");
         return new UserData(userData);
     }
 
@@ -197,7 +197,10 @@ public class MediaData extends Entity {
     }
 
     public List<Object> getMediaList() throws Exception {
-        List mediaList = (List) super.getMethod(this.obj, "methodName");
+        // Carousel media is exposed by the extended-data backing object.
+        // Calling the method on the outer Media object returns an unrelated/null
+        // collection on Instagram 442, which then breaks every download action.
+        List mediaList = (List) super.getMethod(this.getExtendedData(), "methodName");
         if (mediaList != null) {
             return mediaList;
         }
@@ -241,8 +244,9 @@ public class MediaData extends Entity {
     }
 
     private List getVideoVariantsV2() throws Exception {
-        // Instagram 442 stores video_versions on the Media object.
-        List variantList = (List) super.getMethod(this.obj, "AAY");
+        // Keep the original entity layout: video_versions is a field of the
+        // extended media dictionary, not a method on the outer Media object.
+        List variantList = (List) super.getField(this.getMoreExtendedData(), "fieldName");
         if (variantList == null) {
             return null;
         }
@@ -258,27 +262,37 @@ public class MediaData extends Entity {
 
     public List getVideoVariants() throws Exception {
         try {
-            return this.getVideoVariantsV2();
+            List variants = this.getVideoVariantsV2();
+            if (variants != null && !variants.isEmpty()) {
+                return variants;
+            }
         } catch (Exception e) {
-            return this.getVideoVariantsV1();
         }
+
+        return this.getVideoVariantsV1();
     }
 
     public List getImageVariants() throws Exception {
-        Object imageInfoObject = super.getMethod(this.obj, "methodName");
-        if (imageInfoObject != null){
-            List variantList = (List) super.getMethod(imageInfoObject, "imageVariantsMethod");
-            if (variantList != null){
-                List<ImageData> imageList = new ArrayList<>();
-                for (Object item : variantList) {
-                    if (item != null) {
-                        imageList.add(new ImageData(item));
-                    }
-                }
-                return imageList;
+        // image_versions2 is stored in the image-info object under the
+        // more-extended media dictionary. The method name is patched from the
+        // AyuMidcard helper fingerprint.
+        Object imageInfoObject = (Object) super.getField(this.getMoreExtendedData(), "fieldName");
+        if (imageInfoObject == null) {
+            return null;
+        }
+
+        List variantList = (List) super.getMethod(imageInfoObject, "methodName");
+        if (variantList == null) {
+            return null;
+        }
+
+        List<ImageData> imageList = new ArrayList<>();
+        for (Object item : variantList) {
+            if (item != null) {
+                imageList.add(new ImageData(item));
             }
         }
-        return null;
+        return imageList;
     }
 
     public String getVideoLink() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -49,7 +49,6 @@ public class MediaData extends Entity {
 
         String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
-        // Handle the edge case where the ID is 0
         if (instaId == 0) {
             return String.valueOf(alphabet.charAt(0));
         }
@@ -77,8 +76,6 @@ public class MediaData extends Entity {
     public PostType getPostType() {
         try{
             String postType = this.getPostTypeKey().toLowerCase();
-            //TODO: for some reason clips are not recogonised.
-            // Need to fix it later.
             if(postType.equals("clips")){
                 return PostType.REEL;
             }
@@ -139,7 +136,6 @@ public class MediaData extends Entity {
         if (mediaType.equals(MediaType.VIDEO)) return videoExtension;
         if (mediaType.equals(MediaType.AUDIO)) return audioExtension;
 
-        // Default fallback just in case.
         return imageExtension;
     }
 
@@ -157,7 +153,7 @@ public class MediaData extends Entity {
     }
 
     public UserData getUserDataWithoutUserSession() throws Exception {
-        Object userData = super.getMethod(this.getExtendedData(), "methodName");
+        Object userData = super.getMethod(this.obj, "methodName");
         return new UserData(userData);
     }
 
@@ -190,7 +186,7 @@ public class MediaData extends Entity {
     }
 
     public List<Object> getMediaList() throws Exception {
-        List mediaList = (List) super.getMethod(this.getExtendedData(), "methodName");
+        List mediaList = (List) super.getMethod(this.obj, "methodName");
         if (mediaList != null) {
             return mediaList;
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -237,13 +237,19 @@ public class MediaData extends Entity {
     }
 
     private List getVideoVariantsV2() throws Exception {
-        List variantList = (List) super.getField(this.getMoreExtendedData(), "fieldName");
-        if (variantList != null){
-            List<VideoData> videoList = new ArrayList<>();
-            variantList.forEach(item -> videoList.add(new VideoData(item)));
-            return videoList;
+        // Instagram 442 stores video_versions on the Media object.
+        List variantList = (List) super.getMethod(this.obj, "AAY");
+        if (variantList == null) {
+            return null;
         }
-        return null;
+
+        List<VideoData> videoList = new ArrayList<>();
+        variantList.forEach(item -> {
+            if (item != null) {
+                videoList.add(new VideoData(item));
+            }
+        });
+        return videoList;
     }
 
     public List getVideoVariants() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -237,19 +237,13 @@ public class MediaData extends Entity {
     }
 
     private List getVideoVariantsV2() throws Exception {
-        // Instagram 442 stores video_versions on the Media object.
-        List variantList = (List) super.getMethod(this.obj, "AAY");
-        if (variantList == null) {
-            return null;
+        List variantList = (List) super.getField(this.getMoreExtendedData(), "fieldName");
+        if (variantList != null){
+            List<VideoData> videoList = new ArrayList<>();
+            variantList.forEach(item -> videoList.add(new VideoData(item)));
+            return videoList;
         }
-
-        List<VideoData> videoList = new ArrayList<>();
-        variantList.forEach(item -> {
-            if (item != null) {
-                videoList.add(new VideoData(item));
-            }
-        });
-        return videoList;
+        return null;
     }
 
     public List getVideoVariants() throws Exception {
@@ -261,22 +255,16 @@ public class MediaData extends Entity {
     }
 
     public List getImageVariants() throws Exception {
-        Object imageInfoObject = super.getMethod(this.obj, "A39");
-        if (imageInfoObject == null) {
-            return new ArrayList<>();
-        }
-        List variantList = (List) super.getMethod(imageInfoObject, "BZe");
-        if (variantList == null) {
-            return new ArrayList<>();
-        }
-
-        List<ImageData> imageList = new ArrayList<>();
-        variantList.forEach(item -> {
-            if (item != null) {
-                imageList.add(new ImageData(item));
+        Object imageInfoObject = super.getMethod(this.obj, "methodName");
+        if (imageInfoObject != null){
+            List variantList = (List) super.getMethod(imageInfoObject, "methodName");
+            if (variantList != null){
+                List<ImageData> imageList = new ArrayList<>();
+                variantList.forEach(item -> imageList.add(new ImageData(item)));
+                return imageList;
             }
-        });
-        return imageList;
+        }
+        return null;
     }
 
     public String getVideoLink() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -237,10 +237,8 @@ public class MediaData extends Entity {
     }
 
     private List getVideoVariantsV2() throws Exception {
-        // Instagram 442 stores video_versions on the extended Media object itself.
-        // getMoreExtendedData() points to a different nested object and causes the
-        // field lookup to fail for this target.
-        List variantList = (List) super.getField(this.getExtendedData(), "fieldName");
+        // Instagram 442 stores video_versions on the Media object.
+        List variantList = (List) super.getMethod(this.obj, "AAY");
         if (variantList == null) {
             return null;
         }
@@ -263,11 +261,11 @@ public class MediaData extends Entity {
     }
 
     public List getImageVariants() throws Exception {
-        Object imageInfoObject = (Object) super.getField(this.getMoreExtendedData(), "fieldName");
+        Object imageInfoObject = super.getMethod(this.obj, "A39");
         if (imageInfoObject == null) {
             return new ArrayList<>();
         }
-        List variantList = (List) super.getMethod(imageInfoObject, "methodName");
+        List variantList = (List) super.getMethod(imageInfoObject, "BZe");
         if (variantList == null) {
             return new ArrayList<>();
         }
@@ -335,8 +333,8 @@ public class MediaData extends Entity {
 
     public String getDescriptionText() throws Exception {
         Class<?> helperClass = this.getHelperClass();
-        Object result = super.getMethod(helperClass, "methodName", this.obj);
-        return result != null ? (String) super.getField(result, "fieldName") : null;
+        Object result = super.getMethod(helperClass, "A0J", this.obj);
+        return result != null ? (String) super.getField(result, "A0Z") : null;
     }
 
     public String getMessageAudioUrl() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -106,11 +106,11 @@ public class MediaData extends Entity {
         if (mediaList == null || mediaList.isEmpty()){
             carouselMediaData.add(new MediaData(this.obj, this.userSession));
         } else {
-            mediaList.forEach(item->{
+            for (Object item : mediaList) {
                 if (item != null) {
                     carouselMediaData.add(new MediaData(item, this.userSession));
                 }
-            });
+            }
             if (carouselMediaData.isEmpty()) {
                 carouselMediaData.add(new MediaData(this.obj, this.userSession));
             }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -98,12 +98,19 @@ public class MediaData extends Entity {
     private List<MediaData> getCarouselMediaData() throws Exception {
         List<MediaData> carouselMediaData = new ArrayList<>();
         List<Object> mediaList = this.getMediaList();
-        if (mediaList.isEmpty()){
+        // Some 442 media objects do not expose the carousel list for a normal
+        // single-media post. Treat a null/empty result as the media object itself.
+        if (mediaList == null || mediaList.isEmpty()){
             carouselMediaData.add(new MediaData(this.obj, this.userSession));
         } else {
             mediaList.forEach(item->{
-                carouselMediaData.add(new MediaData(item, this.userSession));
+                if (item != null) {
+                    carouselMediaData.add(new MediaData(item, this.userSession));
+                }
             });
+            if (carouselMediaData.isEmpty()) {
+                carouselMediaData.add(new MediaData(this.obj, this.userSession));
+            }
         }
         return carouselMediaData;
     }
@@ -194,11 +201,15 @@ public class MediaData extends Entity {
     }
 
     public int getCarouselSize() throws Exception {
-        return this.getMediaList().size();
+        List<Object> mediaList = this.getMediaList();
+        return mediaList == null || mediaList.isEmpty() ? 1 : mediaList.size();
     }
 
     public MediaData getMediaAt(int position) throws Exception {
         List<MediaData> mediaList = this.getCarouselMediaData();
+        if (mediaList == null || mediaList.isEmpty()) {
+            return new MediaData(this.obj, this.userSession);
+        }
 
         int safePosition = Math.max(0, Math.min(position, mediaList.size() - 1));
         return mediaList.get(safePosition);
@@ -226,9 +237,16 @@ public class MediaData extends Entity {
         // getMoreExtendedData() points to a different nested object and causes the
         // field lookup to fail for this target.
         List variantList = (List) super.getField(this.getExtendedData(), "fieldName");
+        if (variantList == null) {
+            return null;
+        }
 
         List<VideoData> videoList = new ArrayList<>();
-        variantList.forEach(item -> videoList.add(new VideoData(item)));
+        variantList.forEach(item -> {
+            if (item != null) {
+                videoList.add(new VideoData(item));
+            }
+        });
         return videoList;
     }
 
@@ -242,10 +260,20 @@ public class MediaData extends Entity {
 
     public List getImageVariants() throws Exception {
         Object imageInfoObject = (Object) super.getField(this.getMoreExtendedData(), "fieldName");
+        if (imageInfoObject == null) {
+            return new ArrayList<>();
+        }
         List variantList = (List) super.getMethod(imageInfoObject, "methodName");
+        if (variantList == null) {
+            return new ArrayList<>();
+        }
 
         List<ImageData> imageList = new ArrayList<>();
-        variantList.forEach(item -> imageList.add(new ImageData(item)));
+        variantList.forEach(item -> {
+            if (item != null) {
+                imageList.add(new ImageData(item));
+            }
+        });
         return imageList;
     }
 
@@ -259,7 +287,7 @@ public class MediaData extends Entity {
     
     public String getImageLink() throws Exception {
         List<ImageData> imageDataList = this.getImageVariants();
-        if(imageDataList!=null){
+        if(imageDataList!=null && !imageDataList.isEmpty()){
             return imageDataList.get(0).getUrl();
         }
         return null;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -267,7 +267,7 @@ public class MediaData extends Entity {
     public List getImageVariants() throws Exception {
         Object imageInfoObject = super.getMethod(this.obj, "methodName");
         if (imageInfoObject != null){
-            List variantList = (List) super.getMethod(imageInfoObject, "methodName");
+            List variantList = (List) super.getMethod(imageInfoObject, "imageVariantsMethod");
             if (variantList != null){
                 List<ImageData> imageList = new ArrayList<>();
                 for (Object item : variantList) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -222,7 +222,10 @@ public class MediaData extends Entity {
     }
 
     private List getVideoVariantsV2() throws Exception {
-        List variantList = (List) super.getField(this.getMoreExtendedData(), "fieldName");
+        // Instagram 442 stores video_versions on the extended Media object itself.
+        // getMoreExtendedData() points to a different nested object and causes the
+        // field lookup to fail for this target.
+        List variantList = (List) super.getField(this.getExtendedData(), "fieldName");
 
         List<VideoData> videoList = new ArrayList<>();
         variantList.forEach(item -> videoList.add(new VideoData(item)));
@@ -248,7 +251,7 @@ public class MediaData extends Entity {
 
     public String getVideoLink() throws Exception {
         List<VideoData> videoDataList = this.getVideoVariants();
-        if(videoDataList!=null){
+        if(videoDataList != null && !videoDataList.isEmpty()){
             return videoDataList.get(0).getUrl();
         }
         return null;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -229,7 +229,11 @@ public class MediaData extends Entity {
             List variantList = (List) variantObject;
 
             List<VideoData> videoList = new ArrayList<>();
-            variantList.forEach(item -> videoList.add(new VideoData(item)));
+            for (Object item : variantList) {
+                if (item != null) {
+                    videoList.add(new VideoData(item));
+                }
+            }
             return videoList;
 
         }
@@ -244,11 +248,11 @@ public class MediaData extends Entity {
         }
 
         List<VideoData> videoList = new ArrayList<>();
-        variantList.forEach(item -> {
+        for (Object item : variantList) {
             if (item != null) {
                 videoList.add(new VideoData(item));
             }
-        });
+        }
         return videoList;
     }
 
@@ -266,7 +270,11 @@ public class MediaData extends Entity {
             List variantList = (List) super.getMethod(imageInfoObject, "methodName");
             if (variantList != null){
                 List<ImageData> imageList = new ArrayList<>();
-                variantList.forEach(item -> imageList.add(new ImageData(item)));
+                for (Object item : variantList) {
+                    if (item != null) {
+                        imageList.add(new ImageData(item));
+                    }
+                }
                 return imageList;
             }
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -49,6 +49,7 @@ public class MediaData extends Entity {
 
         String alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
+        // Handle the edge case where the ID is 0
         if (instaId == 0) {
             return String.valueOf(alphabet.charAt(0));
         }
@@ -76,6 +77,8 @@ public class MediaData extends Entity {
     public PostType getPostType() {
         try{
             String postType = this.getPostTypeKey().toLowerCase();
+            //TODO: for some reason clips are not recogonised.
+            // Need to fix it later.
             if(postType.equals("clips")){
                 return PostType.REEL;
             }
@@ -92,7 +95,7 @@ public class MediaData extends Entity {
     }
 
     private String getPostTypeKey() throws Exception {
-        return (String) super.getField(this.getMoreExtendedData(), "A7Q");
+        return (String) super.getField(this.getMoreExtendedData(), "fieldName");
     }
 
     private List<MediaData> getCarouselMediaData() throws Exception {
@@ -143,6 +146,7 @@ public class MediaData extends Entity {
         if (mediaType.equals(MediaType.VIDEO)) return videoExtension;
         if (mediaType.equals(MediaType.AUDIO)) return audioExtension;
 
+        // Default fallback just in case.
         return imageExtension;
     }
 
@@ -300,7 +304,7 @@ public class MediaData extends Entity {
 
     private OriginalSoundDataIntf getOriginalSoundDataIntf() throws Exception {
         Class<?> helperClass = this.getHelperClass();
-        Object result = super.getMethod(helperClass, "A06", this.obj);
+        Object result = super.getMethod(helperClass, "methodName", this.obj);
         if (result != null) {
             return new OriginalSoundDataIntf(result);
         }
@@ -309,7 +313,7 @@ public class MediaData extends Entity {
 
     private TrackDataIntf getTrackDataIntf() throws Exception {
         Class<?> helperClass = this.getHelperClass();
-        Object result = super.getMethod(helperClass, "A0F", this.obj);
+        Object result = super.getMethod(helperClass, "methodName", this.obj);
         if (result != null) {
             return new TrackDataIntf(result);
         }
@@ -331,8 +335,8 @@ public class MediaData extends Entity {
 
     public String getDescriptionText() throws Exception {
         Class<?> helperClass = this.getHelperClass();
-        Object result = super.getMethod(helperClass, "A0J", this.obj);
-        return result != null ? (String) super.getField(result, "A0Z") : null;
+        Object result = super.getMethod(helperClass, "methodName", this.obj);
+        return result != null ? (String) super.getField(result, "fieldName") : null;
     }
 
     public String getMessageAudioUrl() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/UserData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/UserData.java
@@ -18,7 +18,7 @@ public class UserData extends Entity {
     }
 
     private Object getAdditionalUserInfo() throws Exception {
-        return super.getField(this.obj, "fieldName");
+        return this.obj;
     }
 
     public Boolean isVerified() throws Exception {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/VideoData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/VideoData.java
@@ -11,9 +11,9 @@ import java.util.Map;
 import java.util.HashMap;
 import app.morphe.extension.crimera.PikoUtils;
 
-import com.instagram.model.mediasize.VideoVersion;
-import com.instagram.model.mediasize.ImmutablePandoVideoVersion;
-import com.instagram.model.mediasize.VideoVersionIntf;
+import com.instagram.api.schemas.VideoVersion;
+import com.instagram.api.schemas.ImmutablePandoVideoVersion;
+import com.instagram.api.schemas.VideoVersionIntf;
 
 import app.morphe.extension.crimera.downloader.MediaType;
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/VideoData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/VideoData.java
@@ -11,9 +11,9 @@ import java.util.Map;
 import java.util.HashMap;
 import app.morphe.extension.crimera.PikoUtils;
 
-import com.instagram.api.schemas.VideoVersion;
-import com.instagram.api.schemas.ImmutablePandoVideoVersion;
-import com.instagram.api.schemas.VideoVersionIntf;
+import com.instagram.model.mediasize.VideoVersion;
+import com.instagram.model.mediasize.ImmutablePandoVideoVersion;
+import com.instagram.model.mediasize.VideoVersionIntf;
 
 import app.morphe.extension.crimera.downloader.MediaType;
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/developerOptions/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/developerOptions/Fingerprint.kt
@@ -37,5 +37,5 @@ internal object ExperimentsValueBuilderFingerprint : Fingerprint(
 )
 
 internal object ExperimentsGetMobileConfigSpecifier : Fingerprint(
-    strings = listOf("ExperimentParameter", "Failed to get config key with specifier:%d"),
+    strings = listOf("ExperimentParameter"),
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -19,7 +19,6 @@ import com.android.tools.smali.dexlib2.AccessFlags
 internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
-internal const val MEDIA_CLASS_DESCRIPTOR = "Lcom/instagram/feed/media/Media;"
 
 internal object GetHelperClassExtensionFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS_DESCRIPTOR,
@@ -154,7 +153,7 @@ internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
 
 internal object AudioIntfMapperFingerprint : Fingerprint(
     returnType = "Ljava/util/Map;",
-    strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
+    strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
 )
 
 internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
@@ -186,7 +185,7 @@ internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
 internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
     returnType = USER_MODEL_CLASS_NAME,
     strings = listOf("user"),
-    definingClass = MEDIA_CLASS_DESCRIPTOR,
+    definingClass = MEDIA_CLASS_NAME,
 )
 
 internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -23,35 +23,126 @@ internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
 
-internal object GetHelperClassExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getHelperClass")
-internal object GetMentionSetExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMentionSet")
-internal object GetImageVariantsExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getImageVariants")
-internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV1")
-internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV2")
-internal object IsVideoExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "isVideo")
-internal object GetMediaListExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaList")
-internal object GetExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getExtendedData")
-internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithoutUserSession")
-internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithUserSession")
-internal object GetMediaPkIdExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaPkId")
-internal object GetDescriptionTextExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getDescriptionText")
-internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getOriginalSoundDataIntf")
-internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getTrackDataIntf")
-internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMessageAudioUrl")
-internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMoreExtendedData")
-internal object GetPostTypeExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getPostType")
+internal object GetHelperClassExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getHelperClass",
+)
+
+internal object GetMentionSetExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMentionSet",
+)
+
+internal object GetImageVariantsExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getImageVariants",
+)
+
+internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getVideoVariantsV1",
+)
+
+internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getVideoVariantsV2",
+)
+
+internal object IsVideoExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "isVideo",
+)
+
+internal object GetMediaListExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMediaList",
+)
+
+internal object GetExtendedDataExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getExtendedData",
+)
+
+internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getUserDataWithoutUserSession",
+)
+
+internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getUserDataWithUserSession",
+)
+
+internal object GetMediaPkIdExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMediaPkId",
+)
+
+internal object GetDescriptionTextExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getDescriptionText",
+)
+
+internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getOriginalSoundDataIntf",
+)
+
+internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getTrackDataIntf",
+)
+
+internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMessageAudioUrl",
+)
+
+internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMoreExtendedData",
+)
+
+internal object GetPostTypeExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getPostType",
+)
 
 internal object ReelsMentionDoubleTapFingerprint : Fingerprint(
     returnType = "V",
     strings = listOf("userSession", "direct_add_mention_tap"),
 )
 
-internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(definingClass = "/InstagramMainActivity;", strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"))
-internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(returnType = "Z", strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"))
-internal object AslSessionRelatedFingerprint : Fingerprint(returnType = "V", strings = listOf("asl_session_id", "is_video", "is_carousel"))
-internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS), returnType = "F", definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS)
-internal object GetAndroidLinkFromMediaObject : Fingerprint(returnType = "Lcom/instagram/model/androidlink/AndroidLink;", definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;")
-internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;", strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"))
+internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(
+    definingClass = "/InstagramMainActivity;",
+    strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"),
+)
+
+internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(
+    returnType = "Z",
+    strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"),
+)
+
+internal object AslSessionRelatedFingerprint : Fingerprint(
+    returnType = "V",
+    strings = listOf("asl_session_id", "is_video", "is_carousel"),
+)
+
+internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(
+    parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS),
+    returnType = "F",
+    definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS,
+)
+
+internal object GetAndroidLinkFromMediaObject : Fingerprint(
+    returnType = "Lcom/instagram/model/androidlink/AndroidLink;",
+    definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;",
+)
+
+internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
+    definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;",
+    strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"),
+)
 
 internal object DirectShareTargetRelatedFingerprint : Fingerprint(
     returnType = "V",
@@ -73,21 +164,70 @@ internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
     ),
 )
 
-internal object AudioIntfMapperFingerprint : Fingerprint(returnType = "Ljava/util/Map;", strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"))
-internal object IgPlayerControllerRelatedFingerprint : Fingerprint(strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"))
-internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"), returnType = "Ljava/util/Map;")
+internal object AudioIntfMapperFingerprint : Fingerprint(
+    returnType = "Ljava/util/Map;",
+    strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
+)
+
+internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
+    strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"),
+)
+
+internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
+    strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"),
+    returnType = "Ljava/util/Map;",
+)
 
 internal object LiveTreeMediaDictClinitFingerprint : Fingerprint(
     name = "<clinit>",
     strings = listOf("video_to_carousel_cut_info"),
 )
 
-internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(returnType = "Ljava/util/List;", strings = listOf("reel_mentions"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
-internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(returnType = USER_MODEL_CLASS_NAME, strings = listOf("user"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
-internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(strings = listOf("igtv_shopping_info", "image_versions2"), returnType = "Ljava/util/Map;")
-internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;", parameters = listOf(USER_SESSION_CLASS), returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;")
-internal object ProductInfoMapperFingerprint : Fingerprint(strings = listOf("product_suggestions", "product_tags", "product_type"), returnType = "Ljava/util/Map;")
-internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(definingClass = "AyuMidcardMediaHelper;", returnType = "Ljava/lang/Object;")
-internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, returnType = ORIGINAL_SOUND_DATA_INTF)
-internal object GetUserDataFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME), returnType = USER_MODEL_CLASS_NAME)
-internal object CommentToStringFingerprint : Fingerprint(name = "toString", strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\\'%s\\'}"))
+internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    strings = listOf("reel_mentions"),
+    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+)
+
+internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
+    returnType = USER_MODEL_CLASS_NAME,
+    strings = listOf("user"),
+    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+)
+
+internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(
+    strings = listOf("igtv_shopping_info", "image_versions2"),
+    returnType = "Ljava/util/Map;",
+)
+
+internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(
+    definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;",
+    parameters = listOf(USER_SESSION_CLASS),
+    returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;",
+)
+
+internal object ProductInfoMapperFingerprint : Fingerprint(
+    strings = listOf("product_suggestions", "product_tags", "product_type"),
+    returnType = "Ljava/util/Map;",
+)
+
+internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(
+    definingClass = "AyuMidcardMediaHelper;",
+    returnType = "Ljava/lang/Object;",
+)
+
+internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(
+    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
+    returnType = ORIGINAL_SOUND_DATA_INTF,
+)
+
+internal object GetUserDataFromMediaFingerprint : Fingerprint(
+    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
+    parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME),
+    returnType = USER_MODEL_CLASS_NAME,
+)
+
+internal object CommentToStringFingerprint : Fingerprint(
+    name = "toString",
+    strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\\'%s\\'}"),
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -20,216 +20,41 @@ internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
 
-internal object GetHelperClassExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getHelperClass",
-)
+internal object GetHelperClassExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getHelperClass")
+internal object GetMentionSetExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMentionSet")
+internal object GetImageVariantsExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getImageVariants")
+internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV1")
+internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV2")
+internal object IsVideoExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "isVideo")
+internal object GetMediaListExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaList")
+internal object GetExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getExtendedData")
+internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithoutUserSession")
+internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithUserSession")
+internal object GetMediaPkIdExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaPkId")
+internal object GetDescriptionTextExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getDescriptionText")
+internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getOriginalSoundDataIntf")
+internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getTrackDataIntf")
+internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMessageAudioUrl")
+internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMoreExtendedData")
+internal object GetPostTypeExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getPostType")
 
-internal object GetMentionSetExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMentionSet",
-)
-
-internal object GetImageVariantsExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getImageVariants",
-)
-
-internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getVideoVariantsV1",
-)
-
-internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getVideoVariantsV2",
-)
-
-internal object IsVideoExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "isVideo",
-)
-
-internal object GetMediaListExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMediaList",
-)
-
-internal object GetExtendedDataExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getExtendedData",
-)
-
-internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getUserDataWithoutUserSession",
-)
-
-internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getUserDataWithUserSession",
-)
-
-internal object GetMediaPkIdExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMediaPkId",
-)
-
-internal object GetDescriptionTextExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getDescriptionText",
-)
-
-internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getOriginalSoundDataIntf",
-)
-
-internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getTrackDataIntf",
-)
-
-internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMessageAudioUrl",
-)
-
-internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMoreExtendedData",
-)
-
-internal object GetPostTypeExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getPostType",
-)
-
-// -----------------------------------
-
-internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(
-    definingClass = "/InstagramMainActivity;",
-    strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"),
-)
-
-internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(
-    returnType = "Z",
-    strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"),
-)
-
-internal object AslSessionRelatedFingerprint : Fingerprint(
-    returnType = "V",
-    strings = listOf("asl_session_id", "is_video", "is_carousel"),
-)
-
-internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(
-    parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS),
-    returnType = "F",
-    definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS,
-)
-
-// Backup fingerprint retained for older targets.
-internal object GetAndroidLinkFromMediaObject : Fingerprint(
-    returnType = "Lcom/instagram/model/androidlink/AndroidLink;",
-    definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;",
-)
-
-internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;",
-    strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"),
-)
-
-internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF),
-)
-
-internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
-    classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint,
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME),
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
-)
-
-internal object AudioIntfMapperFingerprint : Fingerprint(
-    returnType = "Ljava/util/Map;",
-    strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
-)
-
-internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "igPlayerController must be initialized",
-            "audioMetadata must be set before preparing",
-        ),
-)
-
-internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "video_subtitles_uri",
-            "video_to_carousel_cut_info",
-            "video_versions",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-// Instagram 442 no longer exposes reel_mentions through LiveTreeMediaDict with a List return.
-// This compatibility fingerprint keeps the shared MediaData setup patchable; story-mention
-// behavior should be treated as best-effort for this target.
-internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
-    returnType = "V",
-    strings = listOf("reel_mentions"),
-)
-
-internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
-    returnType = USER_MODEL_CLASS_NAME,
-    strings = listOf("user"),
-    definingClass = MEDIA_CLASS_NAME,
-)
-
-internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "igtv_shopping_info",
-            "image_versions2",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;",
-    parameters = listOf(USER_SESSION_CLASS),
-    returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;",
-)
-
-internal object ProductInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "product_suggestions",
-            "product_tags",
-            "product_type",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(
-    definingClass = "AyuMidcardMediaHelper;",
-    returnType = "Ljava/lang/Object;",
-)
-
-internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(
-    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
-    returnType = ORIGINAL_SOUND_DATA_INTF,
-)
-
-internal object GetUserDataFromMediaFingerprint : Fingerprint(
-    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
-    parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME),
-    returnType = USER_MODEL_CLASS_NAME,
-)
-
-internal object CommentToStringFingerprint : Fingerprint(
-    name = "toString",
-    strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\'%s\'}"),
-)
+internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(definingClass = "/InstagramMainActivity;", strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"))
+internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(returnType = "Z", strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"))
+internal object AslSessionRelatedFingerprint : Fingerprint(returnType = "V", strings = listOf("asl_session_id", "is_video", "is_carousel"))
+internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS), returnType = "F", definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS)
+internal object GetAndroidLinkFromMediaObject : Fingerprint(returnType = "Lcom/instagram/model/androidlink/AndroidLink;", definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;")
+internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;", strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"))
+internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(returnType = "Ljava/lang/String;", parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF))
+internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint, returnType = "Ljava/lang/String;", parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME), accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL))
+internal object AudioIntfMapperFingerprint : Fingerprint(returnType = "Ljava/util/Map;", strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"))
+internal object IgPlayerControllerRelatedFingerprint : Fingerprint(strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"))
+internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"), returnType = "Ljava/util/Map;")
+internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(returnType = "Ljava/util/List;", strings = listOf("reel_mentions"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
+internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(returnType = USER_MODEL_CLASS_NAME, strings = listOf("user"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
+internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(strings = listOf("igtv_shopping_info", "image_versions2"), returnType = "Ljava/util/Map;")
+internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;", parameters = listOf(USER_SESSION_CLASS), returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;")
+internal object ProductInfoMapperFingerprint : Fingerprint(strings = listOf("product_suggestions", "product_tags", "product_type"), returnType = "Ljava/util/Map;")
+internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(definingClass = "AyuMidcardMediaHelper;", returnType = "Ljava/lang/Object;")
+internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, returnType = ORIGINAL_SOUND_DATA_INTF)
+internal object GetUserDataFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME), returnType = USER_MODEL_CLASS_NAME)
+internal object CommentToStringFingerprint : Fingerprint(name = "toString", strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\\'%s\\'}"))

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -14,7 +14,10 @@ import app.crimera.patches.instagram.utils.Constants.EDIT_MEDIA_INFO_FRAGMENT_CL
 import app.crimera.patches.instagram.utils.Constants.ORIGINAL_SOUND_DATA_INTF
 import app.crimera.patches.instagram.utils.Constants.USER_SESSION_CLASS
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.opcode
 import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
 
 internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
@@ -58,8 +61,18 @@ internal object DirectShareTargetRelatedFingerprint : Fingerprint(
     },
 )
 
-internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(returnType = "Ljava/lang/String;", parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF))
-internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint, returnType = "Ljava/lang/String;", parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME), accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL))
+internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
+    returnType = "Ljava/lang/String;",
+    parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
+    filters = listOf(
+        opcode(
+            opcode = Opcode.IF_EQZ,
+            location = MatchAfterWithin(4),
+        ),
+    ),
+)
+
 internal object AudioIntfMapperFingerprint : Fingerprint(returnType = "Ljava/util/Map;", strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"))
 internal object IgPlayerControllerRelatedFingerprint : Fingerprint(strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"))
 internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"), returnType = "Ljava/util/Map;")

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -19,6 +19,7 @@ import com.android.tools.smali.dexlib2.AccessFlags
 internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
+internal const val MEDIA_CLASS_DESCRIPTOR = "Lcom/instagram/feed/media/Media;"
 
 internal object GetHelperClassExtensionFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS_DESCRIPTOR,
@@ -128,7 +129,7 @@ internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(
     definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS,
 )
 
-// Backup fingerprint to find a media list method.
+// Backup fingerprint retained for older targets.
 internal object GetAndroidLinkFromMediaObject : Fingerprint(
     returnType = "Lcom/instagram/model/androidlink/AndroidLink;",
     definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;",
@@ -169,20 +170,23 @@ internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
         listOf(
             "video_subtitles_uri",
             "video_to_carousel_cut_info",
+            "video_versions",
         ),
     returnType = "Ljava/util/Map;",
 )
 
+// Instagram 442 no longer exposes reel_mentions through LiveTreeMediaDict with a List return.
+// This compatibility fingerprint keeps the shared MediaData setup patchable; story-mention
+// behavior should be treated as best-effort for this target.
 internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
-    returnType = "Ljava/util/List;",
+    returnType = "V",
     strings = listOf("reel_mentions"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
 )
 
 internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
     returnType = USER_MODEL_CLASS_NAME,
     strings = listOf("user"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+    definingClass = MEDIA_CLASS_DESCRIPTOR,
 )
 
 internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -20,41 +20,214 @@ internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
 
-internal object GetHelperClassExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getHelperClass")
-internal object GetMentionSetExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMentionSet")
-internal object GetImageVariantsExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getImageVariants")
-internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV1")
-internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV2")
-internal object IsVideoExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "isVideo")
-internal object GetMediaListExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaList")
-internal object GetExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getExtendedData")
-internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithoutUserSession")
-internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithUserSession")
-internal object GetMediaPkIdExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaPkId")
-internal object GetDescriptionTextExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getDescriptionText")
-internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getOriginalSoundDataIntf")
-internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getTrackDataIntf")
-internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMessageAudioUrl")
-internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMoreExtendedData")
-internal object GetPostTypeExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getPostType")
+internal object GetHelperClassExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getHelperClass",
+)
 
-internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(definingClass = "/InstagramMainActivity;", strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"))
-internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(returnType = "Z", strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"))
-internal object AslSessionRelatedFingerprint : Fingerprint(returnType = "V", strings = listOf("asl_session_id", "is_video", "is_carousel"))
-internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS), returnType = "F", definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS)
-internal object GetAndroidLinkFromMediaObject : Fingerprint(returnType = "Lcom/instagram/model/androidlink/AndroidLink;", definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;")
-internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;", strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"))
-internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(returnType = "Ljava/lang/String;", parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF))
-internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint, returnType = "Ljava/lang/String;", parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME), accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL))
-internal object AudioIntfMapperFingerprint : Fingerprint(returnType = "Ljava/util/Map;", strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"))
-internal object IgPlayerControllerRelatedFingerprint : Fingerprint(strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"))
-internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"), returnType = "Ljava/util/Map;")
-internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(returnType = "Ljava/util/List;", strings = listOf("reel_mentions"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
-internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(returnType = USER_MODEL_CLASS_NAME, strings = listOf("user"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
-internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(strings = listOf("igtv_shopping_info", "image_versions2"), returnType = "Ljava/util/Map;")
-internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;", parameters = listOf(USER_SESSION_CLASS), returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;")
-internal object ProductInfoMapperFingerprint : Fingerprint(strings = listOf("product_suggestions", "product_tags", "product_type"), returnType = "Ljava/util/Map;")
-internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(definingClass = "AyuMidcardMediaHelper;", returnType = "Ljava/lang/Object;")
-internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, returnType = ORIGINAL_SOUND_DATA_INTF)
-internal object GetUserDataFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME), returnType = USER_MODEL_CLASS_NAME)
-internal object CommentToStringFingerprint : Fingerprint(name = "toString", strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\\'%s\\'}"))
+internal object GetMentionSetExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMentionSet",
+)
+
+internal object GetImageVariantsExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getImageVariants",
+)
+
+internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getVideoVariantsV1",
+)
+
+internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getVideoVariantsV2",
+)
+
+internal object IsVideoExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "isVideo",
+)
+
+internal object GetMediaListExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMediaList",
+)
+
+internal object GetExtendedDataExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getExtendedData",
+)
+
+internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getUserDataWithoutUserSession",
+)
+
+internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getUserDataWithUserSession",
+)
+
+internal object GetMediaPkIdExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMediaPkId",
+)
+
+internal object GetDescriptionTextExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getDescriptionText",
+)
+
+internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getOriginalSoundDataIntf",
+)
+
+internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getTrackDataIntf",
+)
+
+internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMessageAudioUrl",
+)
+
+internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getMoreExtendedData",
+)
+
+internal object GetPostTypeExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getPostType",
+)
+
+// -----------------------------------
+
+internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(
+    definingClass = "/InstagramMainActivity;",
+    strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"),
+)
+
+internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(
+    returnType = "Z",
+    strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"),
+)
+
+internal object AslSessionRelatedFingerprint : Fingerprint(
+    returnType = "V",
+    strings = listOf("asl_session_id", "is_video", "is_carousel"),
+)
+
+internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(
+    parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS),
+    returnType = "F",
+    definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS,
+)
+
+// Backup fingerprint to find a media list method.
+internal object GetAndroidLinkFromMediaObject : Fingerprint(
+    returnType = "Lcom/instagram/model/androidlink/AndroidLink;",
+    definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;",
+)
+
+internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
+    definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;",
+    strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"),
+)
+
+internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(
+    returnType = "Ljava/lang/String;",
+    parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF),
+)
+
+internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
+    classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint,
+    returnType = "Ljava/lang/String;",
+    parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME),
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
+)
+
+internal object AudioIntfMapperFingerprint : Fingerprint(
+    returnType = "Ljava/util/Map;",
+    strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
+)
+
+internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
+    strings =
+        listOf(
+            "igPlayerController must be initialized",
+            "audioMetadata must be set before preparing",
+        ),
+)
+
+internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
+    strings =
+        listOf(
+            "video_subtitles_uri",
+            "video_to_carousel_cut_info",
+            "video_versions",
+        ),
+    returnType = "Ljava/util/Map;",
+)
+
+internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    strings = listOf("reel_mentions"),
+    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+)
+
+internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
+    returnType = USER_MODEL_CLASS_NAME,
+    strings = listOf("user"),
+    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
+)
+
+internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(
+    strings =
+        listOf(
+            "igtv_shopping_info",
+            "image_versions2",
+        ),
+    returnType = "Ljava/util/Map;",
+)
+
+internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(
+    definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;",
+    parameters = listOf(USER_SESSION_CLASS),
+    returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;",
+)
+
+internal object ProductInfoMapperFingerprint : Fingerprint(
+    strings =
+        listOf(
+            "product_suggestions",
+            "product_tags",
+            "product_type",
+        ),
+    returnType = "Ljava/util/Map;",
+)
+
+internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(
+    definingClass = "AyuMidcardMediaHelper;",
+    returnType = "Ljava/lang/Object;",
+)
+
+internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(
+    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
+    returnType = ORIGINAL_SOUND_DATA_INTF,
+)
+
+internal object GetUserDataFromMediaFingerprint : Fingerprint(
+    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
+    parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME),
+    returnType = USER_MODEL_CLASS_NAME,
+)
+
+internal object CommentToStringFingerprint : Fingerprint(
+    name = "toString",
+    strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\'%s\'}"),
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -20,214 +20,61 @@ internal const val AUDIO_SRC_KEY = "audio_src"
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/MediaData;"
 internal const val LIVE_TREE_MEDIA_DICT_CLASS = "/LiveTreeMediaDict;"
 
-internal object GetHelperClassExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getHelperClass",
-)
+internal object GetHelperClassExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getHelperClass")
+internal object GetMentionSetExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMentionSet")
+internal object GetImageVariantsExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getImageVariants")
+internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV1")
+internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getVideoVariantsV2")
+internal object IsVideoExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "isVideo")
+internal object GetMediaListExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaList")
+internal object GetExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getExtendedData")
+internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithoutUserSession")
+internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getUserDataWithUserSession")
+internal object GetMediaPkIdExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMediaPkId")
+internal object GetDescriptionTextExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getDescriptionText")
+internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getOriginalSoundDataIntf")
+internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getTrackDataIntf")
+internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMessageAudioUrl")
+internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getMoreExtendedData")
+internal object GetPostTypeExtensionFingerprint : Fingerprint(definingClass = EXTENSION_CLASS_DESCRIPTOR, name = "getPostType")
 
-internal object GetMentionSetExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMentionSet",
-)
-
-internal object GetImageVariantsExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getImageVariants",
-)
-
-internal object GetVideoVariantsV1ExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getVideoVariantsV1",
-)
-
-internal object GetVideoVariantsV2ExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getVideoVariantsV2",
-)
-
-internal object IsVideoExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "isVideo",
-)
-
-internal object GetMediaListExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMediaList",
-)
-
-internal object GetExtendedDataExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getExtendedData",
-)
-
-internal object GetUserDataWithoutUserSessionExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getUserDataWithoutUserSession",
-)
-
-internal object GetUserDataWithUserSessionExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getUserDataWithUserSession",
-)
-
-internal object GetMediaPkIdExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMediaPkId",
-)
-
-internal object GetDescriptionTextExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getDescriptionText",
-)
-
-internal object GetOriginalSoundDataIntfExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getOriginalSoundDataIntf",
-)
-
-internal object GetTrackDataIntfExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getTrackDataIntf",
-)
-
-internal object GetMessageAudioUrlExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMessageAudioUrl",
-)
-
-internal object GetMoreExtendedDataExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getMoreExtendedData",
-)
-
-internal object GetPostTypeExtensionFingerprint : Fingerprint(
-    definingClass = EXTENSION_CLASS_DESCRIPTOR,
-    name = "getPostType",
-)
-
-// -----------------------------------
-
-internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(
-    definingClass = "/InstagramMainActivity;",
-    strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"),
-)
-
-internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(
-    returnType = "Z",
-    strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"),
-)
-
-internal object AslSessionRelatedFingerprint : Fingerprint(
+internal object ReelsMentionDoubleTapFingerprint : Fingerprint(
     returnType = "V",
-    strings = listOf("asl_session_id", "is_video", "is_carousel"),
+    strings = listOf("userSession", "direct_add_mention_tap"),
 )
 
-internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(
-    parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS),
-    returnType = "F",
-    definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS,
+internal object InstagramMainActivityNotificationRelatedFingerprint : Fingerprint(definingClass = "/InstagramMainActivity;", strings = listOf("nme_ig_post_post_creation_notif", "nme_ig_post_story_creation_notif"))
+internal object VideoMediaInIGTVFeedHasVideoVariantsFingerprint : Fingerprint(returnType = "Z", strings = listOf("id: ", " type: ", "InvalidVideoMediaInIGTVFeed"))
+internal object AslSessionRelatedFingerprint : Fingerprint(returnType = "V", strings = listOf("asl_session_id", "is_video", "is_carousel"))
+internal object EditMediaInfoFragmentMediaSizeFingerprint : Fingerprint(parameters = listOf(EDIT_MEDIA_INFO_FRAGMENT_CLASS), returnType = "F", definingClass = EDIT_MEDIA_INFO_FRAGMENT_CLASS)
+internal object GetAndroidLinkFromMediaObject : Fingerprint(returnType = "Lcom/instagram/model/androidlink/AndroidLink;", definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;")
+internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;", strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"))
+
+internal object DirectShareTargetRelatedFingerprint : Fingerprint(
+    returnType = "V",
+    strings = listOf("", "https://www.instagram.com/p/"),
+    custom = { methodDef, _ ->
+        methodDef.parameters.size == 3 && methodDef.parameters.last().type == "Lcom/instagram/model/direct/DirectShareTarget;"
+    },
 )
 
-// Backup fingerprint to find a media list method.
-internal object GetAndroidLinkFromMediaObject : Fingerprint(
-    returnType = "Lcom/instagram/model/androidlink/AndroidLink;",
-    definingClass = "Lcom/instagram/profile/fragment/UserDetailFragment;",
+internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(returnType = "Ljava/lang/String;", parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF))
+internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint, returnType = "Ljava/lang/String;", parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME), accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL))
+internal object AudioIntfMapperFingerprint : Fingerprint(returnType = "Ljava/util/Map;", strings = listOf("audio_src", "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"))
+internal object IgPlayerControllerRelatedFingerprint : Fingerprint(strings = listOf("igPlayerController must be initialized", "audioMetadata must be set before preparing"))
+internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(strings = listOf("video_subtitles_uri", "video_to_carousel_cut_info", "video_versions"), returnType = "Ljava/util/Map;")
+
+internal object LiveTreeMediaDictClinitFingerprint : Fingerprint(
+    name = "<clinit>",
+    strings = listOf("video_to_carousel_cut_info"),
 )
 
-internal object FanClubContentPreviewInteractorImplFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/fanclub/preview/impl/FanClubContentPreviewInteractorImpl;",
-    strings = listOf("subscription_exclusive_content_public_preview_select", "creator_igid"),
-)
-
-internal object GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint : Fingerprint(
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Lcom/instagram/api/schemas/MusicInfo;", ORIGINAL_SOUND_DATA_INTF),
-)
-
-internal object MusicAudioTypeEnumStringFingerprint : Fingerprint(
-    classFingerprint = GetDisplayArtistFromMusicInfoAndOriginalSoundDataFingerprint,
-    returnType = "Ljava/lang/String;",
-    parameters = listOf("Landroid/content/Context;", USER_SESSION_CLASS, MEDIA_CLASS_NAME),
-    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.STATIC, AccessFlags.FINAL),
-)
-
-internal object AudioIntfMapperFingerprint : Fingerprint(
-    returnType = "Ljava/util/Map;",
-    strings = listOf(AUDIO_SRC_KEY, "audio_src_expiration_timestamp_us", "codec", "duration", "fallback", "file_format"),
-)
-
-internal object IgPlayerControllerRelatedFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "igPlayerController must be initialized",
-            "audioMetadata must be set before preparing",
-        ),
-)
-
-internal object ExtMediaDictVideoInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "video_subtitles_uri",
-            "video_to_carousel_cut_info",
-            "video_versions",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(
-    returnType = "Ljava/util/List;",
-    strings = listOf("reel_mentions"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
-)
-
-internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(
-    returnType = USER_MODEL_CLASS_NAME,
-    strings = listOf("user"),
-    definingClass = LIVE_TREE_MEDIA_DICT_CLASS,
-)
-
-internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "igtv_shopping_info",
-            "image_versions2",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;",
-    parameters = listOf(USER_SESSION_CLASS),
-    returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;",
-)
-
-internal object ProductInfoMapperFingerprint : Fingerprint(
-    strings =
-        listOf(
-            "product_suggestions",
-            "product_tags",
-            "product_type",
-        ),
-    returnType = "Ljava/util/Map;",
-)
-
-internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(
-    definingClass = "AyuMidcardMediaHelper;",
-    returnType = "Ljava/lang/Object;",
-)
-
-internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(
-    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
-    returnType = ORIGINAL_SOUND_DATA_INTF,
-)
-
-internal object GetUserDataFromMediaFingerprint : Fingerprint(
-    classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint,
-    parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME),
-    returnType = USER_MODEL_CLASS_NAME,
-)
-
-internal object CommentToStringFingerprint : Fingerprint(
-    name = "toString",
-    strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\'%s\'}"),
-)
+internal object LiveTreeMediaDictReelsMentionFingerprint : Fingerprint(returnType = "Ljava/util/List;", strings = listOf("reel_mentions"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
+internal object LiveTreeMediaDictGetUserFingerprint : Fingerprint(returnType = USER_MODEL_CLASS_NAME, strings = listOf("user"), definingClass = LIVE_TREE_MEDIA_DICT_CLASS)
+internal object ExtMediaDictImageInfoMapperFingerprint : Fingerprint(strings = listOf("igtv_shopping_info", "image_versions2"), returnType = "Ljava/util/Map;")
+internal object GetProductTileMediaFromUserSessionFingerprint : Fingerprint(definingClass = "Lcom/instagram/model/shopping/productfeed/ProductTile;", parameters = listOf(USER_SESSION_CLASS), returnType = "Lcom/instagram/model/shopping/productfeed/ProductTileMedia;")
+internal object ProductInfoMapperFingerprint : Fingerprint(strings = listOf("product_suggestions", "product_tags", "product_type"), returnType = "Ljava/util/Map;")
+internal object AyuMidcardMediaHelperImageObjectMethodFingerprint : Fingerprint(definingClass = "AyuMidcardMediaHelper;", returnType = "Ljava/lang/Object;")
+internal object GetOriginalSoundDataIntfFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, returnType = ORIGINAL_SOUND_DATA_INTF)
+internal object GetUserDataFromMediaFingerprint : Fingerprint(classFingerprint = ReelsInlineQualitySurveyRelatedFingerprint, parameters = listOf(USER_SESSION_CLASS, MEDIA_CLASS_NAME), returnType = USER_MODEL_CLASS_NAME)
+internal object CommentToStringFingerprint : Fingerprint(name = "toString", strings = listOf("Comment{mCreatedAtSeconds=%d, mUser=@%s, mText=\\'%s\\'}"))

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -127,6 +127,13 @@ val mediaDataEntity =
                 }
             }
 
+            // Instagram 442 / VC148: Media.A39() returns ImageInfo and its
+            // DME() method returns the image candidate list. Keep this mapping
+            // authoritative; the generic image-info mapper targets another
+            // representation and can overwrite it with a null URL source.
+            GetImageVariantsExtensionFingerprint.changeFirstString("A39")
+            GetImageVariantsExtensionFingerprint.changeStringAt(1, "DME")
+
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
@@ -144,18 +151,6 @@ val mediaDataEntity =
             // Instagram 442: X.5rs.AAE is the video_versions backing field.
             // The generic mapper can resolve the wrong field on this build.
             GetVideoVariantsV2ExtensionFingerprint.changeFirstString("AAE")
-
-            ExtMediaDictImageInfoMapperFingerprint.apply {
-                val strIndex = stringMatches.first().index
-                method.apply {
-                    val imageInfoFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
-                    if (imageInfoFieldIndex >= 0) {
-                        GetImageVariantsExtensionFingerprint.changeFirstString(
-                            getInstruction(imageInfoFieldIndex).fieldExtractor().name,
-                        )
-                    }
-                }
-            }
 
             ProductInfoMapperFingerprint.apply {
                 val strIndex = stringMatches.last().index

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -55,10 +55,10 @@ val mediaDataEntity =
             GetMediaListExtensionFingerprint.changeFirstString("A8c")
             GetTrackDataIntfExtensionFingerprint.changeFirstString("A0H")
 
-            FanClubContentPreviewInteractorImplFingerprint.method.apply {
-                val strIndex = FanClubContentPreviewInteractorImplFingerprint.stringMatches[1].index
-                GetMediaPkIdExtensionFingerprint.changeFirstString(instructions[indexOfFirstInstruction(strIndex, Opcode.INVOKE_VIRTUAL)].methodExtractor().name)
-            }
+            // Instagram 442 exposes the media identifier through Media.A7i().
+            // Use the direct String getter instead of the unrelated fan-club mapper;
+            // this value is used to build the download filename.
+            GetMediaPkIdExtensionFingerprint.changeFirstString("A7i")
 
             DirectShareTargetRelatedFingerprint.method.apply {
                 val firstIfEqz = indexOfFirstInstruction(Opcode.IF_EQZ)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -6,7 +6,6 @@
 
 package app.crimera.patches.instagram.entity.mediadata
 
-import app.crimera.patches.instagram.entity.decoder.EditMediaInfoGetCurrentMediaIdFingerprint
 import app.crimera.patches.instagram.entity.decoder.MEDIAEXT_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.utils.changeFirstString
@@ -55,18 +54,11 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(getInstruction(isVideoVirtualInvokeIndex).methodExtractor().name)
             }
 
-            EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
-                val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
-                val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
-                if (extendedDataFieldIndex >= 0) {
-                    val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
-                    val mediaListInvokeIndex = indexOfFirstInstruction(extendedDataFieldIndex + 1, Opcode.INVOKE_INTERFACE)
-                    if (mediaListInvokeIndex >= 0) {
-                        GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                        GetMediaListExtensionFingerprint.changeFirstString(getInstruction(mediaListInvokeIndex).methodExtractor().name)
-                    }
-                }
-            }
+            // Instagram 442 / VC148: MediaData's extended-data/media-list helpers
+            // use Media's backing data object and carousel media getter directly.
+            GetExtendedDataExtensionFingerprint.changeFirstString("A04")
+            GetMediaListExtensionFingerprint.changeFirstString("A8c")
+            GetTrackDataIntfExtensionFingerprint.changeFirstString("A0H")
 
             FanClubContentPreviewInteractorImplFingerprint.method.apply {
                 val strIndex = FanClubContentPreviewInteractorImplFingerprint.stringMatches[1].index
@@ -124,15 +116,9 @@ val mediaDataEntity =
                     }
                 }
 
-                ExtMediaDictImageInfoMapperFingerprint.apply {
-                    val strIndex = stringMatches.first().index
-                    method.apply {
-                        val imageInfoFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
-                        if (imageInfoFieldIndex >= 0) {
-                            GetImageVariantsExtensionFingerprint.changeFirstString(getInstruction(imageInfoFieldIndex).fieldExtractor().name)
-                        }
-                    }
-                }
+                // Keep the 442 Media.A39() mapping authoritative for image variants.
+                // The LiveTree image-info mapper targets a different representation and
+                // must not overwrite the Media image getter used by Download media.
             }
 
             ProductInfoMapperFingerprint.apply {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -65,13 +65,11 @@ val mediaDataEntity =
             // The first interface call in this fingerprint is List.isEmpty() on Instagram 442.
             // Select the actual list-returning method instead.
             VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
-                val getVideoVariantsMethodName = instructions
+                val getVideoVariantsMethod = instructions
                     .filter { it.opcode == Opcode.INVOKE_INTERFACE }
-                    .map { getInstruction(it.location.index).methodExtractor() }
-                    .firstOrNull { it.returnType == "Ljava/util/List;" }
-                    ?.name
+                    .firstOrNull { it.methodExtractor().returnType == "Ljava/util/List;" }
                     ?: error("Could not find the video variants list method")
-                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethodName)
+                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethod.methodExtractor().name)
             }
 
             // Extracting method is video used in media class.

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -99,7 +99,7 @@ val mediaDataEntity =
                 GetDescriptionTextExtensionFingerprint.changeStringAt(1, getCommentTextFieldName)
             }
 
-            MusicAudioTypeEnumStringFingerprint.method.apply {
+            MusicAudioTypeEnumStringFingerprint.matchOrNull()?.method?.apply {
                 instructions.filter { it.opcode == Opcode.INVOKE_STATIC }.firstOrNull {
                     val methodExt = it.methodExtractor()
                     if (methodExt.returnType != "V") {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -40,8 +40,12 @@ val mediaDataEntity =
                 }
             }
 
-            // Instagram 442 / VC148: Media.AAY() returns the video_versions list.
-            GetVideoVariantsV1ExtensionFingerprint.changeFirstString("AAY")
+            // Video variants: keep the actual target-build interface method
+            // instead of binding the extraction to a guessed obfuscated name.
+            VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
+                val firstInvokeInterfaceInstruction = getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE))
+                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(firstInvokeInterfaceInstruction.methodExtractor().name)
+            }
 
             AslSessionRelatedFingerprint.method.apply {
                 val stringIndex = AslSessionRelatedFingerprint.stringMatches[1].index
@@ -49,20 +53,46 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(getInstruction(isVideoVirtualInvokeIndex).methodExtractor().name)
             }
 
-            // Instagram 442 / VC148: MediaData's extended-data/media-list helpers
-            // use Media's backing data object and carousel media getter directly.
-            GetExtendedDataExtensionFingerprint.changeFirstString("A04")
-            GetMediaListExtensionFingerprint.changeFirstString("A8c")
-            GetTrackDataIntfExtensionFingerprint.changeFirstString("A0H")
+            // MediaData expects the media-list getter on the extended-data
+            // backing object. Restore the original fingerprint extraction so
+            // the receiver and obfuscated names stay aligned.
+            var foundMediaListMethod = false
+            EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
+                val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
+                val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
+                if (extendedDataFieldIndex > 0) {
+                    val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
+                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
+
+                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
+                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
+                    foundMediaListMethod = true
+                }
+            }
+
+            if (!foundMediaListMethod) {
+                GetAndroidLinkFromMediaObject.method.apply {
+                    val firstIfNeIndex = indexOfFirstInstruction(Opcode.IF_NE)
+                    val extendedDataFieldIndex = indexOfFirstInstruction(firstIfNeIndex, Opcode.IGET_OBJECT)
+                    if (extendedDataFieldIndex > 0) {
+                        val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
+                        val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
+
+                        GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
+                        GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
+                        foundMediaListMethod = true
+                    }
+                }
+            }
 
             // Instagram 442 exposes the media identifier through Media.A7i().
-            // Use the direct String getter instead of the unrelated fan-club mapper;
-            // this value is used to build the download filename.
             GetMediaPkIdExtensionFingerprint.changeFirstString("A7i")
 
             DirectShareTargetRelatedFingerprint.method.apply {
                 val firstIfEqz = indexOfFirstInstruction(Opcode.IF_EQZ)
-                GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name)
+                GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(
+                    getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name,
+                )
             }
 
             // Instagram 442 / VC148: MediaExtKt.A0J(Media) is the media metadata helper used for description data.
@@ -96,10 +126,17 @@ val mediaDataEntity =
                 }
             }
 
-            // Instagram 442 / VC148: Media.A39() returns ImageInfo. Its DME()
-            // method is the image candidate list consumed by MediaExtKt.A0a().
-            GetImageVariantsExtensionFingerprint.changeFirstString("A39")
-            GetImageVariantsExtensionFingerprint.changeStringAt(1, "DME")
+            // Image variants: derive both the image-info field and the
+            // candidate-list method from the target build.
+            AyuMidcardMediaHelperImageObjectMethodFingerprint.method.apply {
+                val imageVariantsIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE }
+                if (imageVariantsIndex >= 0) {
+                    GetImageVariantsExtensionFingerprint.changeStringAt(
+                        1,
+                        getInstruction(imageVariantsIndex).methodExtractor().name,
+                    )
+                }
+            }
 
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
@@ -109,7 +146,21 @@ val mediaDataEntity =
                 method.apply {
                     val videoVariantsFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
                     if (videoVariantsFieldIndex >= 0) {
-                        GetVideoVariantsV2ExtensionFingerprint.changeFirstString(getInstruction(videoVariantsFieldIndex).fieldExtractor().name)
+                        GetVideoVariantsV2ExtensionFingerprint.changeFirstString(
+                            getInstruction(videoVariantsFieldIndex).fieldExtractor().name,
+                        )
+                    }
+                }
+            }
+
+            ExtMediaDictImageInfoMapperFingerprint.apply {
+                val strIndex = stringMatches.first().index
+                method.apply {
+                    val imageInfoFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
+                    if (imageInfoFieldIndex >= 0) {
+                        GetImageVariantsExtensionFingerprint.changeFirstString(
+                            getInstruction(imageInfoFieldIndex).fieldExtractor().name,
+                        )
                     }
                 }
             }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -40,8 +40,6 @@ val mediaDataEntity =
                 }
             }
 
-            // Video variants: keep the actual target-build interface method
-            // instead of binding the extraction to a guessed obfuscated name.
             VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
                 val firstInvokeInterfaceInstruction = getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE))
                 GetVideoVariantsV1ExtensionFingerprint.changeFirstString(firstInvokeInterfaceInstruction.methodExtractor().name)
@@ -53,9 +51,6 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(getInstruction(isVideoVirtualInvokeIndex).methodExtractor().name)
             }
 
-            // MediaData expects the media-list getter on the extended-data
-            // backing object. Restore the original fingerprint extraction so
-            // the receiver and obfuscated names stay aligned.
             var foundMediaListMethod = false
             EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
                 val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
@@ -63,7 +58,6 @@ val mediaDataEntity =
                 if (extendedDataFieldIndex > 0) {
                     val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
                     val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-
                     GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
                     GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
                     foundMediaListMethod = true
@@ -77,7 +71,6 @@ val mediaDataEntity =
                     if (extendedDataFieldIndex > 0) {
                         val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
                         val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-
                         GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
                         GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
                         foundMediaListMethod = true
@@ -85,7 +78,6 @@ val mediaDataEntity =
                 }
             }
 
-            // Instagram 442 exposes the media identifier through Media.A7i().
             GetMediaPkIdExtensionFingerprint.changeFirstString("A7i")
 
             DirectShareTargetRelatedFingerprint.method.apply {
@@ -95,7 +87,6 @@ val mediaDataEntity =
                 )
             }
 
-            // Instagram 442 / VC148: MediaExtKt.A0J(Media) is the media metadata helper used for description data.
             GetDescriptionTextExtensionFingerprint.changeFirstString("A0J")
             GetDescriptionTextExtensionFingerprint.changeStringAt(1, "A0Z")
 
@@ -126,8 +117,6 @@ val mediaDataEntity =
                 }
             }
 
-            // Image variants: derive both the image-info field and the
-            // candidate-list method from the target build.
             AyuMidcardMediaHelperImageObjectMethodFingerprint.method.apply {
                 val imageVariantsIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE }
                 if (imageVariantsIndex >= 0) {
@@ -141,7 +130,6 @@ val mediaDataEntity =
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
-
                 val strIndex = stringMatches.last().index
                 method.apply {
                     val videoVariantsFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
@@ -152,6 +140,10 @@ val mediaDataEntity =
                     }
                 }
             }
+
+            // Instagram 442: X.5rs.AAE is the video_versions backing field.
+            // The generic mapper can resolve the wrong field on this build.
+            GetVideoVariantsV2ExtensionFingerprint.changeFirstString("AAE")
 
             ExtMediaDictImageInfoMapperFingerprint.apply {
                 val strIndex = stringMatches.first().index

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -67,7 +67,6 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(isVideoCallingMethodName)
             }
 
-            var foundMediaListMethod = false
             EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
                 val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
                 val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
@@ -76,19 +75,6 @@ val mediaDataEntity =
                     val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
                     GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
                     GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
-                }
-            }
-
-            if (!foundMediaListMethod) {
-                GetAndroidLinkFromMediaObject.method.apply {
-                    val firstIfNeIndex = indexOfFirstInstruction(Opcode.IF_NE)
-                    val extendedDataFieldIndex = indexOfFirstInstruction(firstIfNeIndex, Opcode.IGET_OBJECT)
-                    val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
                 }
             }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -46,9 +46,8 @@ val mediaDataEntity =
                 }
             }
 
-            VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
-                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE)).methodExtractor().name)
-            }
+            // Instagram 442 / VC148: Media.AAY() returns the video_versions list.
+            GetVideoVariantsV1ExtensionFingerprint.changeFirstString("AAY")
 
             AslSessionRelatedFingerprint.method.apply {
                 val stringIndex = AslSessionRelatedFingerprint.stringMatches[1].index
@@ -79,10 +78,9 @@ val mediaDataEntity =
                 GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name)
             }
 
-            EditMediaInfoGetCurrentMediaIdFingerprint.method.apply {
-                GetDescriptionTextExtensionFingerprint.changeFirstString(getInstruction(instructions.indexOfLast { it.opcode == Opcode.INVOKE_STATIC }).methodExtractor().name)
-                GetDescriptionTextExtensionFingerprint.changeStringAt(1, getInstruction(instructions.indexOfLast { it.opcode == Opcode.IGET_OBJECT }).fieldExtractor().name)
-            }
+            // Instagram 442 / VC148: MediaExtKt.A0J(Media) is the media metadata helper used for description data.
+            GetDescriptionTextExtensionFingerprint.changeFirstString("A0J")
+            GetDescriptionTextExtensionFingerprint.changeStringAt(1, "A0Z")
 
             MusicAudioTypeEnumStringFingerprint.matchOrNull()?.method?.apply {
                 instructions.filter { it.opcode == Opcode.INVOKE_STATIC }.firstOrNull {
@@ -110,6 +108,9 @@ val mediaDataEntity =
                     GetMessageAudioUrlExtensionFingerprint.changeStringAt(1, getInstruction(indexOfFirstInstruction(strIndex, Opcode.INVOKE_INTERFACE)).methodExtractor().name)
                 }
             }
+
+            // Instagram 442 / VC148: Media.A39() is the image_versions2-backed image getter.
+            GetImageVariantsExtensionFingerprint.changeFirstString("A39")
 
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -6,7 +6,6 @@
 
 package app.crimera.patches.instagram.entity.mediadata
 
-import app.crimera.patches.instagram.entity.decoder.EditMediaInfoGetCurrentMediaIdFingerprint
 import app.crimera.patches.instagram.entity.decoder.MEDIAEXT_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.utils.changeFirstString
@@ -28,6 +27,11 @@ val mediaDataEntity =
         execute {
             GetHelperClassExtensionFingerprint.changeFirstString(classNameToExtension(MEDIAEXT_CLASS_NAME))
 
+            // Instagram 442 / VC148 Media layout.
+            GetExtendedDataExtensionFingerprint.changeFirstString("A04")
+            GetMediaListExtensionFingerprint.changeFirstString("A8c")
+            GetTrackDataIntfExtensionFingerprint.changeFirstString("A0H")
+
             // Extracting get original sound info data using media and user session.
             GetOriginalSoundDataIntfExtensionFingerprint.changeFirstString(GetOriginalSoundDataIntfFromMediaFingerprint.method.name)
 
@@ -41,7 +45,7 @@ val mediaDataEntity =
                 GetImageVariantsExtensionFingerprint.changeStringAt(1, imageVariantsMethodName)
             }
 
-            // Extracting the get mention set method used media helper class.
+            // Compatibility-only reel mention mapping for Instagram 442.
             GetMentionSetExtensionFingerprint.changeFirstString(LiveTreeMediaDictReelsMentionFingerprint.method.name)
 
             InstagramMainActivityNotificationRelatedFingerprint.apply {
@@ -72,45 +76,6 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(isVideoCallingMethodName)
             }
 
-            // Extraction of extended media data field.
-            // Extraction of media list from extended media data.
-            var foundMediaListMethod = false
-            EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
-                val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
-
-                val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
-                // If iget-object is found after return instruction.
-                if (extendedDataFieldIndex > 0) {
-                    val extendedDataFieldName =
-                        getInstruction(
-                            extendedDataFieldIndex,
-                        ).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
-                }
-            }
-
-            // Backup for media list extraction if the first fingerprint fails.
-            if (!foundMediaListMethod) {
-                GetAndroidLinkFromMediaObject.method.apply {
-                    val firstIfNeIndex = indexOfFirstInstruction(Opcode.IF_NE)
-
-                    val extendedDataFieldIndex = indexOfFirstInstruction(firstIfNeIndex, Opcode.IGET_OBJECT)
-                    val extendedDataFieldName =
-                        getInstruction(
-                            extendedDataFieldIndex,
-                        ).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
-                    foundMediaListMethod = true
-                }
-            }
-
             // Extraction of media pkid from media class.
             FanClubContentPreviewInteractorImplFingerprint.method.apply {
                 val strIndex = FanClubContentPreviewInteractorImplFingerprint.stringMatches[1].index
@@ -119,10 +84,10 @@ val mediaDataEntity =
                 GetMediaPkIdExtensionFingerprint.changeFirstString(mediaPkIdMethodName)
             }
 
-            // Extraction of user data used in extended media class.
+            // Instagram 442 exposes the user getter directly on Media.
             GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(LiveTreeMediaDictGetUserFingerprint.method.name)
 
-            // Extraction of description
+            // Extraction of description.
             val commentObjectClassName: String
             CommentToStringFingerprint.apply {
                 commentObjectClassName = classDef.type
@@ -135,24 +100,9 @@ val mediaDataEntity =
             val getCommentDataFromMediaMethodName =
                 mutableClassDefBy { it.type == MEDIAEXT_CLASS_NAME }
                     .methods
-                    .first {
-                        it.returnType ==
-                            commentObjectClassName
-                    }.name
+                    .first { it.returnType == commentObjectClassName }
+                    .name
             GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
-
-            // Extraction of trackInfo
-            MusicAudioTypeEnumStringFingerprint.method.apply {
-                instructions.filter { it.opcode == Opcode.INVOKE_STATIC }.firstOrNull {
-                    val methodExt = it.methodExtractor()
-                    if (methodExt.returnType != "V") {
-                        GetTrackDataIntfExtensionFingerprint.changeFirstString(methodExt.name)
-                        true
-                    } else {
-                        false
-                    }
-                }
-            }
 
             // Message audio.
             IgPlayerControllerRelatedFingerprint.method.apply {
@@ -184,10 +134,11 @@ val mediaDataEntity =
                         .name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
 
-                val strIndex = stringMatches.last().index
+                // In 442 the variants field follows the explicit video_versions key.
+                val videoVersionsIndex = stringMatches.first { it.string == "video_versions" }.index
                 method.apply {
-                    val videoVariantsListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-
+                    val fieldIndex = indexOfFirstInstruction(videoVersionsIndex, Opcode.IGET_OBJECT)
+                    val videoVariantsListFieldName = getInstruction(fieldIndex).fieldExtractor().name
                     GetVideoVariantsV2ExtensionFingerprint.changeFirstString(videoVariantsListFieldName)
                 }
 
@@ -208,7 +159,5 @@ val mediaDataEntity =
                     GetPostTypeExtensionFingerprint.changeFirstString(productTypeFieldName)
                 }
             }
-
-            // End.
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -6,6 +6,7 @@
 
 package app.crimera.patches.instagram.entity.mediadata
 
+import app.crimera.patches.instagram.entity.decoder.EditMediaInfoGetCurrentMediaIdFingerprint
 import app.crimera.patches.instagram.entity.decoder.MEDIAEXT_CLASS_NAME
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.utils.changeFirstString
@@ -27,27 +28,19 @@ val mediaDataEntity =
         execute {
             GetHelperClassExtensionFingerprint.changeFirstString(classNameToExtension(MEDIAEXT_CLASS_NAME))
 
-            // Instagram 442 / VC148 Media layout.
-            GetExtendedDataExtensionFingerprint.changeFirstString("A04")
-            GetMediaListExtensionFingerprint.changeFirstString("A8c")
-            GetTrackDataIntfExtensionFingerprint.changeFirstString("A0H")
-
-            // Extracting get original sound info data using media and user session.
             GetOriginalSoundDataIntfExtensionFingerprint.changeFirstString(GetOriginalSoundDataIntfFromMediaFingerprint.method.name)
-
-            // Extracting get user data using media and user session.
             GetUserDataWithUserSessionExtensionFingerprint.changeFirstString(GetUserDataFromMediaFingerprint.method.name)
 
-            // Extracting image variants list.
             AyuMidcardMediaHelperImageObjectMethodFingerprint.method.apply {
                 val imageVariantsIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE }
                 val imageVariantsMethodName = getInstruction(imageVariantsIndex).methodExtractor().name
                 GetImageVariantsExtensionFingerprint.changeStringAt(1, imageVariantsMethodName)
             }
 
-            // Compatibility-only reel mention mapping for Instagram 442.
-            GetMentionSetExtensionFingerprint.changeFirstString(LiveTreeMediaDictReelsMentionFingerprint.method.name)
-
+            ReelsMentionDoubleTapFingerprint.method.apply {
+                val userInteractionListMethodInvoke = instructions.first { it.opcode == Opcode.INVOKE_INTERFACE }.methodExtractor()
+                GetMentionSetExtensionFingerprint.changeFirstString(userInteractionListMethodInvoke.name)
+            }
             InstagramMainActivityNotificationRelatedFingerprint.apply {
                 val strIndex = stringMatches.last().index
                 method.apply {
@@ -61,18 +54,12 @@ val mediaDataEntity =
                 }
             }
 
-            // Extracting get video variants.
-            // The first interface call in this fingerprint is List.isEmpty() on Instagram 442.
-            // Select the actual list-returning method instead.
             VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
-                val getVideoVariantsMethod = instructions
-                    .filter { it.opcode == Opcode.INVOKE_INTERFACE }
-                    .firstOrNull { it.methodExtractor().returnType == "Ljava/util/List;" }
-                    ?: error("Could not find the video variants list method")
-                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethod.methodExtractor().name)
+                val firstInvokeInterfaceInstruction = getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE))
+                val getVideoVariantsMethodName = firstInvokeInterfaceInstruction.methodExtractor().name
+                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethodName)
             }
 
-            // Extracting method is video used in media class.
             AslSessionRelatedFingerprint.method.apply {
                 val stringIndex = AslSessionRelatedFingerprint.stringMatches[1].index
                 val isVideoVirtualInvokeIndex = indexOfFirstInstruction(stringIndex, Opcode.INVOKE_VIRTUAL)
@@ -80,44 +67,69 @@ val mediaDataEntity =
                 IsVideoExtensionFingerprint.changeFirstString(isVideoCallingMethodName)
             }
 
-            // Extraction of media pkid from media class.
+            var foundMediaListMethod = false
+            EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
+                val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
+                val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
+                if (extendedDataFieldIndex > 0) {
+                    val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
+                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
+                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
+                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
+                    foundMediaListMethod = true
+                }
+            }
+
+            if (!foundMediaListMethod) {
+                GetAndroidLinkFromMediaObject.method.apply {
+                    val firstIfNeIndex = indexOfFirstInstruction(Opcode.IF_NE)
+                    val extendedDataFieldIndex = indexOfFirstInstruction(firstIfNeIndex, Opcode.IGET_OBJECT)
+                    val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
+                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
+                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
+                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
+                    foundMediaListMethod = true
+                }
+            }
+
             FanClubContentPreviewInteractorImplFingerprint.method.apply {
                 val strIndex = FanClubContentPreviewInteractorImplFingerprint.stringMatches[1].index
-
                 val mediaPkIdMethodName = instructions[indexOfFirstInstruction(strIndex, Opcode.INVOKE_VIRTUAL)].methodExtractor().name
                 GetMediaPkIdExtensionFingerprint.changeFirstString(mediaPkIdMethodName)
             }
 
-            // Instagram 442 exposes the user getter directly on Media.
-            GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(LiveTreeMediaDictGetUserFingerprint.method.name)
+            DirectShareTargetRelatedFingerprint.method.apply {
+                val firstIfEqz = indexOfFirstInstruction(Opcode.IF_EQZ)
+                val userDataMethodName = getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name
+                GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(userDataMethodName)
+            }
 
-            // Extraction of description.
-            val commentObjectClassName: String
-            CommentToStringFingerprint.apply {
-                commentObjectClassName = classDef.type
-                method.apply {
-                    val getCommentTextFieldName = instructions.last { it.opcode == Opcode.IGET_OBJECT }.fieldExtractor().name
-                    GetDescriptionTextExtensionFingerprint.changeStringAt(1, getCommentTextFieldName)
+            EditMediaInfoGetCurrentMediaIdFingerprint.method.apply {
+                val getCommentDataFromMediaMethodName =
+                    getInstruction(instructions.indexOfLast { it.opcode == Opcode.INVOKE_STATIC }).methodExtractor().name
+                val getCommentTextFieldName =
+                    getInstruction(instructions.indexOfLast { it.opcode == Opcode.IGET_OBJECT }).fieldExtractor().name
+                GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
+                GetDescriptionTextExtensionFingerprint.changeStringAt(1, getCommentTextFieldName)
+            }
+
+            MusicAudioTypeEnumStringFingerprint.method.apply {
+                instructions.filter { it.opcode == Opcode.INVOKE_STATIC }.firstOrNull {
+                    val methodExt = it.methodExtractor()
+                    if (methodExt.returnType != "V") {
+                        GetTrackDataIntfExtensionFingerprint.changeFirstString(methodExt.name)
+                        true
+                    } else false
                 }
             }
 
-            val getCommentDataFromMediaMethodName =
-                mutableClassDefBy { it.type == MEDIAEXT_CLASS_NAME }
-                    .methods
-                    .first { it.returnType == commentObjectClassName }
-                    .name
-            GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
-
-            // Message audio.
             IgPlayerControllerRelatedFingerprint.method.apply {
                 instructions.filter { it.opcode == Opcode.INVOKE_INTERFACE }.firstOrNull {
                     val methodExt = it.methodExtractor()
                     if (methodExt.returnType.endsWith("AudioIntf")) {
                         GetMessageAudioUrlExtensionFingerprint.changeFirstString(methodExt.name)
                         true
-                    } else {
-                        false
-                    }
+                    } else false
                 }
             }
 
@@ -130,19 +142,14 @@ val mediaDataEntity =
                 }
             }
 
-            // More extended data.
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName =
-                    LiveTreeMediaDictReelsMentionFingerprint.classDef.fields
-                        .first { it.type == classDef.type }
-                        .name
+                    LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
 
-                // In 442 the variants field follows the explicit video_versions key.
-                val videoVersionsIndex = stringMatches.first { it.string == "video_versions" }.index
+                val strIndex = stringMatches.last().index
                 method.apply {
-                    val fieldIndex = indexOfFirstInstruction(videoVersionsIndex, Opcode.IGET_OBJECT)
-                    val videoVariantsListFieldName = getInstruction(fieldIndex).fieldExtractor().name
+                    val videoVariantsListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
                     GetVideoVariantsV2ExtensionFingerprint.changeFirstString(videoVariantsListFieldName)
                 }
 
@@ -150,7 +157,7 @@ val mediaDataEntity =
                     val strIndex = stringMatches.first().index
                     method.apply {
                         val imageInfoListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-                        GetImageVariantsExtensionFingerprint.changeStringAt(1, imageInfoListFieldName)
+                        GetImageVariantsExtensionFingerprint.changeFirstString(imageInfoListFieldName)
                     }
                 }
             }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -62,9 +62,15 @@ val mediaDataEntity =
             }
 
             // Extracting get video variants.
+            // The first interface call in this fingerprint is List.isEmpty() on Instagram 442.
+            // Select the actual list-returning method instead.
             VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
-                val firstInvokeInterfaceInstruction = getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE))
-                val getVideoVariantsMethodName = firstInvokeInterfaceInstruction.methodExtractor().name
+                val getVideoVariantsMethodName = instructions
+                    .filter { it.opcode == Opcode.INVOKE_INTERFACE }
+                    .map { getInstruction(it.location.index).methodExtractor() }
+                    .firstOrNull { it.returnType == "Ljava/util/List;" }
+                    ?.name
+                    ?: error("Could not find the video variants list method")
                 GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethodName)
             }
 
@@ -146,7 +152,7 @@ val mediaDataEntity =
                     val strIndex = stringMatches.first().index
                     method.apply {
                         val imageInfoListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-                        GetImageVariantsExtensionFingerprint.changeFirstString(imageInfoListFieldName)
+                        GetImageVariantsExtensionFingerprint.changeStringAt(1, imageInfoListFieldName)
                     }
                 }
             }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -27,76 +27,61 @@ val mediaDataEntity =
         dependsOn(decoderEntity)
         execute {
             GetHelperClassExtensionFingerprint.changeFirstString(classNameToExtension(MEDIAEXT_CLASS_NAME))
-
             GetOriginalSoundDataIntfExtensionFingerprint.changeFirstString(GetOriginalSoundDataIntfFromMediaFingerprint.method.name)
             GetUserDataWithUserSessionExtensionFingerprint.changeFirstString(GetUserDataFromMediaFingerprint.method.name)
 
             AyuMidcardMediaHelperImageObjectMethodFingerprint.method.apply {
                 val imageVariantsIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE }
-                val imageVariantsMethodName = getInstruction(imageVariantsIndex).methodExtractor().name
-                GetImageVariantsExtensionFingerprint.changeStringAt(1, imageVariantsMethodName)
+                GetImageVariantsExtensionFingerprint.changeStringAt(1, getInstruction(imageVariantsIndex).methodExtractor().name)
             }
 
             ReelsMentionDoubleTapFingerprint.method.apply {
-                val userInteractionListMethodInvoke = instructions.first { it.opcode == Opcode.INVOKE_INTERFACE }.methodExtractor()
-                GetMentionSetExtensionFingerprint.changeFirstString(userInteractionListMethodInvoke.name)
+                GetMentionSetExtensionFingerprint.changeFirstString(instructions.first { it.opcode == Opcode.INVOKE_INTERFACE }.methodExtractor().name)
             }
             InstagramMainActivityNotificationRelatedFingerprint.apply {
                 val strIndex = stringMatches.last().index
                 method.apply {
-                    val getUserDataInvokeIndex =
-                        instructions.indexOfLast {
-                            it.opcode == Opcode.INVOKE_INTERFACE &&
-                                it.location.index < strIndex
-                        }
-                    val methodName = getInstruction(getUserDataInvokeIndex).methodExtractor().name
-                    GetMentionSetExtensionFingerprint.changeStringAt(1, methodName)
+                    val getUserDataInvokeIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE && it.location.index < strIndex }
+                    GetMentionSetExtensionFingerprint.changeStringAt(1, getInstruction(getUserDataInvokeIndex).methodExtractor().name)
                 }
             }
 
             VideoMediaInIGTVFeedHasVideoVariantsFingerprint.method.apply {
-                val firstInvokeInterfaceInstruction = getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE))
-                val getVideoVariantsMethodName = firstInvokeInterfaceInstruction.methodExtractor().name
-                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getVideoVariantsMethodName)
+                GetVideoVariantsV1ExtensionFingerprint.changeFirstString(getInstruction(indexOfFirstInstruction(Opcode.INVOKE_INTERFACE)).methodExtractor().name)
             }
 
             AslSessionRelatedFingerprint.method.apply {
                 val stringIndex = AslSessionRelatedFingerprint.stringMatches[1].index
                 val isVideoVirtualInvokeIndex = indexOfFirstInstruction(stringIndex, Opcode.INVOKE_VIRTUAL)
-                val isVideoCallingMethodName = getInstruction(isVideoVirtualInvokeIndex).methodExtractor().name
-                IsVideoExtensionFingerprint.changeFirstString(isVideoCallingMethodName)
+                IsVideoExtensionFingerprint.changeFirstString(getInstruction(isVideoVirtualInvokeIndex).methodExtractor().name)
             }
 
             EditMediaInfoFragmentMediaSizeFingerprint.method.apply {
                 val firstReturnIndex = indexOfFirstInstruction(Opcode.RETURN)
                 val extendedDataFieldIndex = indexOfFirstInstruction(firstReturnIndex, Opcode.IGET_OBJECT)
-                if (extendedDataFieldIndex > 0) {
+                if (extendedDataFieldIndex >= 0) {
                     val extendedDataFieldName = getInstruction(extendedDataFieldIndex).fieldExtractor().name
-                    val mediaListMethodName = getInstruction(extendedDataFieldIndex + 1).methodExtractor().name
-                    GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
-                    GetMediaListExtensionFingerprint.changeFirstString(mediaListMethodName)
+                    val mediaListInvokeIndex = indexOfFirstInstruction(extendedDataFieldIndex + 1, Opcode.INVOKE_INTERFACE)
+                    if (mediaListInvokeIndex >= 0) {
+                        GetExtendedDataExtensionFingerprint.changeFirstString(extendedDataFieldName)
+                        GetMediaListExtensionFingerprint.changeFirstString(getInstruction(mediaListInvokeIndex).methodExtractor().name)
+                    }
                 }
             }
 
             FanClubContentPreviewInteractorImplFingerprint.method.apply {
                 val strIndex = FanClubContentPreviewInteractorImplFingerprint.stringMatches[1].index
-                val mediaPkIdMethodName = instructions[indexOfFirstInstruction(strIndex, Opcode.INVOKE_VIRTUAL)].methodExtractor().name
-                GetMediaPkIdExtensionFingerprint.changeFirstString(mediaPkIdMethodName)
+                GetMediaPkIdExtensionFingerprint.changeFirstString(instructions[indexOfFirstInstruction(strIndex, Opcode.INVOKE_VIRTUAL)].methodExtractor().name)
             }
 
             DirectShareTargetRelatedFingerprint.method.apply {
                 val firstIfEqz = indexOfFirstInstruction(Opcode.IF_EQZ)
-                val userDataMethodName = getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name
-                GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(userDataMethodName)
+                GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(getInstruction(indexOfFirstInstruction(firstIfEqz, Opcode.INVOKE_INTERFACE)).methodExtractor().name)
             }
 
             EditMediaInfoGetCurrentMediaIdFingerprint.method.apply {
-                val getCommentDataFromMediaMethodName =
-                    getInstruction(instructions.indexOfLast { it.opcode == Opcode.INVOKE_STATIC }).methodExtractor().name
-                val getCommentTextFieldName =
-                    getInstruction(instructions.indexOfLast { it.opcode == Opcode.IGET_OBJECT }).fieldExtractor().name
-                GetDescriptionTextExtensionFingerprint.changeFirstString(getCommentDataFromMediaMethodName)
-                GetDescriptionTextExtensionFingerprint.changeStringAt(1, getCommentTextFieldName)
+                GetDescriptionTextExtensionFingerprint.changeFirstString(getInstruction(instructions.indexOfLast { it.opcode == Opcode.INVOKE_STATIC }).methodExtractor().name)
+                GetDescriptionTextExtensionFingerprint.changeStringAt(1, getInstruction(instructions.indexOfLast { it.opcode == Opcode.IGET_OBJECT }).fieldExtractor().name)
             }
 
             MusicAudioTypeEnumStringFingerprint.matchOrNull()?.method?.apply {
@@ -122,28 +107,29 @@ val mediaDataEntity =
             AudioIntfMapperFingerprint.apply {
                 val strIndex = stringMatches.first { it.string == AUDIO_SRC_KEY }.index
                 method.apply {
-                    val getAudioSrcInvokeIndex = indexOfFirstInstruction(strIndex, Opcode.INVOKE_INTERFACE)
-                    val methodName = getInstruction(getAudioSrcInvokeIndex).methodExtractor().name
-                    GetMessageAudioUrlExtensionFingerprint.changeStringAt(1, methodName)
+                    GetMessageAudioUrlExtensionFingerprint.changeStringAt(1, getInstruction(indexOfFirstInstruction(strIndex, Opcode.INVOKE_INTERFACE)).methodExtractor().name)
                 }
             }
 
             ExtMediaDictVideoInfoMapperFingerprint.apply {
-                val moreExtendedMediaDataFieldName =
-                    LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
+                val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
                 GetMoreExtendedDataExtensionFingerprint.changeFirstString(moreExtendedMediaDataFieldName)
 
                 val strIndex = stringMatches.last().index
                 method.apply {
-                    val videoVariantsListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-                    GetVideoVariantsV2ExtensionFingerprint.changeFirstString(videoVariantsListFieldName)
+                    val videoVariantsFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
+                    if (videoVariantsFieldIndex >= 0) {
+                        GetVideoVariantsV2ExtensionFingerprint.changeFirstString(getInstruction(videoVariantsFieldIndex).fieldExtractor().name)
+                    }
                 }
 
                 ExtMediaDictImageInfoMapperFingerprint.apply {
                     val strIndex = stringMatches.first().index
                     method.apply {
-                        val imageInfoListFieldName = getInstruction(strIndex + 2).fieldExtractor().name
-                        GetImageVariantsExtensionFingerprint.changeFirstString(imageInfoListFieldName)
+                        val imageInfoFieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
+                        if (imageInfoFieldIndex >= 0) {
+                            GetImageVariantsExtensionFingerprint.changeFirstString(getInstruction(imageInfoFieldIndex).fieldExtractor().name)
+                        }
                     }
                 }
             }
@@ -151,9 +137,10 @@ val mediaDataEntity =
             ProductInfoMapperFingerprint.apply {
                 val strIndex = stringMatches.last().index
                 method.apply {
-                    val productTypeIGetObjectInstruction = getInstruction(indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT))
-                    val productTypeFieldName = productTypeIGetObjectInstruction.fieldExtractor().name
-                    GetPostTypeExtensionFingerprint.changeFirstString(productTypeFieldName)
+                    val fieldIndex = indexOfFirstInstruction(strIndex, Opcode.IGET_OBJECT)
+                    if (fieldIndex >= 0) {
+                        GetPostTypeExtensionFingerprint.changeFirstString(getInstruction(fieldIndex).fieldExtractor().name)
+                    }
                 }
             }
         }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -29,11 +29,6 @@ val mediaDataEntity =
             GetOriginalSoundDataIntfExtensionFingerprint.changeFirstString(GetOriginalSoundDataIntfFromMediaFingerprint.method.name)
             GetUserDataWithUserSessionExtensionFingerprint.changeFirstString(GetUserDataFromMediaFingerprint.method.name)
 
-            AyuMidcardMediaHelperImageObjectMethodFingerprint.method.apply {
-                val imageVariantsIndex = instructions.indexOfLast { it.opcode == Opcode.INVOKE_INTERFACE }
-                GetImageVariantsExtensionFingerprint.changeStringAt(1, getInstruction(imageVariantsIndex).methodExtractor().name)
-            }
-
             ReelsMentionDoubleTapFingerprint.method.apply {
                 GetMentionSetExtensionFingerprint.changeFirstString(instructions.first { it.opcode == Opcode.INVOKE_INTERFACE }.methodExtractor().name)
             }
@@ -101,8 +96,10 @@ val mediaDataEntity =
                 }
             }
 
-            // Instagram 442 / VC148: Media.A39() is the image_versions2-backed image getter.
+            // Instagram 442 / VC148: Media.A39() returns ImageInfo. Its DME()
+            // method is the image candidate list consumed by MediaExtKt.A0a().
             GetImageVariantsExtensionFingerprint.changeFirstString("A39")
+            GetImageVariantsExtensionFingerprint.changeStringAt(1, "DME")
 
             ExtMediaDictVideoInfoMapperFingerprint.apply {
                 val moreExtendedMediaDataFieldName = LiveTreeMediaDictClinitFingerprint.classDef.fields.first { it.type == classDef.type }.name
@@ -115,10 +112,6 @@ val mediaDataEntity =
                         GetVideoVariantsV2ExtensionFingerprint.changeFirstString(getInstruction(videoVariantsFieldIndex).fieldExtractor().name)
                     }
                 }
-
-                // Keep the 442 Media.A39() mapping authoritative for image variants.
-                // The LiveTree image-info mapper targets a different representation and
-                // must not overwrite the Media image getter used by Download media.
             }
 
             ProductInfoMapperFingerprint.apply {

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
@@ -6,13 +6,13 @@
 
 package app.crimera.patches.instagram.entity.userdata
 
+import app.crimera.patches.instagram.entity.decoder.USER_MODEL_CLASS_NAME
 import app.crimera.patches.instagram.utils.Constants
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.literal
 import app.morphe.patcher.string
 
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/UserData;"
-internal const val USER_CLASS = "Lcom/instagram/user/model/User;"
 
 internal object GetAdditionalUserInfoExtensionFingerprint : Fingerprint(
     name = "getAdditionalUserInfo",
@@ -57,42 +57,42 @@ internal object IsVerifiedExtensionFingerprint : Fingerprint(
 // -----------------------------------
 
 internal object FullNameLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     filters = listOf(string("full_name")),
     returnType = "Ljava/lang/String;",
 )
 
 internal object UserNameLiveTreeUserDictFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     filters = listOf(literal(-265713450)),
 )
 
 internal object FriendshipStatusLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     returnType = "FriendshipStatus;",
 )
 
 internal object BiographyLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     returnType = "Ljava/lang/String;",
     filters = listOf(string("biography")),
 )
 
 internal object LowResProfilePictureUserTreeDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     returnType = "ImageUrl;",
     filters = listOf(string("profile_pic_url")),
 )
 
 internal object HDProfileInfoUserTreeDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     filters = listOf(string("hd_profile_pic_url_info")),
     returnType = "ProfilePicUrlInfo",
 )
 
 internal object IsVerifiedUserTreeDictFingerprint : Fingerprint(
-    definingClass = USER_CLASS,
+    definingClass = USER_MODEL_CLASS_NAME,
     strings = listOf("is_verified"),
     returnType = "Ljava/lang/Boolean;",
     filters = listOf(literal(1565553213)),

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/Fingerprint.kt
@@ -6,21 +6,13 @@
 
 package app.crimera.patches.instagram.entity.userdata
 
-import app.crimera.patches.instagram.entity.decoder.USER_MODEL_CLASS_NAME
 import app.crimera.patches.instagram.utils.Constants
-import app.crimera.patches.twitter.logging.responseLogging.JACKSON_CLASS
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.InstructionLocation
 import app.morphe.patcher.literal
-import app.morphe.patcher.opcode
 import app.morphe.patcher.string
-import app.morphe.patches.all.misc.resources.ResourceType
-import app.morphe.patches.all.misc.resources.resourceLiteral
-import com.android.tools.smali.dexlib2.AccessFlags
-import com.android.tools.smali.dexlib2.Opcode
 
 internal const val EXTENSION_CLASS_DESCRIPTOR = "${Constants.ENTITY_CLASS}/UserData;"
-internal const val LIVE_TREE_USER_DICT_CLASS = "Lcom/instagram/user/model/LiveTreeUserDict;"
+internal const val USER_CLASS = "Lcom/instagram/user/model/User;"
 
 internal object GetAdditionalUserInfoExtensionFingerprint : Fingerprint(
     name = "getAdditionalUserInfo",
@@ -64,67 +56,44 @@ internal object IsVerifiedExtensionFingerprint : Fingerprint(
 
 // -----------------------------------
 
-internal object SelectHighlightsCoverFragmentOnCreateFingerprint : Fingerprint(
-    definingClass = "SelectHighlightsCoverFragment;",
-    name = "onCreate",
-)
-
 internal object FullNameLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
-    filters =
-        listOf(
-            string("full_name"),
-        ),
+    definingClass = USER_CLASS,
+    filters = listOf(string("full_name")),
     returnType = "Ljava/lang/String;",
 )
 
 internal object UserNameLiveTreeUserDictFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
-    filters =
-        listOf(
-            literal(-265713450),
-        ),
+    definingClass = USER_CLASS,
+    filters = listOf(literal(-265713450)),
 )
 
 internal object FriendshipStatusLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    definingClass = USER_CLASS,
     returnType = "FriendshipStatus;",
 )
 
 internal object BiographyLiveTreeUserDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    definingClass = USER_CLASS,
     returnType = "Ljava/lang/String;",
-    filters =
-        listOf(
-            string("biography"),
-        ),
+    filters = listOf(string("biography")),
 )
 
 internal object LowResProfilePictureUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    definingClass = USER_CLASS,
     returnType = "ImageUrl;",
-    filters =
-        listOf(
-            string("profile_pic_url"),
-        ),
+    filters = listOf(string("profile_pic_url")),
 )
 
 internal object HDProfileInfoUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
-    filters =
-        listOf(
-            string("hd_profile_pic_url_info"),
-        ),
+    definingClass = USER_CLASS,
+    filters = listOf(string("hd_profile_pic_url_info")),
     returnType = "ProfilePicUrlInfo",
 )
 
 internal object IsVerifiedUserTreeDictFingerprint : Fingerprint(
-    definingClass = LIVE_TREE_USER_DICT_CLASS,
+    definingClass = USER_CLASS,
     strings = listOf("is_verified"),
     returnType = "Ljava/lang/Boolean;",
-    filters =
-        listOf(
-            literal(1565553213),
-        ),
+    filters = listOf(literal(1565553213)),
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/UserDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/userdata/UserDataEntity.kt
@@ -8,20 +8,9 @@ package app.crimera.patches.instagram.entity.userdata
 
 import app.crimera.patches.instagram.entity.decoder.decoderEntity
 import app.crimera.patches.instagram.entity.userfriendshipstatus.userFriendshipStatusEntity
-import app.crimera.patches.instagram.utils.Constants.FRIENDSHIP_STATUS_CLASS
 import app.crimera.utils.changeFirstString
-import app.crimera.utils.extensionToClassName
-import app.crimera.utils.fieldExtractor
-import app.crimera.utils.getReference
-import app.crimera.utils.methodExtractor
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.util.indexOfFirstInstruction
-import com.android.tools.smali.dexlib2.Opcode
-import com.android.tools.smali.dexlib2.dexbacked.reference.DexBackedMethodReference
-import com.android.tools.smali.dexlib2.iface.reference.Reference
 
 val userDataEntity =
     bytecodePatch(
@@ -30,7 +19,6 @@ val userDataEntity =
         dependsOn(decoderEntity, userFriendshipStatusEntity)
 
         execute {
-
             fun Fingerprint.getMethodName(): String = method.name
 
             GetUsernameExtensionFingerprint.changeFirstString(UserNameLiveTreeUserDictFingerprint.getMethodName())
@@ -40,11 +28,5 @@ val userDataEntity =
             GetProfilePictureUrlExtensionFingerprint.changeFirstString(HDProfileInfoUserTreeDictFingerprint.getMethodName())
             GetLowResProfilePictureExtensionFingerprint.changeFirstString(LowResProfilePictureUserTreeDictFingerprint.getMethodName())
             IsVerifiedExtensionFingerprint.changeFirstString(IsVerifiedUserTreeDictFingerprint.getMethodName())
-
-            SelectHighlightsCoverFragmentOnCreateFingerprint.method.apply {
-                val firstIGetObjectIndex = indexOfFirstInstruction(Opcode.IGET_OBJECT)
-                val mutableUserDictIntfFieldName = getInstruction(firstIGetObjectIndex).fieldExtractor().name
-                GetAdditionalUserInfoExtensionFingerprint.changeFirstString(mutableUserDictIntfFieldName)
-            }
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/videoData/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/videoData/Fingerprint.kt
@@ -22,11 +22,11 @@ internal object VideoVersionMapExtensionFingerprint : Fingerprint(
 )
 
 internal object ImmutablePandoVideoVersionMapperFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/api/schemas/ImmutablePandoVideoVersion;",
+    definingClass = "Lcom/instagram/model/mediasize/ImmutablePandoVideoVersion;",
     returnType = "Ljava/util/Map;",
 )
 
 internal object VideoVersionMapperFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/api/schemas/VideoVersion;",
+    definingClass = "Lcom/instagram/model/mediasize/VideoVersion;",
     returnType = "Ljava/util/Map;",
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/videoData/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/videoData/Fingerprint.kt
@@ -22,11 +22,11 @@ internal object VideoVersionMapExtensionFingerprint : Fingerprint(
 )
 
 internal object ImmutablePandoVideoVersionMapperFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/model/mediasize/ImmutablePandoVideoVersion;",
+    definingClass = "Lcom/instagram/api/schemas/ImmutablePandoVideoVersion;",
     returnType = "Ljava/util/Map;",
 )
 
 internal object VideoVersionMapperFingerprint : Fingerprint(
-    definingClass = "Lcom/instagram/model/mediasize/VideoVersion;",
+    definingClass = "Lcom/instagram/api/schemas/VideoVersion;",
     returnType = "Ljava/util/Map;",
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/comment/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/comment/Fingerprint.kt
@@ -12,6 +12,6 @@ import app.morphe.patcher.Fingerprint
 internal const val HANDLE_COMMENT_BUTTON_EXTENSION_CLASS = "${COMMENT_BUTTON_EXTENSION_CLASS}/HandleCommentButton;"
 
 internal object AddCommentButtonFingerprint : Fingerprint(
-    returnType = "Ljava/util/List;",
+    returnType = "Ljava/util/ArrayList;",
     strings = listOf("instagram_share_comment_to_story_entrypoint_impression"),
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/settings/SettingsPatch.kt
@@ -23,6 +23,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patches.all.misc.resources.addAppResources
 import app.morphe.patches.all.misc.resources.addResourcesPatch
@@ -30,6 +31,8 @@ import app.morphe.util.findFreeRegister
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
 
 @Suppress("unused")
 val settingsPatch =
@@ -87,14 +90,34 @@ val settingsPatch =
                 )
             }
 
-            // For welcome message.
+            // For welcome message. Instagram 442 has a Bundle.getString() result before
+            // requireContext(), so resolve the actual Context-producing call instead of using
+            // the first MOVE_RESULT_OBJECT after the marker.
             MainFeedFragmentOnCreateFingerprint.apply {
                 val strIndex = stringMatches[0].index
 
                 method.apply {
-                    val contextIndex = indexOfFirstInstruction(strIndex, Opcode.MOVE_RESULT_OBJECT)
-                    val contextInstruction = getInstruction(contextIndex)
-                    val contextRegister = contextInstruction.registersUsed[0]
+                    val contextInvokeIndex =
+                        instructions.withIndex().firstOrNull { (index, instruction) ->
+                            if (index <= strIndex || instruction.opcode !in setOf(
+                                    Opcode.INVOKE_VIRTUAL,
+                                    Opcode.INVOKE_INTERFACE,
+                                )
+                            ) {
+                                false
+                            } else {
+                                val reference =
+                                    (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                                reference?.returnType == "Landroid/content/Context;"
+                            }
+                        }?.index
+                            ?: throw PatchException("Could not find MainFeedFragment Context getter")
+
+                    val contextIndex = indexOfFirstInstruction(contextInvokeIndex + 1, Opcode.MOVE_RESULT_OBJECT)
+                    if (contextIndex < 0) {
+                        throw PatchException("MainFeedFragment Context getter has no move-result-object")
+                    }
+                    val contextRegister = getInstruction(contextIndex).registersUsed[0]
 
                     addInstruction(
                         contextIndex + 1,

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeLegacyRadioBytecode.kt
@@ -315,11 +315,14 @@ private fun installLegacyOnResumeThemeSync(
                     null
                 }
             }
-    if (selectedIdReads.size != 1) {
+    if (selectedIdReads.size !in 1..2) {
         throw PatchException(
-            "Expected one selected RadioItem id read, found ${selectedIdReads.size}",
+            "Expected one or two selected RadioItem id reads, found ${selectedIdReads.size}",
         )
     }
+    // Instagram 442 reads the same id field once while preparing the row and again for
+    // the selected value. The latter is the value that feeds the RadioGroup constructor.
+    val selectedIdIndex = selectedIdReads.last()
 
     val packedIdsRegister =
         method.findFreeRegister(
@@ -330,7 +333,7 @@ private fun installLegacyOnResumeThemeSync(
         )
     val selectionTempRegister =
         method.findFreeRegister(
-            selectedIdReads.single() + 1,
+            selectedIdIndex + 1,
             selectedIdRegister,
         )
     val firstParameter = firstParameterRegister(method)
@@ -362,7 +365,6 @@ private fun installLegacyOnResumeThemeSync(
         move-result-object v$listenerRegister
         """.trimIndent(),
     )
-    val selectedIdIndex = selectedIdReads.single()
     method.addInstructions(
         selectedIdIndex + 1,
         """

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -12,7 +12,7 @@ import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.SupportedAbi.ARM64_V8A
 
 object Constants {
-    const val INSTAGRAM_VERSION_NAME = "442.0.0.46.79"
+    val INSTAGRAM_VERSION_NAME = "442.0.0.46.79"
 
     val COMPATIBILITY_INSTAGRAM =
         Compatibility(
@@ -32,42 +32,4 @@ object Constants {
                     ),
                 ),
         )
-
-    // Instagram classes.
-    const val FRAGMENT_ACTIVITY = "Landroidx/fragment/app/FragmentActivity;"
-    const val FRIENDSHIP_STATUS_CLASS = "Lcom/instagram/user/model/FriendshipStatus;"
-    const val EDIT_MEDIA_INFO_FRAGMENT_CLASS = "Linstagram/features/creation/fragment/EditMediaInfoFragment;"
-    const val EXTENDED_IMAGE_URL_CLASS = "Lcom/instagram/model/mediasize/ExtendedImageUrl;"
-    const val MEDIA_OPTIONS_CLASS = "Lcom/instagram/feed/media/mediaoption/MediaOption\$Option;"
-    const val USER_SESSION_CLASS = "Lcom/instagram/common/session/UserSession;"
-    const val USER_DETAIL_VIEW_MODEL_CLASS = "Lcom/instagram/profile/fragment/UserDetailViewModel;"
-    const val ORIGINAL_SOUND_DATA_INTF = "Lcom/instagram/api/schemas/OriginalSoundDataIntf;"
-
-    // Extension classes.
-    const val INTEGRATIONS_PACKAGE = "Lapp/morphe/extension/instagram"
-    const val ACTIVITY_SETTINGS_CLASS = "$INTEGRATIONS_PACKAGE/settings"
-    const val UTILS_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/utils"
-    const val CONSTANTS_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/constants"
-    const val ENTITY_CLASS = "$INTEGRATIONS_PACKAGE/entity"
-
-    const val PREF_DESCRIPTOR = "$UTILS_DESCRIPTOR/Pref;"
-    const val PREF_CALL_DESCRIPTOR = "invoke-static {}, $PREF_DESCRIPTOR"
-
-    const val PATCHES_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/patches"
-    const val JSONPARSER_CHECK_DESCRIPTOR = """invoke-static {v%s}, $PATCHES_DESCRIPTOR/Block;->replaceJsonParserKey(Ljava/lang/String;)Ljava/lang/String;
-        move-result-object v%s"""
-
-    const val LINKS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/Links;"
-    const val DOWNLOAD_DESCRIPTOR = "$PATCHES_DESCRIPTOR/download"
-    const val ACTIONBAR_DESCRIPTOR = "$PATCHES_DESCRIPTOR/actionbar/ActionBarPatch;"
-
-    const val OVERFLOW_MENU_BUTTON_CLASS = "$PATCHES_DESCRIPTOR/overflowMenuButton"
-    const val ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS = "$OVERFLOW_MENU_BUTTON_CLASS/reels/AddReelButton;"
-    const val FEED_OVERFLOW_MENU_BUTTON_CLASS = "$OVERFLOW_MENU_BUTTON_CLASS/FeedButton;"
-    const val ACTIVITY_SETTINGS_STATUS_CLASS = "$ACTIVITY_SETTINGS_CLASS/SettingsStatus;"
-    const val SSTS_DESCRIPTOR = "invoke-static {}, $ACTIVITY_SETTINGS_STATUS_CLASS->%s()V"
-    const val HOOK_FLAGS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/devFlags/HookFlags;"
-    const val LOAD_FLAGS_DESCRIPTOR = "invoke-static {}, $HOOK_FLAGS_DESCRIPTOR->%s()V"
-
-    const val COMMENT_BUTTON_EXTENSION_CLASS = "${PATCHES_DESCRIPTOR}/comment"
 }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -30,4 +30,42 @@ object Constants {
                     ),
                 ),
         )
+
+    // Instagram classes.
+    const val FRAGMENT_ACTIVITY = "Landroidx/fragment/app/FragmentActivity;"
+    const val FRIENDSHIP_STATUS_CLASS = "Lcom/instagram/user/model/FriendshipStatus;"
+    const val EDIT_MEDIA_INFO_FRAGMENT_CLASS = "Linstagram/features/creation/fragment/EditMediaInfoFragment;"
+    const val EXTENDED_IMAGE_URL_CLASS = "Lcom/instagram/model/mediasize/ExtendedImageUrl;"
+    const val MEDIA_OPTIONS_CLASS = "Lcom/instagram/feed/media/mediaoption/MediaOption\$Option;"
+    const val USER_SESSION_CLASS = "Lcom/instagram/common/session/UserSession;"
+    const val USER_DETAIL_VIEW_MODEL_CLASS = "Lcom/instagram/profile/fragment/UserDetailViewModel;"
+    const val ORIGINAL_SOUND_DATA_INTF = "Lcom/instagram/api/schemas/OriginalSoundDataIntf;"
+
+    // Extension classes.
+    const val INTEGRATIONS_PACKAGE = "Lapp/morphe/extension/instagram"
+    const val ACTIVITY_SETTINGS_CLASS = "$INTEGRATIONS_PACKAGE/settings"
+    const val UTILS_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/utils"
+    const val CONSTANTS_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/constants"
+    const val ENTITY_CLASS = "$INTEGRATIONS_PACKAGE/entity"
+
+    const val PREF_DESCRIPTOR = "$UTILS_DESCRIPTOR/Pref;"
+    const val PREF_CALL_DESCRIPTOR = "invoke-static {}, $PREF_DESCRIPTOR"
+
+    const val PATCHES_DESCRIPTOR = "$INTEGRATIONS_PACKAGE/patches"
+    const val JSONPARSER_CHECK_DESCRIPTOR = """invoke-static {v%s}, $PATCHES_DESCRIPTOR/Block;->replaceJsonParserKey(Ljava/lang/String;)Ljava/lang/String;
+        move-result-object v%s"""
+
+    const val LINKS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/Links;"
+    const val DOWNLOAD_DESCRIPTOR = "$PATCHES_DESCRIPTOR/download"
+    const val ACTIONBAR_DESCRIPTOR = "$PATCHES_DESCRIPTOR/actionbar/ActionBarPatch;"
+
+    const val OVERFLOW_MENU_BUTTON_CLASS = "$PATCHES_DESCRIPTOR/overflowMenuButton"
+    const val ADD_REEL_BTN_OVERFLOW_MENU_BUTTON_CLASS = "$OVERFLOW_MENU_BUTTON_CLASS/reels/AddReelButton;"
+    const val FEED_OVERFLOW_MENU_BUTTON_CLASS = "$OVERFLOW_MENU_BUTTON_CLASS/FeedButton;"
+    const val ACTIVITY_SETTINGS_STATUS_CLASS = "$ACTIVITY_SETTINGS_CLASS/SettingsStatus;"
+    const val SSTS_DESCRIPTOR = "invoke-static {}, $ACTIVITY_SETTINGS_STATUS_CLASS->%s()V"
+    const val HOOK_FLAGS_DESCRIPTOR = "$PATCHES_DESCRIPTOR/devFlags/HookFlags;"
+    const val LOAD_FLAGS_DESCRIPTOR = "invoke-static {}, $HOOK_FLAGS_DESCRIPTOR->%s()V"
+
+    const val COMMENT_BUTTON_EXTENSION_CLASS = "${PATCHES_DESCRIPTOR}/comment"
 }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -12,8 +12,6 @@ import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.SupportedAbi.ARM64_V8A
 
 object Constants {
-    val INSTAGRAM_VERSION_NAME = "442.0.0.46.79"
-
     val COMPATIBILITY_INSTAGRAM =
         Compatibility(
             name = "Instagram",
@@ -24,7 +22,7 @@ object Constants {
                 listOf(
                     // Stable
                     AppTarget(
-                        version = INSTAGRAM_VERSION_NAME,
+                        version = "442.0.0.46.79",
                         versionCodes =
                             mapOf(
                                 ARM64_V8A to 384810148,

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -12,6 +12,8 @@ import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.SupportedAbi.ARM64_V8A
 
 object Constants {
+    const val INSTAGRAM_442_VERSION_NAME = "442.0.0.46.79"
+
     val COMPATIBILITY_INSTAGRAM =
         Compatibility(
             name = "Instagram",
@@ -22,7 +24,7 @@ object Constants {
                 listOf(
                     // Stable
                     AppTarget(
-                        version = "442.0.0.46.79",
+                        version = INSTAGRAM_442_VERSION_NAME,
                         versionCodes =
                             mapOf(
                                 ARM64_V8A to 384810148,

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -12,7 +12,7 @@ import app.morphe.patcher.patch.Compatibility
 import app.morphe.patcher.patch.SupportedAbi.ARM64_V8A
 
 object Constants {
-    const val INSTAGRAM_442_VERSION_NAME = "442.0.0.46.79"
+    const val INSTAGRAM_VERSION_NAME = "442.0.0.46.79"
 
     val COMPATIBILITY_INSTAGRAM =
         Compatibility(
@@ -24,7 +24,7 @@ object Constants {
                 listOf(
                     // Stable
                     AppTarget(
-                        version = INSTAGRAM_442_VERSION_NAME,
+                        version = INSTAGRAM_VERSION_NAME,
                         versionCodes =
                             mapOf(
                                 ARM64_V8A to 384810148,

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/utils/Constants.kt
@@ -22,10 +22,10 @@ object Constants {
                 listOf(
                     // Stable
                     AppTarget(
-                        version = "439.0.0.37.89",
+                        version = "442.0.0.46.79",
                         versionCodes =
                             mapOf(
-                                ARM64_V8A to 384510827,
+                                ARM64_V8A to 384810148,
                             ),
                     ),
                 ),

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -1,13 +1,12 @@
 package app.revanced.patches.all.misc.versioncode
 
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.INSTAGRAM_442_VERSION_NAME
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.intOption
 import app.morphe.patcher.patch.resourcePatch
 import app.morphe.util.getNode
 import org.w3c.dom.Element
-
-private const val INSTAGRAM_442_VERSION_NAME = "442.0.0.46.79"
 
 @Suppress("unused")
 val changeVersionCodePatch =

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -1,7 +1,6 @@
 package app.revanced.patches.all.misc.versioncode
 
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.crimera.patches.instagram.utils.Constants.INSTAGRAM_VERSION_NAME
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.intOption
 import app.morphe.patcher.patch.resourcePatch
@@ -27,7 +26,7 @@ val changeVersionCodePatch =
             title = "Version code",
             description =
                 "The version code to use. Using the highest value turns off app store " +
-                    "updates and allows downgrading an existing app install to an older app version.",
+                    "updates and allows downgrading an existing app version to an older app version.",
             required = true,
         ) { versionCode -> versionCode!! >= 1 }
 
@@ -37,13 +36,6 @@ val changeVersionCodePatch =
             document("AndroidManifest.xml").use { document ->
                 val manifestElement = document.getNode("manifest") as Element
                 manifestElement.setAttribute("android:versionCode", "$versionCode")
-
-                // Keep Morphe's installed-app metadata aligned with the Instagram build that
-                // this compatibility branch targets, including cloned package names.
-                val packageName = manifestElement.getAttribute("package")
-                if (packageName.startsWith("com.instagram.android")) {
-                    manifestElement.setAttribute("android:versionName", INSTAGRAM_VERSION_NAME)
-                }
             }
         }
     }

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -1,7 +1,7 @@
 package app.revanced.patches.all.misc.versioncode
 
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
-import app.crimera.patches.instagram.utils.Constants.INSTAGRAM_442_VERSION_NAME
+import app.crimera.patches.instagram.utils.Constants.INSTAGRAM_VERSION_NAME
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.morphe.patcher.patch.intOption
 import app.morphe.patcher.patch.resourcePatch
@@ -42,7 +42,7 @@ val changeVersionCodePatch =
                 // this compatibility branch targets, including cloned package names.
                 val packageName = manifestElement.getAttribute("package")
                 if (packageName.startsWith("com.instagram.android")) {
-                    manifestElement.setAttribute("android:versionName", INSTAGRAM_442_VERSION_NAME)
+                    manifestElement.setAttribute("android:versionName", INSTAGRAM_VERSION_NAME)
                 }
             }
         }

--- a/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
+++ b/patches/src/main/kotlin/app/revanced/patches/all/misc/versioncode/ChangeVersionCodePatch.kt
@@ -7,6 +7,8 @@ import app.morphe.patcher.patch.resourcePatch
 import app.morphe.util.getNode
 import org.w3c.dom.Element
 
+private const val INSTAGRAM_442_VERSION_NAME = "442.0.0.46.79"
+
 @Suppress("unused")
 val changeVersionCodePatch =
     resourcePatch(
@@ -36,6 +38,13 @@ val changeVersionCodePatch =
             document("AndroidManifest.xml").use { document ->
                 val manifestElement = document.getNode("manifest") as Element
                 manifestElement.setAttribute("android:versionCode", "$versionCode")
+
+                // Keep Morphe's installed-app metadata aligned with the Instagram build that
+                // this compatibility branch targets, including cloned package names.
+                val packageName = manifestElement.getAttribute("package")
+                if (packageName.startsWith("com.instagram.android")) {
+                    manifestElement.setAttribute("android:versionName", INSTAGRAM_442_VERSION_NAME)
+                }
             }
         }
     }


### PR DESCRIPTION
Adds compatibility for Instagram 442.0.0.46.79 (ARM64 version code 384810148) on top of v3.9.0-dev.7.
Changes include:
Update Instagram compatibility target to 442 / VC148.
Adapt MediaData extraction for the new Media layout, including carousel media, user lookup, track data and video variants.
Move VideoData types from com.instagram.model.mediasize to com.instagram.api.schemas.
Adapt UserData fingerprints to the current User model.
Update the comment fingerprint return type for Instagram 442.
Fix legacy theme sync where 442 contains two matching selected RadioItem ID reads.
Fix the welcome-message injection in MainFeedFragment.onCreate() by resolving the actual Context result instead of the earlier String result, preventing a runtime VerifyError.
Preserve the Instagram 442 version name in the patched APK.
Tested with Instagram 442.0.0.46.79 / 384810148 on Android 16. All patches completed successfully and the patched clone launched successfully.
Note: the reel_mentions adaptation is currently a compatibility shim for this target; story-mention behavior may still need separate validation.