### PR TITLE
fix(Instagram): Use xml mime type for settings export

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/fragments/BackupPrefActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/fragments/BackupPrefActivity.java
@@ -74,7 +74,7 @@ public class BackupPrefActivity extends AppCompatActivity {
         fileName = fileName + "_" + new SimpleDateFormat("yyyy_MM_dd_HH_mm_ss").format(new Date()) + extension;
         Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
         intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("application/json");
+        intent.setType(".xml".equals(extension) ? "application/xml" : "application/json");
         intent.putExtra(Intent.EXTRA_TITLE, fileName);
 
         startActivityForResult(intent, 1);


### PR DESCRIPTION
Fixes exported piko settings filenames ending in .xml.json

## Testing
- `.\gradlew.bat test --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.7
- Tested on Samsung Galaxy S26