### PR TITLE
improve(Instagram): Confirm before piko settings reset

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -7,6 +7,7 @@
 package app.morphe.extension.instagram.settings.preference.widgets;
 
 import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
 import android.preference.Preference;
 import android.util.AttributeSet;
@@ -26,6 +27,8 @@ import app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.InstaUtils;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
 
 public class ButtonPref extends Preference {
     private final Context context;
@@ -67,7 +70,7 @@ public class ButtonPref extends Preference {
                         ActivityHook.launchFragment((Activity) context, key);
                         
                     } else if (key.equals("piko_reset_pref")) {
-                        InstaUtils.deletePref();
+                        showResetSettingsDialog();
 
                     } else if (key.equals("piko_delete_analytics_cache")) {
                         Block.deleteAnalyticsCacheFolder();
@@ -96,6 +99,17 @@ public class ButtonPref extends Preference {
                 return true;
             }
         });
+    }
+
+    private void showResetSettingsDialog() {
+        new AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(context))
+                .setTitle(str("piko_reset_pref_confirm"))
+                .setNegativeButton(str("piko_cancel"), null)
+                .setPositiveButton(
+                        str("piko_ok"),
+                        (dialogInterface, which) -> InstaUtils.deletePref()
+                )
+                .show();
     }
 
     private static Runnable recreateActivityOnComplete(Context context) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -7,7 +7,6 @@
 package app.morphe.extension.instagram.settings.preference.widgets;
 
 import android.app.Activity;
-import android.app.AlertDialog;
 import android.content.Context;
 import android.preference.Preference;
 import android.util.AttributeSet;
@@ -27,8 +26,6 @@ import app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.InstaUtils;
-
-import static app.morphe.extension.instagram.utils.IgStr.str;
 
 public class ButtonPref extends Preference {
     private final Context context;
@@ -70,7 +67,7 @@ public class ButtonPref extends Preference {
                         ActivityHook.launchFragment((Activity) context, key);
                         
                     } else if (key.equals("piko_reset_pref")) {
-                        showResetSettingsDialog();
+                        InstaUtils.showResetSettingsDialog(context);
 
                     } else if (key.equals("piko_delete_analytics_cache")) {
                         Block.deleteAnalyticsCacheFolder();
@@ -99,17 +96,6 @@ public class ButtonPref extends Preference {
                 return true;
             }
         });
-    }
-
-    private void showResetSettingsDialog() {
-        new AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(context))
-                .setTitle(str("piko_reset_pref_confirm"))
-                .setNegativeButton(str("piko_cancel"), null)
-                .setPositiveButton(
-                        str("piko_ok"),
-                        (dialogInterface, which) -> InstaUtils.deletePref()
-                )
-                .show();
     }
 
     private static Runnable recreateActivityOnComplete(Context context) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/InstaUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/InstaUtils.java
@@ -9,6 +9,7 @@ package app.morphe.extension.instagram.utils;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
+import android.app.AlertDialog;
 import android.content.Context;
 import android.os.Build;
 import android.os.Environment;
@@ -21,6 +22,7 @@ import java.net.HttpURLConnection;
 
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.entity.DeveloperOptions;
+import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
 import app.morphe.extension.crimera.PikoUtils;
 
 import app.morphe.extension.shared.Utils;
@@ -72,6 +74,17 @@ public class InstaUtils {
         fileDone = PikoUtils.pikoWriteFile(fileName, Constants.DEFAULT_PIKO_FOLDER, data, false);
         fileDoneTxt = fileDone ? " created" : fileDoneTxt;
         PikoUtils.toast(fileName + fileDoneTxt);
+    }
+
+    public static void showResetSettingsDialog(Context context) {
+        new AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(context))
+                .setTitle(str("piko_reset_pref_confirm"))
+                .setNegativeButton(str("piko_cancel"), null)
+                .setPositiveButton(
+                        str("piko_ok"),
+                        (dialogInterface, which) -> deletePref()
+                )
+                .show();
     }
 
     public static void deletePref(){

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -181,9 +181,10 @@
     <string name="piko_category_about">About</string>
     <string name="piko_export_pref">Export Piko preferences</string>
     <string name="piko_import_pref">Import Piko preferences</string>
-    <string name="piko_reset_pref">Reset Piko preferences</string>
-    <string name="piko_reset_pref_success">Piko preferences deleted</string>
-    <string name="piko_reset_pref_failed">Failed to delete Piko preferences</string>
+    <string name="piko_reset_pref">Reset Piko settings</string>
+    <string name="piko_reset_pref_confirm">Reset Piko settings?</string>
+    <string name="piko_reset_pref_success">Piko settings reset</string>
+    <string name="piko_reset_pref_failed">Failed to reset Piko settings</string>
     <string name="piko_app_version">App version: %s</string>
     <string name="piko_patch_version">Patch version: %s</string>
     <string name="piko_patch_info_title">Patch information</string>


### PR DESCRIPTION
Adds a confirmation dialog before resetting piko settings. also changes the related english text from preferences to settings

## Testing
- `.\gradlew.bat :extensions:instagram:compileDebugJavaWithJavac :patches:compileKotlin --no-daemon --console=plain`
- `.\gradlew.bat test --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26