### PR TITLE
feat(Instagram): Add custom sharing domain

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
@@ -32,6 +33,8 @@ public class Links {
             "com.bloks.www.bloks.ig.ndx.ci.entry.screen";
     private static final String NDX_LOCATION_SERVICES_SCREEN =
             "com.bloks.www.bloks.ig.ndx.ls.entry.screen";
+    private static final Pattern VALID_DOMAIN =
+            Pattern.compile("[A-Za-z0-9-]+(\\.[A-Za-z0-9-]+)*(:\\d{1,5})?");
     private static final boolean DISABLE_ANALYTICS;
     private static final boolean DISABLE_STORIES;
     private static final boolean DISABLE_EXPLORE;
@@ -166,6 +169,44 @@ public class Links {
             Logger.printException(() -> "sanitizeUrl failed: ", e);
         }
         return url;
+    }
+
+    public static String changeDomain(String url) {
+        try {
+            String domain = normalizeCustomDomain(Pref.customSharingDomain());
+            if (domain.isEmpty()) return url;
+
+            Uri uri = Uri.parse(url);
+            String host = uri.getHost();
+
+            if (host == null
+                    || !(host.equalsIgnoreCase("instagram.com") || host.equalsIgnoreCase("www.instagram.com"))
+                    || host.equalsIgnoreCase(domain)) {
+                return url;
+            }
+
+            return uri.buildUpon().encodedAuthority(domain).build().toString();
+        } catch (Exception e) {
+            Logger.printException(() -> "changeDomain failed: ", e);
+        }
+        return url;
+    }
+
+    private static String normalizeCustomDomain(String customDomain) {
+        String domain = customDomain.trim()
+                .replaceFirst("^[^/?#]*://", "")
+                .replaceFirst("[/?#].*", "")
+                .replaceFirst("^[^@]*@", "");
+
+        int portStart = domain.lastIndexOf(':');
+        String host = portStart < 0 ? domain : domain.substring(0, portStart);
+        String port = portStart < 0 ? "" : domain.substring(portStart);
+
+        String bareHost = host.regionMatches(true, 0, "www.", 0, 4) ? host.substring(4) : host;
+        if (!bareHost.isEmpty() && bareHost.indexOf('.') < 0) host += ".com";
+
+        domain = host + port;
+        return VALID_DOMAIN.matcher(domain).matches() ? domain : "";
     }
 
     public static boolean signatureCheck(Object appIdentityObject){

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -7,6 +7,8 @@
 
 package app.morphe.extension.instagram.patches;
 
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
 import android.net.Uri;
 import java.io.IOException;
 import java.net.URI;
@@ -190,6 +192,11 @@ public class Links {
             Logger.printException(() -> "changeDomain failed: ", e);
         }
         return url;
+    }
+
+    public static String customSharingDomainSummary(String customDomain) {
+        String domain = normalizeCustomDomain(customDomain);
+        return domain.isEmpty() ? str("piko_custom_sharing_domain_desc") : domain;
     }
 
     private static String normalizeCustomDomain(String customDomain) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -22,6 +22,7 @@ public class Settings {
     public static final BooleanSetting DISABLE_ADS = new BooleanSetting("disable_ads", true);
     public static final BooleanSetting OPEN_LINKS_EXTERNALLY = new BooleanSetting("open_links_externally", true);
     public static final BooleanSetting SANITIZE_SHARE_LINKS = new BooleanSetting("sanitize_share_links", true);
+    public static final StringSetting CUSTOM_SHARING_DOMAIN = new StringSetting("custom_sharing_domain", "");
     public static final BooleanSetting HIDE_SUGGESTED_CONTENT = new BooleanSetting("hide_suggested_content", true);
     public static final BooleanSetting DEVELOPER_OPTIONS = new BooleanSetting("enable_developer_options", true);
     public static final BooleanSetting DIRECTLY_OPEN_METACONFIG = new BooleanSetting("directly_open_metaconfig",false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -56,8 +56,10 @@ public class SettingsStatus {
     }
     public static boolean sanitizeShareLinks = false;
     public static void sanitizeShareLinks() {sanitizeShareLinks = true;}
+    public static boolean customSharingDomain = false;
+    public static void customSharingDomain() {customSharingDomain = true;}
     public static boolean linksSection() {
-        return (openLinksExternally || sanitizeShareLinks);
+        return (openLinksExternally || sanitizeShareLinks || customSharingDomain);
     }
 
 
@@ -269,6 +271,7 @@ public class SettingsStatus {
         FLAGS.put(str("piko_view_stories_anonymously"),SettingsStatus.viewStoriesAnonymously);
 
         FLAGS.put(str("piko_sanitize_share_links"),SettingsStatus.sanitizeShareLinks);
+        FLAGS.put(str("piko_custom_sharing_domain"),SettingsStatus.customSharingDomain);
         FLAGS.put(str("piko_open_links_externally"),SettingsStatus.openLinksExternally);
         FLAGS.put(str("piko_download_voice_media"),SettingsStatus.downloadVoiceMessage);
         FLAGS.put(str("piko_download_with_external_downloader"),SettingsStatus.downloadWithExternalDownloader);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -25,6 +25,7 @@ import  app.morphe.extension.instagram.patches.devFlags.RecommendedFlags;
 import  app.morphe.extension.instagram.patches.devFlags.Flag;
 
 import app.morphe.extension.crimera.downloader.StorageUtils;
+import app.morphe.extension.instagram.patches.Links;
 import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.widgets.*;
@@ -324,13 +325,10 @@ public class ScreenBuilder {
             );
         }
         if (SettingsStatus.customSharingDomain) {
-            String customSharingDomain = Pref.customSharingDomain();
             addPreference(
                     helper.editTextPreference(
                             str("piko_custom_sharing_domain"),
-                            customSharingDomain.isEmpty()
-                                    ? str("piko_custom_sharing_domain_desc")
-                                    : customSharingDomain,
+                            Links.customSharingDomainSummary(Pref.customSharingDomain()),
                             Settings.CUSTOM_SHARING_DOMAIN
                     )
             );

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -323,6 +323,18 @@ public class ScreenBuilder {
                     )
             );
         }
+        if (SettingsStatus.customSharingDomain) {
+            String customSharingDomain = Pref.customSharingDomain();
+            addPreference(
+                    helper.editTextPreference(
+                            str("piko_custom_sharing_domain"),
+                            customSharingDomain.isEmpty()
+                                    ? str("piko_custom_sharing_domain_desc")
+                                    : customSharingDomain,
+                            Settings.CUSTOM_SHARING_DOMAIN
+                    )
+            );
+        }
     }
 
     public void distractionFreeSection() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
