### PR TITLE
fix(Instagram): blank entries in all deleted messages screen

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
@@ -81,13 +81,6 @@ public class PikoMessageDb extends SQLiteOpenHelper {
      * Insert a captured message. If the row already exists (same message_id), the insert is
      * ignored — EXCEPT that any newly-arriving non-empty content / username / sender_id is
      * written into the existing row when its corresponding column is still empty.
-     *
-     * This matters because the feature captures the same message from multiple hooks at
-     * different times: an early hook may store an empty-content placeholder, and the later
-     * authoritative source (e.g. Hook 4 reading Instagram's own "messages" table at delete
-     * time, or a username resolved after the fact) must be able to fill those blanks in.
-     * A plain CONFLICT_IGNORE would silently drop that better data, leaving the UI showing
-     * "[text]" / "Unknown".
      */
     public void insertOrIgnore(String messageId, String threadId, String senderId,
                                String senderUsername, String content, String type, long timestamp) {
@@ -196,6 +189,16 @@ public class PikoMessageDb extends SQLiteOpenHelper {
         if (c.moveToFirst()) alive = c.getInt(0) == 0;
         c.close();
         return alive;
+    }
+
+    public boolean isStored(String messageId) {
+        if (messageId == null) return false;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, new String[]{"message_id"}, "message_id = ?",
+                new String[]{messageId}, null, null, null);
+        boolean stored = c.moveToFirst();
+        c.close();
+        return stored;
     }
 
     /** Permanently remove one saved message from the vault. */
@@ -322,11 +325,15 @@ public class PikoMessageDb extends SQLiteOpenHelper {
         return (result != null && !result.isEmpty()) ? result : null;
     }
 
+    private static final String HAS_CONTENT =
+        " AND (COALESCE(content, '') <> '' OR COALESCE(sender_id, '') <> ''"
+            + " OR COALESCE(sender_username, '') <> '')";
+
     // Returns [messageId, threadId, senderUsername, content, messageType, timestamp, senderId]
     public List<String[]> getDeletedMessages() {
         List<String[]> result = new ArrayList<>();
         SQLiteDatabase db = getReadableDatabase();
-        Cursor c = db.query(TABLE, null, "is_deleted = 1", null, null, null, "timestamp DESC");
+        Cursor c = db.query(TABLE, null, "is_deleted = 1" + HAS_CONTENT, null, null, null, "timestamp DESC");
         while (c.moveToNext()) {
             result.add(rowToStringArray(c));
         }
@@ -340,7 +347,7 @@ public class PikoMessageDb extends SQLiteOpenHelper {
         // (thread id was unknown at capture) and must not surface as a specific chat's history.
         if (threadId == null || threadId.isEmpty()) return result;
         SQLiteDatabase db = getReadableDatabase();
-        Cursor c = db.query(TABLE, null, "is_deleted = 1 AND thread_id = ?",
+        Cursor c = db.query(TABLE, null, "is_deleted = 1 AND thread_id = ?" + HAS_CONTENT,
             new String[]{threadId}, null, null, "timestamp DESC");
         while (c.moveToNext()) {
             result.add(rowToStringArray(c));

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
@@ -355,7 +355,7 @@ public class SavedMessagesHook {
         }
     }
 
-    public static void onMessageHiddenFromDb(Object dao, String serverId, String clientId) {
+    public static void onMessageHiddenFromDb(String serverId, String clientId) {
         try {
             if (!Pref.saveDeletedMessages()) return;
 
@@ -363,14 +363,14 @@ public class SavedMessagesHook {
             if (itemId == null) return;
 
             PikoMessageDb vault = PikoMessageDb.getInstance(PikoUtils.getContext());
+            if (!vault.isStored(itemId)) return;
+
             boolean wasReceived = vault.isStoredAlive(itemId);
             String messageType = vault.getMessageType(itemId);
-            boolean own = isOwnSender(vault.getSenderId(itemId));
 
-            vault.insertOrIgnore(itemId, "", null, null, null, messageType, System.currentTimeMillis());
             vault.markDeleted(itemId);
 
-            if (wasReceived && !own && claimNotification(itemId)) {
+            if (wasReceived && claimNotification(itemId)) {
                 String stored = vault.getStoredContent(itemId);
                 boolean isMedia = stored == null || stored.isEmpty()
                         || stored.startsWith("http") || stored.startsWith("[");

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/dm/saveMessages/SaveDeletedMessagesPatch.kt
@@ -107,18 +107,16 @@ val saveDeletedMessagesPatch =
             // Hook 4: SQLite DAO delete — inject at entry so our DB record is still present when the hook fires.
             runCatching {
                 DirectItemDbHideFingerprint.method.apply {
-                    val regs = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 3)
+                    val regs = getFreeRegisterProvider(index = 0, numberOfFreeRegistersNeeded = 2)
                     val r0 = regs.getFreeRegister()
                     val r1 = regs.getFreeRegister()
-                    val r2 = regs.getFreeRegister()
 
                     addInstructions(
                         0,
                         """
-                        move-object/from16 v$r0, p0
-                        move-object/from16 v$r1, p2
-                        move-object/from16 v$r2, p3
-                        invoke-static {v$r0, v$r1, v$r2}, $HOOK_CLASS->onMessageHiddenFromDb(Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
+                        move-object/from16 v$r0, p2
+                        move-object/from16 v$r1, p3
+                        invoke-static {v$r0, v$r1}, $HOOK_CLASS->onMessageHiddenFromDb(Ljava/lang/String;Ljava/lang/String;)V
                         """.trimIndent(),
                     )
                 }


### PR DESCRIPTION

Follow-up to #1531

Own messages are skipped on capture (that plan existed before but was skipped later)
But the unsend hook inserted a row regardless so unsending your own message created an entry  showing as [unknown] 
It only showed in the all deleted messages screen, not in a single chat

now only marks messages that were actually captured. Entries with no content and no sender are filtered out