### PR TITLE
fix(Instagram): Correct shared link sanitization

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -10,16 +10,15 @@ package app.morphe.extension.instagram.patches;
 import android.net.Uri;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
-import java.util.Locale;
 
 import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.utils.Pref;
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.ShareLinkSanitizer;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.instagram.constants.PostType;
 import app.morphe.extension.instagram.constants.Constants;
@@ -42,6 +41,11 @@ public class Links {
     private static final boolean DISABLE_HIGHLIGHTS;
     private static final boolean DISABLE_ONBOARDING_PERMISSION_PROMPTS;
     private static final List<String> META_PACKAGES;
+    private static final ShareLinkSanitizer SHARE_LINK_SANITIZER = new ShareLinkSanitizer(
+            "instagram.com",
+            Arrays.asList("comment_id", "img_index", "open_comments", "story_media_id"),
+            Arrays.asList("igsh", "igsi", "utm_source", "utm_medium", "utm_content", "fbclid", "si")
+    );
 
     static {
         DISABLE_ANALYTICS = Pref.disableAnalytics() && SettingsStatus.disableAnalytics;
@@ -157,98 +161,11 @@ public class Links {
 
     public static String sanitizeUrl(String url){
         try{
-            return ShareLinkSanitizer.sanitize(url, Pref.sanitizeShareLinks());
+            return SHARE_LINK_SANITIZER.sanitize(url, Pref.sanitizeShareLinks());
         } catch (Exception e) {
             Logger.printException(() -> "sanitizeUrl failed: ", e);
         }
         return url;
-    }
-
-    static final class ShareLinkSanitizer {
-        private static final String INSTAGRAM_DOMAIN = "instagram.com";
-        private static final List<String> INSTAGRAM_FUNCTIONAL_QUERY_PARAMETERS = Arrays.asList(
-                "comment_id",
-                "img_index",
-                "open_comments",
-                "story_media_id"
-        );
-        private static final List<String> TRACKING_QUERY_PARAMETERS = Arrays.asList(
-                "igsh",
-                "igsi",
-                "utm_source",
-                "utm_medium",
-                "utm_content",
-                "fbclid",
-                "si"
-        );
-
-        private ShareLinkSanitizer() {
-        }
-
-        static String sanitize(String url, boolean enabled) {
-            if (!enabled || url == null) {
-                return url;
-            }
-
-            try {
-                URI uri = new URI(url);
-                String host = uri.getHost();
-                String rawQuery = uri.getRawQuery();
-                if (host == null || rawQuery == null) {
-                    return url;
-                }
-
-                List<String> filteredParameters = filterQuery(rawQuery, isInstagramHost(host));
-                String filteredQuery = String.join("&", filteredParameters);
-                if (filteredQuery.equals(rawQuery)) {
-                    return url;
-                }
-                return replaceQuery(url, filteredQuery, !filteredParameters.isEmpty());
-            } catch (Exception ignored) {
-                return url;
-            }
-        }
-
-        private static boolean isInstagramHost(String host) {
-            String normalizedHost = host.toLowerCase(Locale.ROOT);
-            return normalizedHost.equals(INSTAGRAM_DOMAIN)
-                    || normalizedHost.endsWith("." + INSTAGRAM_DOMAIN);
-        }
-
-        private static List<String> filterQuery(String rawQuery, boolean instagramHost) {
-            List<String> filteredParameters = new ArrayList<>();
-            for (String parameter : rawQuery.split("&", -1)) {
-                String parameterName = parameterName(parameter);
-                boolean keepParameter = parameter.isEmpty()
-                        ? !instagramHost
-                        : instagramHost
-                                ? INSTAGRAM_FUNCTIONAL_QUERY_PARAMETERS.contains(parameterName)
-                                : !TRACKING_QUERY_PARAMETERS.contains(parameterName);
-                if (keepParameter) {
-                    filteredParameters.add(parameter);
-                }
-            }
-            return filteredParameters;
-        }
-
-        private static String parameterName(String parameter) {
-            int separatorIndex = parameter.indexOf('=');
-            return separatorIndex < 0 ? parameter : parameter.substring(0, separatorIndex);
-        }
-
-        private static String replaceQuery(String url, String query, boolean keepQueryDelimiter) {
-            int queryStart = url.indexOf('?');
-            if (queryStart < 0) {
-                return url;
-            }
-
-            int fragmentStart = url.indexOf('#', queryStart);
-            String fragment = fragmentStart < 0 ? "" : url.substring(fragmentStart);
-            String sanitizedUrl = url.substring(0, queryStart);
-            return keepQueryDelimiter
-                    ? sanitizedUrl + "?" + query + fragment
-                    : sanitizedUrl + fragment;
-        }
     }
 
     public static boolean signatureCheck(Object appIdentityObject){

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -10,8 +10,10 @@ package app.morphe.extension.instagram.patches;
 import android.net.Uri;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Arrays;
+import java.util.Locale;
 
 import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
@@ -155,16 +157,98 @@ public class Links {
 
     public static String sanitizeUrl(String url){
         try{
-            return url.replaceAll("([&?])igsh=[^&]*", "")
-                    .replaceAll("([&?])utm_source=[^&]*", "")
-                    .replaceAll("([&?])utm_medium=[^&]*", "")
-                    .replaceAll("([&?])utm_content=[^&]*", "")
-                    .replaceAll("([&?])fbclid=[^&]*", "")
-                    .replaceAll("([&?])si=[^&]*", "");
+            return ShareLinkSanitizer.sanitize(url, Pref.sanitizeShareLinks());
         } catch (Exception e) {
             Logger.printException(() -> "sanitizeUrl failed: ", e);
         }
         return url;
+    }
+
+    static final class ShareLinkSanitizer {
+        private static final String INSTAGRAM_DOMAIN = "instagram.com";
+        private static final List<String> INSTAGRAM_FUNCTIONAL_QUERY_PARAMETERS = Arrays.asList(
+                "comment_id",
+                "img_index",
+                "open_comments",
+                "story_media_id"
+        );
+        private static final List<String> TRACKING_QUERY_PARAMETERS = Arrays.asList(
+                "igsh",
+                "igsi",
+                "utm_source",
+                "utm_medium",
+                "utm_content",
+                "fbclid",
+                "si"
+        );
+
+        private ShareLinkSanitizer() {
+        }
+
+        static String sanitize(String url, boolean enabled) {
+            if (!enabled || url == null) {
+                return url;
+            }
+
+            try {
+                URI uri = new URI(url);
+                String host = uri.getHost();
+                String rawQuery = uri.getRawQuery();
+                if (host == null || rawQuery == null) {
+                    return url;
+                }
+
+                List<String> filteredParameters = filterQuery(rawQuery, isInstagramHost(host));
+                String filteredQuery = String.join("&", filteredParameters);
+                if (filteredQuery.equals(rawQuery)) {
+                    return url;
+                }
+                return replaceQuery(url, filteredQuery, !filteredParameters.isEmpty());
+            } catch (Exception ignored) {
+                return url;
+            }
+        }
+
+        private static boolean isInstagramHost(String host) {
+            String normalizedHost = host.toLowerCase(Locale.ROOT);
+            return normalizedHost.equals(INSTAGRAM_DOMAIN)
+                    || normalizedHost.endsWith("." + INSTAGRAM_DOMAIN);
+        }
+
+        private static List<String> filterQuery(String rawQuery, boolean instagramHost) {
+            List<String> filteredParameters = new ArrayList<>();
+            for (String parameter : rawQuery.split("&", -1)) {
+                String parameterName = parameterName(parameter);
+                boolean keepParameter = parameter.isEmpty()
+                        ? !instagramHost
+                        : instagramHost
+                                ? INSTAGRAM_FUNCTIONAL_QUERY_PARAMETERS.contains(parameterName)
+                                : !TRACKING_QUERY_PARAMETERS.contains(parameterName);
+                if (keepParameter) {
+                    filteredParameters.add(parameter);
+                }
+            }
+            return filteredParameters;
+        }
+
+        private static String parameterName(String parameter) {
+            int separatorIndex = parameter.indexOf('=');
+            return separatorIndex < 0 ? parameter : parameter.substring(0, separatorIndex);
+        }
+
+        private static String replaceQuery(String url, String query, boolean keepQueryDelimiter) {
+            int queryStart = url.indexOf('?');
+            if (queryStart < 0) {
+                return url;
+            }
+
+            int fragmentStart = url.indexOf('#', queryStart);
+            String fragment = fragmentStart < 0 ? "" : url.substring(fragmentStart);
+            String sanitizedUrl = url.substring(0, queryStart);
+            return keepQueryDelimiter
+                    ? sanitizedUrl + "?" + query + fragment
+                    : sanitizedUrl + fragment;
+        }
     }
 
     public static boolean signatureCheck(Object appIdentityObject){

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/ShareLinkSanitizer.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/ShareLinkSanitizer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.shared;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public final class ShareLinkSanitizer {
+    private final String firstPartyDomain;
+    private final Set<String> functionalQueryParameters;
+    private final Set<String> trackingQueryParameters;
+
+    public ShareLinkSanitizer(
+            String firstPartyDomain,
+            Collection<String> functionalQueryParameters,
+            Collection<String> trackingQueryParameters
+    ) {
+        this.firstPartyDomain = firstPartyDomain.toLowerCase(Locale.ROOT);
+        this.functionalQueryParameters = new HashSet<>(functionalQueryParameters);
+        this.trackingQueryParameters = new HashSet<>(trackingQueryParameters);
+    }
+
+    public String sanitize(String url, boolean enabled) {
+        if (!enabled || url == null) {
+            return url;
+        }
+
+        try {
+            URI uri = new URI(url);
+            String host = uri.getHost();
+            String rawQuery = uri.getRawQuery();
+            if (host == null || rawQuery == null) {
+                return url;
+            }
+
+            List<String> filteredParameters = filterQuery(rawQuery, isFirstPartyHost(host));
+            String filteredQuery = String.join("&", filteredParameters);
+            if (filteredQuery.equals(rawQuery)) {
+                return url;
+            }
+            return replaceQuery(url, filteredQuery, !filteredParameters.isEmpty());
+        } catch (Exception ignored) {
+            return url;
+        }
+    }
+
+    private boolean isFirstPartyHost(String host) {
+        String normalizedHost = host.toLowerCase(Locale.ROOT);
+        return normalizedHost.equals(firstPartyDomain)
+                || normalizedHost.endsWith("." + firstPartyDomain);
+    }
+
+    private List<String> filterQuery(String rawQuery, boolean firstPartyHost) {
+        List<String> filteredParameters = new ArrayList<>();
+        for (String parameter : rawQuery.split("&", -1)) {
+            String parameterName = parameterName(parameter);
+            boolean keepParameter = parameter.isEmpty()
+                    ? !firstPartyHost
+                    : firstPartyHost
+                            ? functionalQueryParameters.contains(parameterName)
+                            : !trackingQueryParameters.contains(parameterName);
+            if (keepParameter) {
+                filteredParameters.add(parameter);
+            }
+        }
+        return filteredParameters;
+    }
+
+    private static String parameterName(String parameter) {
+        int separatorIndex = parameter.indexOf('=');
+        return separatorIndex < 0 ? parameter : parameter.substring(0, separatorIndex);
+    }
+
+    private static String replaceQuery(String url, String query, boolean keepQueryDelimiter) {
+        int queryStart = url.indexOf('?');
+        if (queryStart < 0) {
+            return url;
+        }
+
+        int fragmentStart = url.indexOf('#', queryStart);
+        String fragment = fragmentStart < 0 ? "" : url.substring(fragmentStart);
+        String sanitizedUrl = url.substring(0, queryStart);
+        return keepQueryDelimiter
+                ? sanitizedUrl + "?" + query + fragment
+                : sanitizedUrl + fragment;
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/sanitizeShareLinks/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/sanitizeShareLinks/Fingerprint.kt
@@ -14,6 +14,10 @@ internal val TARGET_STRING_ARRAY =
         "profile_to_share_url",
     )
 
+private const val HIGHLIGHT_SHARE_ENDPOINT_STRING =
+    "third_party_sharing/%s/get_story_highlights_to_share_url/"
+private const val HIGHLIGHT_PERMALINK_ACTION_STRING = "create_highlight_permalink_share_url"
+
 internal object PermalinkResponseJsonParserFingerprint : Fingerprint(
     strings = listOf(TARGET_STRING_ARRAY[0]),
     custom = { methodDef, _ ->
@@ -28,6 +32,13 @@ internal object ProfileUrlResponseJsonParserFingerprint : Fingerprint(
     },
 )
 
+internal object AudioUrlResponseJsonParserFingerprint : Fingerprint(
+    strings = listOf("audio_to_share_url"),
+    custom = { methodDef, _ ->
+        methodDef.name.lowercase().contains("parsefromjson")
+    },
+)
+
 internal object StoryItemThirdPartySharingUrlResponseImplFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",
     definingClass = "StoryItemThirdPartySharingUrlResponseImpl;",
@@ -36,4 +47,8 @@ internal object StoryItemThirdPartySharingUrlResponseImplFingerprint : Fingerpri
 internal object LiveThirdPartySharingUrlResponseImplFingerprint : Fingerprint(
     returnType = "Ljava/lang/String;",
     definingClass = "Lcom/instagram/api/schemas/LiveThirdPartySharingUrlResponseImpl;",
+)
+
+internal object HighlightShareUrlRequestFingerprint : Fingerprint(
+    strings = listOf(HIGHLIGHT_SHARE_ENDPOINT_STRING, HIGHLIGHT_PERMALINK_ACTION_STRING),
 )

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/sanitizeShareLinks/SanitizeShareLinksPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/sanitizeShareLinks/SanitizeShareLinksPatch.kt
@@ -12,10 +12,15 @@ import app.crimera.patches.instagram.utils.Constants.LINKS_DESCRIPTOR
 import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.util.indexOfFirstInstruction
 import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
 
 @Suppress("unused")
 val sanitizeShareLinksPatch =
@@ -50,6 +55,28 @@ val sanitizeShareLinksPatch =
                 }
             }
 
+            val audioUrlParserMatch = AudioUrlResponseJsonParserFingerprint.matchAll(1..1).single()
+            val audioUrlStringIndex = audioUrlParserMatch.stringMatches.single().index
+            audioUrlParserMatch.method.apply {
+                val audioUrlAssignmentIndex =
+                    instructions
+                        .withIndex()
+                        .filter { (index, instruction) ->
+                            index > audioUrlStringIndex &&
+                                instruction.opcode == Opcode.IPUT_OBJECT &&
+                                ((instruction as? ReferenceInstruction)?.reference as? FieldReference)?.type ==
+                                "Ljava/lang/String;"
+                        }.map { it.index }
+                        .singleOrNull()
+                        ?: throw PatchException("Expected one audio share URL assignment")
+                val urlRegister = instructions[audioUrlAssignmentIndex].registersUsed[0]
+
+                addInstructions(
+                    audioUrlAssignmentIndex,
+                    EXTENSION_METHOD.format(urlRegister, urlRegister, urlRegister),
+                )
+            }
+
             val responseImplFingerprint =
                 listOf(
                     StoryItemThirdPartySharingUrlResponseImplFingerprint,
@@ -65,6 +92,56 @@ val sanitizeShareLinksPatch =
                     addInstructions(index, EXTENSION_METHOD.format(urlRegister, urlRegister, urlRegister))
                 }
             }
+
+            val highlightShareUrlRequestMatch =
+                HighlightShareUrlRequestFingerprint.matchAll(1..1).single()
+            val highlightCallbackType =
+                highlightShareUrlRequestMatch.method.instructions
+                    .mapNotNull { instruction ->
+                        if (instruction.opcode != Opcode.NEW_INSTANCE) {
+                            return@mapNotNull null
+                        }
+                        ((instruction as? ReferenceInstruction)?.reference as? TypeReference)?.type
+                    }.singleOrNull()
+                    ?: throw PatchException("Expected one highlight share URL callback class")
+
+            val highlightCallbackMethod =
+                mutableClassDefBy(highlightCallbackType)
+                    .methods
+                    .singleOrNull { method ->
+                        method.returnType == "V" &&
+                            method.parameterTypes.map(CharSequence::toString) == listOf("Ljava/lang/Object;")
+                    } ?: throw PatchException("Expected one highlight share URL callback method")
+
+            val highlightUrlResultIndex =
+                highlightCallbackMethod.instructions
+                    .withIndex()
+                    .filter { (index, instruction) ->
+                        if (instruction.opcode != Opcode.INVOKE_INTERFACE) {
+                            return@filter false
+                        }
+                        val methodReference =
+                            (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                        methodReference?.returnType == "Ljava/lang/String;" &&
+                            highlightCallbackMethod.instructions.getOrNull(index + 1)?.opcode ==
+                                Opcode.MOVE_RESULT_OBJECT
+                    }.map { it.index + 1 }
+                    .singleOrNull()
+                    ?: throw PatchException("Expected one highlight share URL result")
+
+            val highlightUrlRegister =
+                highlightCallbackMethod.instructions[highlightUrlResultIndex]
+                    .registersUsed
+                    .singleOrNull()
+                    ?: throw PatchException("Expected one highlight share URL result register")
+            highlightCallbackMethod.addInstructions(
+                highlightUrlResultIndex + 1,
+                EXTENSION_METHOD.format(
+                    highlightUrlRegister,
+                    highlightUrlRegister,
+                    highlightUrlRegister,
+                ),
+            )
 
             enableSettings("sanitizeShareLinks")
         }


### PR DESCRIPTION
Fixes share links being sanitized even when the setting is turned off. when enabled, it removes `igsi` and other unwanted parameters without breaking comments, multi-item posts, or stories, and now also covers highlight and audio share links

## Testing
- `.\gradlew.bat test --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26

Closes #1682 