### PR TITLE
fix(Twitter): Fix `Show sensitive media` on the Compose timeline

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelineEntry.java
@@ -11,6 +11,7 @@ import static app.morphe.extension.shared.StringRef.str;
 import android.text.TextUtils;
 import android.view.View;
 
+import com.x.models.interstitial.BlurImageInterstitial;
 import com.twitter.model.json.mediavisibility.JsonBlurredImageInterstitial;
 import com.twitter.model.json.timeline.urt.JsonTimelineEntry;
 import com.twitter.model.json.core.JsonSensitiveMediaWarning;
@@ -129,6 +130,9 @@ public class TimelineEntry {
             patchInterface.patch_showSensitiveMedia();
         }
         return (JsonSensitiveMediaWarning) patchInterface;
+    }
+    public static BlurImageInterstitial showSensitiveMedia(BlurImageInterstitial interstitial) {
+        return showSensitiveMedia ? null : interstitial;
     }
     public static void showSensitiveImage(View view) {
         if (showSensitiveMedia && view != null) {

--- a/extensions/twitter/stub/src/main/java/com/x/models/interstitial/BlurImageInterstitial.java
+++ b/extensions/twitter/stub/src/main/java/com/x/models/interstitial/BlurImageInterstitial.java
@@ -1,0 +1,4 @@
+package com.x.models.interstitial;
+
+public class BlurImageInterstitial {
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -119,9 +119,8 @@ private object SensitiveMediaInterstitialViewFingerprint : Fingerprint(
 )
 
 private object ComposeSensitiveMediaInterstitialFingerprint : Fingerprint(
-    definingClass = "Lcom/x/sensitivemedia/impl/p;",
-    name = "c",
     returnType = "Ljava/lang/Object;",
+    parameters = listOf("Landroidx/compose/runtime/Composer;", "I"),
     filters = listOf(
         methodCall(
             opcode = Opcode.INVOKE_VIRTUAL,

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/sensitivemediasettings/ShowSensitiveMediaPatch.kt
@@ -18,6 +18,7 @@ import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.opcode
+import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
 import app.morphe.patches.all.misc.resources.ResourceType
@@ -42,6 +43,16 @@ private const val JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX =
     "Lcom/twitter/model/json/core/JsonSensitiveMediaWarning"
 private const val JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX =
     "Lcom/twitter/model/json/mediavisibility/JsonBlurredImageInterstitial"
+private const val BLURRED_IMAGE_INTERSTITIAL_CLASS =
+    "Lcom/x/models/interstitial/BlurImageInterstitial;"
+
+private inline fun applyOptionalPatch(block: () -> Unit): Boolean =
+    try {
+        block()
+        true
+    } catch (_: PatchException) {
+        false
+    }
 
 internal fun getJsonFingerprint(classPrefix: String) = object : Fingerprint(
     definingClass = "$classPrefix;",
@@ -107,6 +118,22 @@ private object SensitiveMediaInterstitialViewFingerprint : Fingerprint(
     )
 )
 
+private object ComposeSensitiveMediaInterstitialFingerprint : Fingerprint(
+    definingClass = "Lcom/x/sensitivemedia/impl/p;",
+    name = "c",
+    returnType = "Ljava/lang/Object;",
+    filters = listOf(
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            smali = "Lcom/x/models/interstitial/MediaVisibilityResults;->getBlurImageInterstitial()$BLURRED_IMAGE_INTERSTITIAL_CLASS",
+        ),
+        opcode(
+            opcode = Opcode.MOVE_RESULT_OBJECT,
+            location = MatchAfterImmediately()
+        )
+    )
+)
+
 @Suppress("unused")
 val sensitiveMediaPatch =
     bytecodePatch(
@@ -119,96 +146,96 @@ val sensitiveMediaPatch =
         )
 
         execute {
-
             // region Override the sensitive media fields in API response
+            val appliedLegacyApiHooks = applyOptionalPatch {
+                getJsonFingerprint(JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX).classDef.apply {
+                    interfaces.add(EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE)
 
-            getJsonFingerprint(JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX).classDef.apply {
-                interfaces.add(EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE)
-
-                val interstitialActionField = fields.find { field ->
-                    field.type == "Ljava/lang/String;"
-                }
-                val verificationOptionsField = fields.find { field ->
-                    field.type == "Ljava/lang/Object;"
-                }
-
-                methods.add(
-                    ImmutableMethod(
-                        type,
-                        "patch_showSensitiveMedia",
-                        listOf(),
-                        "V",
-                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
-                        null,
-                        null,
-                        MutableMethodImplementation(2),
-                    ).toMutable().apply {
-                        addInstructions(
-                            0,
-                            """
-                                const-string v0, ""
-                                iput-object v0, p0, $interstitialActionField
-                                invoke-static { }, Ljava/util/Collections;->emptyList()Ljava/util/List;
-                                move-result-object v0
-                                iput-object v0, p0, $verificationOptionsField
-                                return-void
-                            """
-                        )
+                    val interstitialActionField = fields.find { field ->
+                        field.type == "Ljava/lang/String;"
                     }
-                )
-            }
+                    val verificationOptionsField = fields.find { field ->
+                        field.type == "Ljava/lang/Object;"
+                    }
 
-            getJsonFingerprint(JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX).classDef.apply {
-                interfaces.add(EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE)
+                    methods.add(
+                        ImmutableMethod(
+                            type,
+                            "patch_showSensitiveMedia",
+                            listOf(),
+                            "V",
+                            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(2),
+                        ).toMutable().apply {
+                            addInstructions(
+                                0,
+                                """
+                                    const-string v0, ""
+                                    iput-object v0, p0, $interstitialActionField
+                                    invoke-static { }, Ljava/util/Collections;->emptyList()Ljava/util/List;
+                                    move-result-object v0
+                                    iput-object v0, p0, $verificationOptionsField
+                                    return-void
+                                """
+                            )
+                        }
+                    )
+                }
 
-                var smaliInstructions =
-                    """
-                        const/4 v0, 0x0
-                    """
-                fields.filter { it.type == "Z" }.forEach { field ->
+                getJsonFingerprint(JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX).classDef.apply {
+                    interfaces.add(EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE)
+
+                    var smaliInstructions =
+                        """
+                            const/4 v0, 0x0
+                        """
+                    fields.filter { it.type == "Z" }.forEach { field ->
+                        smaliInstructions +=
+                            """
+                                iput-boolean v0, p0, $field
+                            """
+                    }
                     smaliInstructions +=
                         """
-                            iput-boolean v0, p0, $field
+                            return-void
                         """
+
+                    methods.add(
+                        ImmutableMethod(
+                            type,
+                            "patch_showSensitiveMedia",
+                            listOf(),
+                            "V",
+                            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+                            null,
+                            null,
+                            MutableMethodImplementation(2),
+                        ).toMutable().apply {
+                            addInstructions(0, smaliInstructions)
+                        }
+                    )
                 }
-                smaliInstructions +=
-                    """
-                        return-void
-                    """
 
-                methods.add(
-                    ImmutableMethod(
-                        type,
-                        "patch_showSensitiveMedia",
-                        listOf(),
-                        "V",
-                        AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
-                        null,
-                        null,
-                        MutableMethodImplementation(2),
-                    ).toMutable().apply {
-                        addInstructions(0, smaliInstructions)
-                    }
-                )
-            }
+                mapOf(
+                    JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX to EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE,
+                    JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX to EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE,
+                ).forEach { (classPrefix, patchInterface) ->
+                    getJsonObjectMapperFingerprint(classPrefix).let {
+                        it.method.apply {
+                            val match = it.instructionMatches.last()
+                            val index = match.index
+                            val register = match.instruction.registersUsed[0]
 
-            mapOf(
-                JSON_BLURRED_IMAGE_INTERSTITIAL_CLASS_PREFIX to EXTENSION_JSON_BLURRED_IMAGE_INTERSTITIAL_INTERFACE,
-                JSON_SENSITIVE_MEDIA_WARNING_CLASS_PREFIX to EXTENSION_JSON_SENSITIVE_MEDIA_WARNING_INTERFACE,
-            ).forEach { (classPrefix, patchInterface) ->
-                getJsonObjectMapperFingerprint(classPrefix).let {
-                    it.method.apply {
-                        val match = it.instructionMatches.last()
-                        val index = match.index
-                        val register = match.instruction.registersUsed[0]
-
-                        addInstructions(
-                            index + 1,
-                            """
-                                invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveMedia($patchInterface)$classPrefix;
-                                move-result-object v$register
-                            """
-                        )
+                            addInstructions(
+                                index + 1,
+                                """
+                                    invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveMedia($patchInterface)$classPrefix;
+                                    move-result-object v$register
+                                """
+                            )
+                        }
                     }
                 }
             }
@@ -217,37 +244,39 @@ val sensitiveMediaPatch =
 
             // region Close the profile warning alert dialog (Caution: This profile may include potentially sensitive content)
 
-            SensitiveMediaInterstitialProfileFingerprint.let {
-                it.method.apply {
-                    val dialogVisibilityMatch = it.instructionMatches[0]
-                    val dialogVisibilityIndex = dialogVisibilityMatch.index
-                    val dialogVisibilityRegister = dialogVisibilityMatch.instruction.registersUsed[1]
-                    val freeRegister = findFreeRegister(dialogVisibilityIndex)
+            applyOptionalPatch {
+                SensitiveMediaInterstitialProfileFingerprint.let {
+                    it.method.apply {
+                        val dialogVisibilityMatch = it.instructionMatches[0]
+                        val dialogVisibilityIndex = dialogVisibilityMatch.index
+                        val dialogVisibilityRegister = dialogVisibilityMatch.instruction.registersUsed[1]
+                        val freeRegister = findFreeRegister(dialogVisibilityIndex)
 
-                    val titleInstruction = instructionToString(it.instructionMatches[1].instruction)
+                        val titleInstruction = instructionToString(it.instructionMatches[1].instruction)
 
-                    val buttonMatch = it.instructionMatches.last()
-                    val buttonIndex = buttonMatch.index
-                    val buttonRegister = buttonMatch.instruction.registersUsed[0]
+                        val buttonMatch = it.instructionMatches.last()
+                        val buttonIndex = buttonMatch.index
+                        val buttonRegister = buttonMatch.instruction.registersUsed[0]
 
-                    // If it is a general sensitive media warning, also click the dismiss button on the alert dialog
-                    // This is to prevent the UI from breaking due to incorrect WindowInsets calculations, even though the alert dialog is hidden
-                    addInstruction(
-                        buttonIndex + 1,
-                        "invoke-static { v$buttonRegister }, $EXTENSION_CLASS->showSensitiveProfile(Landroid/view/View;)V"
-                    )
+                        // If it is a general sensitive media warning, also click the dismiss button on the alert dialog
+                        // This is to prevent the UI from breaking due to incorrect WindowInsets calculations, even though the alert dialog is hidden
+                        addInstruction(
+                            buttonIndex + 1,
+                            "invoke-static { v$buttonRegister }, $EXTENSION_CLASS->showSensitiveProfile(Landroid/view/View;)V"
+                        )
 
-                    // Check the title of the alert dialog to prevent other profile warnings (such as racism or terrorism) from closing
-                    // If it is a general sensitive media warning, hide the alert dialog
-                    addInstructions(
-                        dialogVisibilityIndex,
-                        """
-                            $titleInstruction
-                            move-result-object v$freeRegister
-                            invoke-static { v$freeRegister, v$dialogVisibilityRegister }, $EXTENSION_CLASS->setSensitiveProfileWarningDialogTitle(Ljava/lang/String;I)I
-                            move-result v$dialogVisibilityRegister                            
-                        """
-                    )
+                        // Check the title of the alert dialog to prevent other profile warnings (such as racism or terrorism) from closing
+                        // If it is a general sensitive media warning, hide the alert dialog
+                        addInstructions(
+                            dialogVisibilityIndex,
+                            """
+                                $titleInstruction
+                                move-result-object v$freeRegister
+                                invoke-static { v$freeRegister, v$dialogVisibilityRegister }, $EXTENSION_CLASS->setSensitiveProfileWarningDialogTitle(Ljava/lang/String;I)I
+                                move-result v$dialogVisibilityRegister
+                            """
+                        )
+                    }
                 }
             }
 
@@ -255,17 +284,45 @@ val sensitiveMediaPatch =
 
             // region Click the 'Show' button on the timeline to make the blurred image visible
 
-            SensitiveMediaInterstitialViewFingerprint.let {
-                it.method.apply {
-                    val match = it.instructionMatches.last()
-                    val index = match.index
-                    val register = match.instruction.registersUsed[0]
+            applyOptionalPatch {
+                SensitiveMediaInterstitialViewFingerprint.let {
+                    it.method.apply {
+                        val match = it.instructionMatches.last()
+                        val index = match.index
+                        val register = match.instruction.registersUsed[0]
 
-                    addInstruction(
-                        index,
-                        "invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveImage(Landroid/view/View;)V"
-                    )
+                        addInstruction(
+                            index,
+                            "invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveImage(Landroid/view/View;)V"
+                        )
+                    }
                 }
+            }
+
+            // endregion
+
+            // region Bypass the Compose sensitive-media interstitial
+
+            val appliedComposeHook = applyOptionalPatch {
+                ComposeSensitiveMediaInterstitialFingerprint.let {
+                    it.method.apply {
+                        val match = it.instructionMatches.last()
+                        val index = match.index
+                        val register = match.instruction.registersUsed[0]
+
+                        addInstructions(
+                            index + 1,
+                            """
+                                invoke-static { v$register }, $EXTENSION_CLASS->showSensitiveMedia($BLURRED_IMAGE_INTERSTITIAL_CLASS)$BLURRED_IMAGE_INTERSTITIAL_CLASS
+                                move-result-object v$register
+                            """
+                        )
+                    }
+                }
+            }
+
+            if (!appliedLegacyApiHooks && !appliedComposeHook) {
+                throw PatchException("Could not find a supported sensitive-media implementation")
             }
 
             // endregion


### PR DESCRIPTION
Follow-up to #1723. That PR was mechanically fine, I checked the fingerprints and the injection points, and they're all correct, but it hooks to a pipeline the app has mostly moved off of, so for a bunch of users (me included) nothing changed.

More information regarding the research and solution available in https://github.com/crimera/piko/issues/1730.

Closes https://github.com/crimera/piko/issues/1730 https://github.com/crimera/piko/issues/1659, https://github.com/crimera/piko/issues/1587, https://github.com/crimera/piko/issues/1106, https://github.com/crimera/piko/issues/846, https://github.com/crimera/piko/issues/640. 

