### PR TITLE
fix(Instagram): Rebind piko settings category icons

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -120,6 +120,7 @@ public class ButtonPref extends Preference {
     protected void onBindView(View view) {
         String key = getKey();
         InstagramPreferenceStyle.bindText(this, view);
+        InstagramPreferenceStyle.bindIcon(view, getIconResourceName(key));
         InstagramPreferenceStyle.setTrailingVisible(view, hasVisibleTrail(key));
         InstagramPreferenceStyle.setPressedHighlightEnabled(
                 view,
@@ -154,6 +155,9 @@ public class ButtonPref extends Preference {
     }
 
     private String getIconResourceName(String key) {
+        if (key == null) {
+            return null;
+        }
         if(key.equals(Constants.PIKO_FRAGMENT_ADS)){
             return UI.DRAWABLE_SHEILD_ICON;
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -270,6 +270,12 @@ public final class InstagramPreferenceStyle {
         }
     }
 
+    public static void bindIcon(View view, String iconResName) {
+        if (view instanceof PreferenceRow) {
+            ((PreferenceRow) view).setIcon(iconResName);
+        }
+    }
+
     public static void setPressedHighlightEnabled(View view, boolean enabled) {
         if (view instanceof PreferenceRow) {
             ((PreferenceRow) view).setPressedHighlightEnabled(enabled);
@@ -362,7 +368,7 @@ public final class InstagramPreferenceStyle {
             setWillNotDraw(false);
         }
 
-        private void initIconView(Context context, String iconResName) {
+        private void initIconView(Context context) {
             iconView = new ImageView(context);
 
             int iconSize = dp(context, 24);
@@ -372,15 +378,23 @@ public final class InstagramPreferenceStyle {
             params.setMarginEnd(dp(context, 16));
             iconView.setLayoutParams(params);
 
-            UI.setThemedIcon(iconView, iconResName);
             iconView.setScaleType(ImageView.ScaleType.FIT_CENTER);
             addView(iconView, 0);
         }
 
         void setIcon(String iconResName) {
-            if (iconResName != null) {
-                initIconView(getContext(), iconResName);
+            if (iconResName == null) {
+                if (iconView != null) {
+                    iconView.setImageDrawable(null);
+                    iconView.setVisibility(View.GONE);
+                }
+                return;
             }
+            if (iconView == null) {
+                initIconView(getContext());
+            }
+            UI.setThemedIcon(iconView, iconResName);
+            iconView.setVisibility(View.VISIBLE);
         }
 
         void setHighlightView(View highlightView) {


### PR DESCRIPTION
Fixes an issue caused by #1684 where reused piko settings category rows retained their previous leading icon after scrolling

## Testing
- `.\gradlew.bat :patches:check :extensions:instagram:assembleRelease --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26