@@ -50,6 +50,7 @@ public class EditTextPref extends EditTextPreference {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 helper.setValue(preference,newValue);
+                //TODO: Implement better soution for summary.
                 String summary = (String) newValue;
                 if (Settings.CUSTOM_SHARING_DOMAIN.key.equals(preference.getKey())) {
                     summary = Links.customSharingDomainSummary(summary);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
@@ -13,6 +13,8 @@ import android.preference.Preference;
 import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import app.morphe.extension.instagram.patches.Links;
+import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.Helper;
 
 public class EditTextPref extends EditTextPreference {
@@ -48,7 +50,11 @@ public class EditTextPref extends EditTextPreference {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 helper.setValue(preference,newValue);
-                preference.setSummary((String) newValue);
+                String summary = (String) newValue;
+                if (Settings.CUSTOM_SHARING_DOMAIN.key.equals(preference.getKey())) {
+                    summary = Links.customSharingDomainSummary(summary);
+                }
+                preference.setSummary(summary);
                 return true;
             }
         });

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -61,6 +61,10 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.SANITIZE_SHARE_LINKS);
     }
 
+    public static String customSharingDomain() {
+        return SharedPref.getStringPref(Settings.CUSTOM_SHARING_DOMAIN);
+    }
+
     public static boolean getTurnOnAllGhostModes() {
         return SharedPref.getBooleanPref(Settings.TURN_ON_ALL_GHOST_MODES);
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/CustomSharingDomainPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/CustomSharingDomainPatch.kt
@@ -4,8 +4,11 @@
  * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
  */
 
-package app.crimera.patches.instagram.links.sanitizeShareLinks
+package app.crimera.patches.instagram.links
 
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.AUDIO
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.HIGHLIGHT
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.PROFILE
 import app.crimera.patches.instagram.links.shareLinks.hookShareLinks
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
@@ -13,17 +16,18 @@ import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.patch.bytecodePatch
 
 @Suppress("unused")
-val sanitizeShareLinksPatch =
+val customSharingDomainPatch =
     bytecodePatch(
-        name = "Sanitize share links",
+        name = "Custom sharing domain",
+        description = "Allows for using custom domains when sharing posts, reels and stories.",
     ) {
 
         dependsOn(settingsPatch)
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 
         execute {
-            hookShareLinks("sanitizeUrl")
+            hookShareLinks("changeDomain", skip = setOf(PROFILE, AUDIO, HIGHLIGHT))
 
-            enableSettings("sanitizeShareLinks")
+            enableSettings("customSharingDomain")
         }
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/shareLinks/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/shareLinks/Fingerprint.kt
@@ -4,7 +4,7 @@
  * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
  */
 
-package app.crimera.patches.instagram.links.sanitizeShareLinks
+package app.crimera.patches.instagram.links.shareLinks
 
 import app.morphe.patcher.Fingerprint
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/shareLinks/ShareLinks.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/shareLinks/ShareLinks.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.links.shareLinks
+
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.AUDIO
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.HIGHLIGHT
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.LIVE
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.POST
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.PROFILE
+import app.crimera.patches.instagram.links.shareLinks.ShareLinkKind.STORY
+import app.crimera.patches.instagram.utils.Constants.LINKS_DESCRIPTOR
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.util.indexOfFirstInstructionOrThrow
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+
+internal enum class ShareLinkKind {
+    POST,
+    PROFILE,
+    STORY,
+    LIVE,
+    AUDIO,
+    HIGHLIGHT,
+}
+
+/**
+ * Routes every share URL the app hands out through [extensionMethodName] on `Links`.
+ *
+ * @param extensionMethodName Name of a `String -> String` method on the `Links` extension class.
+ * @param skip Kinds of share link to leave untouched.
+ */
+context(patchContext: BytecodePatchContext)
+internal fun hookShareLinks(
+    extensionMethodName: String,
+    skip: Set<ShareLinkKind> = emptySet(),
+) {
+    fun hook(urlRegister: Int) =
+        """
+        invoke-static/range { v$urlRegister .. v$urlRegister }, $LINKS_DESCRIPTOR->$extensionMethodName(Ljava/lang/String;)Ljava/lang/String;
+        move-result-object v$urlRegister
+        """.trimIndent()
+
+    listOfNotNull(
+        PermalinkResponseJsonParserFingerprint.takeIf { POST !in skip },
+        ProfileUrlResponseJsonParserFingerprint.takeIf { PROFILE !in skip },
+    ).forEach { fingerprint ->
+        fingerprint.method.apply {
+            val iPutObjectIndex =
+                indexOfFirstInstructionOrThrow(fingerprint.stringMatches[0].index, Opcode.IPUT_OBJECT)
+
+            addInstructions(iPutObjectIndex, hook(instructions[iPutObjectIndex].registersUsed[0]))
+        }
+    }
+
+    listOfNotNull(
+        StoryItemThirdPartySharingUrlResponseImplFingerprint.takeIf { STORY !in skip },
+        LiveThirdPartySharingUrlResponseImplFingerprint.takeIf { LIVE !in skip },
+    ).forEach { fingerprint ->
+        fingerprint.method.apply {
+            val returnInstruction = instructions.last { it.opcode == Opcode.RETURN_OBJECT }
+
+            addInstructions(returnInstruction.location.index, hook(returnInstruction.registersUsed[0]))
+        }
+    }
+
+    if (AUDIO !in skip) hookAudioShareLink(::hook)
+    if (HIGHLIGHT !in skip) hookHighlightShareLink(::hook)
+}
+
+context(patchContext: BytecodePatchContext)
+private fun hookAudioShareLink(hook: (Int) -> String) {
+    val audioUrlParserMatch = AudioUrlResponseJsonParserFingerprint.matchAll(1..1).single()
+    val audioUrlStringIndex = audioUrlParserMatch.stringMatches.single().index
+
+    audioUrlParserMatch.method.apply {
+        val audioUrlAssignmentIndex =
+            instructions
+                .withIndex()
+                .filter { (index, instruction) ->
+                    index > audioUrlStringIndex &&
+                        instruction.opcode == Opcode.IPUT_OBJECT &&
+                        ((instruction as? ReferenceInstruction)?.reference as? FieldReference)?.type ==
+                        "Ljava/lang/String;"
+                }.map { it.index }
+                .singleOrNull()
+                ?: throw PatchException("Expected one audio share URL assignment")
+
+        addInstructions(
+            audioUrlAssignmentIndex,
+            hook(instructions[audioUrlAssignmentIndex].registersUsed[0]),
+        )
+    }
+}
+
+context(patchContext: BytecodePatchContext)
+private fun hookHighlightShareLink(hook: (Int) -> String) {
+    val highlightShareUrlRequestMatch = HighlightShareUrlRequestFingerprint.matchAll(1..1).single()
+    val highlightCallbackType =
+        highlightShareUrlRequestMatch.method.instructions
+            .mapNotNull { instruction ->
+                if (instruction.opcode != Opcode.NEW_INSTANCE) {
+                    return@mapNotNull null
+                }
+                ((instruction as? ReferenceInstruction)?.reference as? TypeReference)?.type
+            }.singleOrNull()
+            ?: throw PatchException("Expected one highlight share URL callback class")
+
+    val highlightCallbackMethod =
+        patchContext
+            .mutableClassDefBy(highlightCallbackType)
+            .methods
+            .singleOrNull { method ->
+                method.returnType == "V" &&
+                    method.parameterTypes.map(CharSequence::toString) == listOf("Ljava/lang/Object;")
+            } ?: throw PatchException("Expected one highlight share URL callback method")
+
+    val highlightUrlResultIndex =
+        highlightCallbackMethod.instructions
+            .withIndex()
+            .filter { (index, instruction) ->
+                if (instruction.opcode != Opcode.INVOKE_INTERFACE) {
+                    return@filter false
+                }
+                val methodReference =
+                    (instruction as? ReferenceInstruction)?.reference as? MethodReference
+                methodReference?.returnType == "Ljava/lang/String;" &&
+                    highlightCallbackMethod.instructions.getOrNull(index + 1)?.opcode ==
+                        Opcode.MOVE_RESULT_OBJECT
+            }.map { it.index + 1 }
+            .singleOrNull()
+            ?: throw PatchException("Expected one highlight share URL result")
+
+    val highlightUrlRegister =
+        highlightCallbackMethod.instructions[highlightUrlResultIndex]
+            .registersUsed
+            .singleOrNull()
+            ?: throw PatchException("Expected one highlight share URL result register")
+
+    highlightCallbackMethod.addInstructions(
+        highlightUrlResultIndex + 1,
+        hook(highlightUrlRegister),
+    )
+}

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -30,6 +30,8 @@
     <string name="piko_open_links_externally">Open links externally</string>
     <string name="piko_open_links_externally_desc">Open links in external browser instead of in-app browser</string>
     <string name="piko_sanitize_share_links">Sanitize share links</string>
+    <string name="piko_custom_sharing_domain">Custom sharing domain</string>
+    <string name="piko_custom_sharing_domain_desc">Domain to use when sharing links</string>
 
     <!-- Ghost Section -->
     <string name="piko_category_ghost">Ghost</string>


### PR DESCRIPTION
# Add possibility to change the domain when sharing links

> Excluded Highlightes, Audio and Profiles.
> I really don't know if there are InstaFix that can show those, so I let those links out.

It works perfect fine with the sanitize, I needed to extract the functions that @naoverse06 did here #1698 to correct work with this.

<img width="1080" height="776" alt="image" src="https://github.com/user-attachments/assets/422f1716-3408-45f1-a2c3-24376ad5bb6e" />

<img width="1080" height="197" alt="image" src="https://github.com/user-attachments/assets/7f52a750-c39f-4378-8d40-582347ab534a" />

<img width="1080" height="258" alt="image" src="https://github.com/user-attachments/assets/a7d142ae-def3-4076-abdc-596c35cb9492" />


## Used Claude Opus 5, focused on implementing these two functions, less in refactoring and shit.
Tested using a Xiaomi 12 Evolution X Android 15 with Instagram v439.0.0.37.89 (384510827)

