### PR TITLE
fix(Twitter): Fix `Show sensitive media` patch

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
@@ -6,12 +6,21 @@
 
 package app.morphe.extension.twitter.patches;
 
+import static app.morphe.extension.shared.StringRef.str;
+
+import android.text.TextUtils;
+import android.view.View;
+
+import com.twitter.model.json.mediavisibility.JsonBlurredImageInterstitial;
 import com.twitter.model.json.timeline.urt.JsonTimelineEntry;
 import com.twitter.model.json.core.JsonSensitiveMediaWarning;
 import com.twitter.model.json.timeline.urt.JsonTimelineModuleItem;
+
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.twitter.Pref;
 import app.morphe.extension.twitter.settings.SettingsStatus;
 import app.morphe.extension.twitter.entity.Video;
+
 import java.util.List;
 import java.util.ArrayList;
 import app.morphe.extension.crimera.PikoUtils;
@@ -82,50 +91,84 @@ public class TimelineEntry {
     public static JsonTimelineEntry checkEntry(JsonTimelineEntry jsonTimelineEntry) {
         try {
             String entryId = jsonTimelineEntry.a;
-            if(isEntryIdRemove(entryId)){
+            if (isEntryIdRemove(entryId)) {
                 return null;
             }
-        } catch (Exception unused) {
-
+        } catch (Exception ignored) {
         }
         return jsonTimelineEntry;
     }
     public static JsonTimelineModuleItem checkEntry(JsonTimelineModuleItem jsonTimelineModuleItem) {
         try {
             String entryId = jsonTimelineModuleItem.a;
-            if(isEntryIdRemove(entryId)){
+            if (isEntryIdRemove(entryId)) {
                 return null;
             }
-        } catch (Exception unused) {
-
+        } catch (Exception ignored) {
         }
         return jsonTimelineModuleItem;
     }
-    public static JsonSensitiveMediaWarning sensitiveMedia(JsonSensitiveMediaWarning jsonSensitiveMediaWarning) {
-        try {
-            if(showSensitiveMedia){
-                jsonSensitiveMediaWarning.a = false;
-                jsonSensitiveMediaWarning.b = false;
-                jsonSensitiveMediaWarning.c = false;
-            }
-        } catch (Exception unused) {
-
+    // Interface to reset obfuscated fields
+    // This is one of the methods to avoid using Java Reflection, which has high overhead
+    public interface JsonBlurredImageInterstitialPatchInterface {
+        // Method is added during patching
+        void patch_showSensitiveMedia();
+    }
+    public interface JsonSensitiveMediaWarningPatchInterface {
+        // Method is added during patching
+        void patch_showSensitiveMedia();
+    }
+    public static JsonBlurredImageInterstitial showSensitiveMedia(JsonBlurredImageInterstitialPatchInterface patchInterface) {
+        if (showSensitiveMedia && patchInterface != null) {
+            patchInterface.patch_showSensitiveMedia();
         }
-        return jsonSensitiveMediaWarning;
+        return (JsonBlurredImageInterstitial) patchInterface;
+    }
+    public static JsonSensitiveMediaWarning showSensitiveMedia(JsonSensitiveMediaWarningPatchInterface patchInterface) {
+        if (showSensitiveMedia && patchInterface != null) {
+            patchInterface.patch_showSensitiveMedia();
+        }
+        return (JsonSensitiveMediaWarning) patchInterface;
+    }
+    public static void showSensitiveImage(View view) {
+        if (showSensitiveMedia && view != null) {
+            // Click the 'Show' button on the timeline to make the blurred image visible
+            Utils.runOnMainThread(view::callOnClick);
+        }
+    }
+    // Caution: This profile may include potentially sensitive content
+    private static final String sensitiveProfileHeader = str("profile_interstitial_sensitive_media_header");
+    private static boolean isSensitiveProfile = false;
+    public static int setSensitiveProfileWarningDialogTitle(String title, int visibility) {
+        if (showSensitiveMedia) {
+            // Check the title of the alert dialog to prevent other profile warnings (such as racism or terrorism) from closing
+            isSensitiveProfile = TextUtils.equals(sensitiveProfileHeader, title);
+
+            if (isSensitiveProfile) {
+                // If it is a general sensitive media warning, hide the alert dialog
+                return View.GONE;
+            }
+        }
+
+        return visibility;
+    }
+    public static void showSensitiveProfile(View view) {
+        if (isSensitiveProfile && view != null) {
+            // If it is a general sensitive media warning, also click the dismiss button on the alert dialog
+            // This is to prevent the UI from breaking due to incorrect WindowInsets calculations, even though the alert dialog is hidden
+            Utils.runOnMainThread(view::callOnClick);
+        }
     }
     public static boolean hidePromotedTrend(Object data) {
-        if (data != null && hideAds) {
-            return true;
-        }
-        return false;
+        return data != null && hideAds;
     }
 
-    public static List timelineVideos(List videoEnities){
+    public static List<Object> timelineVideos(List<Object> videoEntities){
         int maxBitrate = 0;
         Object maxVideoObject = null;
         try{
             if(Pref.ENABLE_FORCE_HD) {
-                for (Object vidObj : videoEnities) {
+                for (Object vidObj : videoEntities) {
                     Video vid = new Video(vidObj);
                     String mediaExt = vid.getExtension();
                     if (!(mediaExt.equals("mp4"))) continue;
@@ -136,17 +179,17 @@ public class TimelineEntry {
                     maxVideoObject = vidObj;
                 }
                 if (maxVideoObject != null) {
-                    ArrayList result = new ArrayList();
+                    ArrayList<Object> result = new ArrayList<>();
                     result.add(maxVideoObject);
                     return result;
                 }
             }
 
-        }catch(Exception ex){
+        } catch (Exception ex) {
             PikoUtils.logger(ex);
         }
 
-        return videoEnities;
+        return videoEntities;
     }
 
 //end

--- a/extensions/twitter/stub/src/main/java/com/twitter/model/json/mediavisibility/JsonBlurredImageInterstitial.java
+++ b/extensions/twitter/stub/src/main/java/com/twitter/model/json/mediavisibility/JsonBlurredImageInterstitial.java
@@ -1,0 +1,8 @@
+package com.twitter.model.json.mediavisibility;
+
+public class JsonBlurredImageInterstitial {
+    // interstitialAction
+    public String d;
+    // verificationOptions
+    public Object e;
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -19,7 +19,6 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.util.proxy.mutableTypes.MutableField
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
@@ -64,7 +63,6 @@ internal fun getJsonObjectMapperFingerprint(classPrefix: String) = object : Fing
         )
     )
 ) {}
-
 
 private object SensitiveMediaInterstitialProfileFingerprint : Fingerprint(
     name = "<init>",
@@ -125,14 +123,14 @@ val sensitiveMediaPatch =
             // region Override the sensitive media fields in API response
 
             getJsonFingerprint(JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX).classDef.apply {
+                interfaces.add(EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE)
+
                 val interstitialActionField = fields.find { field ->
                     field.type == "Ljava/lang/String;"
                 }
                 val verificationOptionsField = fields.find { field ->
                     field.type == "Ljava/lang/Object;"
                 }
-
-                interfaces.add(EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE)
 
                 methods.add(
                     ImmutableMethod(
@@ -161,28 +159,22 @@ val sensitiveMediaPatch =
             }
 
             getJsonFingerprint(JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX).classDef.apply {
-                val jsonFields = mutableListOf<MutableField>()
+                interfaces.add(EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE)
+
                 var smaliInstructions =
                     """
                         const/4 v0, 0x0
                     """
-                fields.forEach { field ->
-                    if (!jsonFields.contains(field) && field.type == "Z") {
-                        jsonFields.add(field)
-
-                        smaliInstructions +=
-                            """
-                                iput-boolean v0, p0, $field
-                            """
-                    }
+                fields.filter { it.type == "Z" }.forEach { field ->
+                    smaliInstructions +=
+                        """
+                            iput-boolean v0, p0, $field
+                        """
                 }
-
                 smaliInstructions +=
                     """
                         return-void
                     """
-
-                interfaces.add(EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE)
 
                 methods.add(
                     ImmutableMethod(

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -10,18 +10,103 @@ import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.Constants.PATCHES_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
+import app.crimera.utils.instructionToString
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableField
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.util.findFreeRegister
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
 
 // Credits to @Cradlesofashes
 
-private object sensitiveMediaSettingsPatchFingerprint : Fingerprint(
-    definingClass = "Lcom/twitter/model/json/core/JsonSensitiveMediaWarning\$\$JsonObjectMapper;",
+private const val EXTENSION_CLASS =
+    "$PATCHES_DESCRIPTOR/TimelineEntry;"
+private const val EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE =
+    $$"$$PATCHES_DESCRIPTOR/TimelineEntry$JsonSensitiveMediaWarningPatchInterface;"
+private const val EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE =
+    $$"$$PATCHES_DESCRIPTOR/TimelineEntry$JsonBlurredImageInterstitialPatchInterface;"
+private const val JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX =
+    "Lcom/twitter/model/json/core/JsonSensitiveMediaWarning"
+private const val JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX =
+    "Lcom/twitter/model/json/mediavisibility/JsonBlurredImageInterstitial"
+
+internal fun getJsonFingerprint(classPrefix: String) = object : Fingerprint(
+    definingClass = "$classPrefix;",
+    name = "<init>"
+) {}
+
+internal fun getJsonObjectMapperFingerprint(classPrefix: String) = object : Fingerprint(
+    definingClass = $$$"$$$classPrefix$$JsonObjectMapper;",
     name = "parse",
     returnType = "Ljava/lang/Object",
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            returnType = "$classPrefix;"
+        ),
+        opcode(
+            opcode = Opcode.MOVE_RESULT_OBJECT,
+            location = MatchAfterImmediately()
+        )
+    )
+) {}
+
+
+private object SensitiveMediaInterstitialProfileFingerprint : Fingerprint(
+    name = "<init>",
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/view/View;->setVisibility(I)V"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_INTERFACE,
+            name = "getTitle",
+            parameters = listOf(),
+            returnType = "Ljava/lang/String;"
+        ),
+        resourceLiteral(
+            type = ResourceType.ID,
+            name = "warning_body"
+        ),
+        resourceLiteral(
+            type = ResourceType.ID,
+            name = "primary_button"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Landroid/view/View;->setOnClickListener(Landroid/view/View\$OnClickListener;)V",
+            location = MatchAfterWithin(10)
+        )
+    )
+)
+
+private object SensitiveMediaInterstitialViewFingerprint : Fingerprint(
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    filters = listOf(
+        resourceLiteral(
+            type = ResourceType.STRING,
+            name = "sensitive_media_interstitial_show"
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "setText"
+        )
+    )
 )
 
 @Suppress("unused")
@@ -30,23 +115,169 @@ val sensitiveMediaPatch =
         name = "Show sensitive media",
     ) {
         compatibleWith(COMPATIBILITY_X)
-        dependsOn(settingsPatch)
+        dependsOn(
+            settingsPatch,
+            resourceMappingPatch
+        )
 
         execute {
-            val TIMELINE_ENTRY_DESCRIPTOR = "$PATCHES_DESCRIPTOR/TimelineEntry"
 
-            val methods = sensitiveMediaSettingsPatchFingerprint.method
-            val instructions = methods.instructions
+            // region Override the sensitive media fields in API response
 
-            val returnObj = instructions.last { it.opcode == Opcode.RETURN_OBJECT }.location.index
+            getJsonFingerprint(JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX).classDef.apply {
+                val interstitialActionField = fields.find { field ->
+                    field.type == "Ljava/lang/String;"
+                }
+                val verificationOptionsField = fields.find { field ->
+                    field.type == "Ljava/lang/Object;"
+                }
 
-            methods.addInstructions(
-                returnObj,
-                """
-                invoke-static {p1}, $TIMELINE_ENTRY_DESCRIPTOR;->sensitiveMedia(Lcom/twitter/model/json/core/JsonSensitiveMediaWarning;)Lcom/twitter/model/json/core/JsonSensitiveMediaWarning;
-                move-result-object p1
-                """.trimIndent(),
-            )
+                interfaces.add(EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE)
+
+                methods.add(
+                    ImmutableMethod(
+                        type,
+                        "patch_showSensitiveMedia",
+                        listOf(),
+                        "V",
+                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(2),
+                    ).toMutable().apply {
+                        addInstructions(
+                            0,
+                            """
+                                const-string v0, ""
+                                iput-object v0, p0, $interstitialActionField
+                                invoke-static { }, Ljava/util/Collections;->emptyList()Ljava/util/List;
+                                move-result-object v0
+                                iput-object v0, p0, $verificationOptionsField
+                                return-void
+                            """
+                        )
+                    }
+                )
+            }
+
+            getJsonFingerprint(JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX).classDef.apply {
+                val jsonFields = mutableListOf<MutableField>()
+                var smaliInstructions =
+                    """
+                        const/4 v0, 0x0
+                    """
+                fields.forEach { field ->
+                    if (!jsonFields.contains(field) && field.type == "Z") {
+                        jsonFields.add(field)
+
+                        smaliInstructions +=
+                            """
+                                iput-boolean v0, p0, $field
+                            """
+                    }
+                }
+
+                smaliInstructions +=
+                    """
+                        return-void
+                    """
+
+                interfaces.add(EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE)
+
+                methods.add(
+                    ImmutableMethod(
+                        type,
+                        "patch_showSensitiveMedia",
+                        listOf(),
+                        "V",
+                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                        null,
+                        null,
+                        MutableMethodImplementation(2),
+                    ).toMutable().apply {
+                        addInstructions(0, smaliInstructions)
+                    }
+                )
+            }
+
+            mapOf(
+                JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX to EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE,
+                JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX to EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE,
+            ).forEach { (classPrefix, patchInterface) ->
+                getJsonObjectMapperFingerprint(classPrefix).let {
+                    it.method.apply {
+                        val match = it.instructionMatches.last()
+                        val index = match.index
+                        val register = match.instruction.registersUsed[0]
+
+                        addInstructions(
+                            index + 1,
+                            """
+                                invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveMedia($patchInterface)$classPrefix;
+                                move-result-object v$register
+                            """
+                        )
+                    }
+                }
+            }
+
+            // endregion
+
+            // region Close the profile warning alert dialog (Caution: This profile may include potentially sensitive content)
+
+            SensitiveMediaInterstitialProfileFingerprint.let {
+                it.method.apply {
+                    val dialogVisibilityMatch = it.instructionMatches[0]
+                    val dialogVisibilityIndex = dialogVisibilityMatch.index
+                    val dialogVisibilityRegister = dialogVisibilityMatch.instruction.registersUsed[1]
+                    val freeRegister = findFreeRegister(dialogVisibilityIndex)
+
+                    val titleInstruction = instructionToString(it.instructionMatches[1].instruction)
+
+                    val buttonMatch = it.instructionMatches.last()
+                    val buttonIndex = buttonMatch.index
+                    val buttonRegister = buttonMatch.instruction.registersUsed[0]
+
+                    // If it is a general sensitive media warning, also click the dismiss button on the alert dialog
+                    // This is to prevent the UI from breaking due to incorrect WindowInsets calculations, even though the alert dialog is hidden
+                    addInstruction(
+                        buttonIndex + 1,
+                        "invoke-static { v$buttonRegister }, $EXTENSION_CLASS->showSensitiveProfile(Landroid/view/View;)V"
+                    )
+
+                    // Check the title of the alert dialog to prevent other profile warnings (such as racism or terrorism) from closing
+                    // If it is a general sensitive media warning, hide the alert dialog
+                    addInstructions(
+                        dialogVisibilityIndex,
+                        """
+                            $titleInstruction
+                            move-result-object v$freeRegister
+                            invoke-static { v$freeRegister, v$dialogVisibilityRegister }, $EXTENSION_CLASS->setSensitiveProfileWarningDialogTitle(Ljava/lang/String;I)I
+                            move-result v$dialogVisibilityRegister                            
+                        """
+                    )
+                }
+            }
+
+            // endregion
+
+            // region Click the 'Show' button on the timeline to make the blurred image visible
+
+            SensitiveMediaInterstitialViewFingerprint.let {
+                it.method.apply {
+                    val match = it.instructionMatches.last()
+                    val index = match.index
+                    val register = match.instruction.registersUsed[0]
+
+                    addInstruction(
+                        index,
+                        "invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveImage(Landroid/view/View;)V"
+                    )
+                }
+            }
+
+            // endregion
+
             enableSettings("showSensitiveMedia")
         }
     }


### PR DESCRIPTION
### Description

Closes #1659, #1587, #1106, #846, #640.

### Additional Context

> [!Note]
> - Remove image blur from the timeline (`Content warning: Sensitive content`, `Verify Age`).
> 
> - Remove alert dialog from profile (`Caution: This profile may include potentially sensitive content`).

I implemented this patch 3 months ago, but I forgot to open a PR.

### Test Results

Tested on X 12.17.0-release.0.