### PR TITLE
feat(Twitter): Add `Block update screen` patch

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
@@ -6,11 +6,16 @@
 
 package app.morphe.extension.twitter;
 
+import static app.morphe.extension.shared.Utils.runOnMainThread;
+
 import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
 
 import app.morphe.extension.shared.ResourceUtils;
 import app.morphe.extension.twitter.settings.Settings;
 import app.morphe.extension.twitter.settings.SettingsStatus;
+
 import com.google.android.material.tabs.TabLayout$g;
 import java.util.*;
 
@@ -138,6 +143,18 @@ public class Pref {
     }
 
     public static boolean redirect(TabLayout$g g) {return Utils.redirect(g);}
+
+    public static void blockUpdateScreen(View view) {
+        if (Utils.getBooleanPref(Settings.MISC_BLOCK_UPDATE_SCREEN) && view != null) {
+            if (view.getParent() instanceof ViewGroup container &&
+                    container.getParent() instanceof ViewGroup scrollView) {
+                // Hide the alert dialog container first
+                scrollView.setVisibility(View.GONE);
+            }
+            // Click the dismiss button after the alert dialog shows (this button is hidden)
+            runOnMainThread(view::callOnClick);
+        }
+    }
 
     public static boolean isRoundOffNumbersEnabled() {
         return Utils.getBooleanPref(Settings.MISC_ROUND_OFF_NUMBERS);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/ScreenBuilder.java
@@ -568,6 +568,15 @@ public class ScreenBuilder {
         LegacyTwitterPreferenceCategory category = null;
         if(buildCategory)
             category = preferenceCategory(str("piko_title_misc"));
+        if (SettingsStatus.blockUpdateScreen) {
+            addPreference(category,
+                    helper.switchPreference(
+                            str("piko_pref_block_update_screen"),
+                            str("piko_pref_block_update_screen_desc"),
+                            Settings.MISC_BLOCK_UPDATE_SCREEN
+                    )
+            );
+        }
         if (SettingsStatus.enableFontMod) {
             addPreference(category,
                     helper.switchPreference(

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/Settings.java
@@ -7,7 +7,6 @@
 package app.morphe.extension.twitter.settings;
 
 import app.morphe.extension.shared.ResourceUtils;
-import app.morphe.extension.shared.Utils;
 import app.morphe.extension.crimera.settings.BooleanSetting;
 import app.morphe.extension.crimera.settings.StringSetting;
 
@@ -24,6 +23,7 @@ public class Settings {
     public static final BooleanSetting EXTERNAL_DOWNLOADER = new BooleanSetting("external_downloader", true);
     public static final StringSetting EXTERNAL_DOWNLOADER_PACKAGE_NAME = new StringSetting("external_downloader_package_name", "");
 
+    public static final BooleanSetting MISC_BLOCK_UPDATE_SCREEN = new BooleanSetting("misc_block_update_screen", true);
     public static final BooleanSetting MISC_FONT = new BooleanSetting("misc_font", false);
     public static final BooleanSetting MISC_HIDE_FAB = new BooleanSetting("misc_hide_fab", false);
     public static final BooleanSetting MISC_HIDE_FAB_BTN = new BooleanSetting("misc_hide_fab_btns", false);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/SettingsStatus.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/SettingsStatus.java
@@ -393,6 +393,11 @@ public class SettingsStatus {
         blockRedirectingToXLite = true;
     }
 
+    public static boolean blockUpdateScreen = false;
+    public static void blockUpdateScreen() {
+        blockUpdateScreen = true;
+    }
+
     public static boolean enableNativeShareMenu = false;
     public static void enableNativeShareMenu() {
         enableNativeShareMenu = true;

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/settings/fragments/SettingsAboutFragment.java
@@ -92,7 +92,7 @@ public class SettingsAboutFragment extends PreferenceFragment {
                 )
         );
 
-        TreeMap<String,Boolean> flags = new TreeMap();
+        TreeMap<String,Boolean> flags = new TreeMap<>();
         flags.put(str("piko_pref_customisation_more_info_on_profile"),SettingsStatus.moreInfoOnProfile);
         flags.put(str("piko_pref_external_downloader_toggle"),SettingsStatus.externalDownloader);
         flags.put(str("piko_title_native_share_menu"),SettingsStatus.enableNativeShareMenu);
@@ -168,6 +168,7 @@ public class SettingsAboutFragment extends PreferenceFragment {
         flags.put(str("piko_legacy_share_link"),SettingsStatus.legacyShareLink);
         flags.put(str("piko_pref_export_login_token"),SettingsStatus.exportLoginToken);
         flags.put(str("piko_block_redirecting_to_x_lite"),SettingsStatus.blockRedirectingToXLite);
+        flags.put(str("piko_pref_block_update_screen"),SettingsStatus.blockUpdateScreen);
 
         LegacyTwitterPreferenceCategory patPref = preferenceCategory(str("piko_pref_patches"), screen);
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockRedirectToXLite/BlockRedirectingToXLitePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockRedirectToXLite/BlockRedirectingToXLitePatch.kt
@@ -10,12 +10,15 @@ import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.enableSettings
 import app.crimera.patches.twitter.utils.is_11_98_or_greater
+import app.crimera.patches.twitter.utils.is_12_07_or_greater
 import app.crimera.patches.twitter.utils.versionCheckPatch
 import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterImmediately
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
-import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.opcode
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.string
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
@@ -25,27 +28,43 @@ import java.util.logging.Logger
 
 private object RedirectingToXLiteFlagCheckFingerprint : Fingerprint(
     returnType = "Z",
-    strings =
+    filters =
         listOf(
-            "x_lite_in_tfa_for_existing_users_enabled",
-            "existing_user_redirected_to_x_lite",
-            "x_lite_in_tfa_for_existing_users_exit_enabled",
+            string("existing_user_redirected_to_x_lite"),
+            methodCall(
+                opcode = Opcode.INVOKE_INTERFACE,
+                name = "putBoolean",
+                parameters = listOf("Ljava/lang/String;", "Z"),
+            )
         ),
 )
 
-private object XLiteSettingItemsAdderFingerprint : Fingerprint(
+private fun getXLiteSettingItemsAdderFingerprint(migratedToXLite: Boolean) = object : Fingerprint(
     filters =
         listOf(
-            resourceLiteral(ResourceType.STRING, "settings_back_to_x_item_title"),
+            methodCall(
+                opcode = Opcode.INVOKE_INTERFACE,
+                returnType = "Z",
+            ),
+            opcode(
+                opcode = Opcode.MOVE_RESULT,
+                location = MatchAfterImmediately()
+            ),
+            resourceLiteral(
+                type = ResourceType.STRING,
+                name = if (migratedToXLite)
+                    "settings_back_to_x_item_title"
+                else
+                    "x_lite_settings_back_to_x_item_title"
+            )
         ),
-)
+) {}
 
 @Suppress("unused")
 val blockRedirectingToXLitePatch =
     bytecodePatch(
         name = "Block redirecting to X Lite",
         description = "Blocks redirecting to the new X Android UI on launch",
-        default = true,
     ) {
         compatibleWith(COMPATIBILITY_X)
         dependsOn(settingsPatch, versionCheckPatch, resourceMappingPatch)
@@ -53,29 +72,21 @@ val blockRedirectingToXLitePatch =
         execute {
 
             if (is_11_98_or_greater) {
-                RedirectingToXLiteFlagCheckFingerprint.method.apply {
-                    val lastMoveResultObjectInstruction = instructions.last { it.opcode == Opcode.MOVE_RESULT_OBJECT }
-                    val lastMoveResultObjectIndex = lastMoveResultObjectInstruction.location.index
-
-                    val putBooleanIntoSharedPrefIndex = lastMoveResultObjectIndex + 1
-                    val putBooleanIntoSharedPrefInstruction = getInstruction(putBooleanIntoSharedPrefIndex)
-                    val boolRegister = putBooleanIntoSharedPrefInstruction.registersUsed[2]
-
-                    addInstruction(
-                        putBooleanIntoSharedPrefIndex,
-                        """
-                        const v$boolRegister, 0x0
-                        """.trimIndent(),
-                    )
+                RedirectingToXLiteFlagCheckFingerprint.let {
+                    it.method.apply {
+                        val match = it.instructionMatches.last()
+                        val index = match.index
+                        val register = match.instruction.registersUsed[2]
+                        addInstruction(index, "const v$register, 0x0")
+                    }
                 }
 
-                XLiteSettingItemsAdderFingerprint.apply {
-                    val strIndex = instructionMatches.first().index
-                    method.apply {
-                        val originalXItemCheckInstruction =
-                            instructions.last { it.opcode == Opcode.IF_EQZ && it.location.index < strIndex }
-                        val register = originalXItemCheckInstruction.registersUsed[0]
-                        addInstruction(originalXItemCheckInstruction.location.index, "const v$register, 0x1")
+                getXLiteSettingItemsAdderFingerprint(is_12_07_or_greater).let {
+                    it.method.apply {
+                        val match = it.instructionMatches[1]
+                        val index = match.index
+                        val register = match.instruction.registersUsed[0]
+                        addInstruction(index + 1, "const v$register, 0x1")
                     }
                 }
 

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
@@ -64,7 +64,6 @@ private fun getShowDialogFingerprint(dismissButtonField: FieldReference) = objec
     )
 ) {}
 
-
 @Suppress("unused")
 val blockUpdateScreenPatch =
     bytecodePatch(

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.twitter.misc.blockUpdateScreen
+
+import app.crimera.patches.twitter.misc.settings.settingsPatch
+import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
+import app.crimera.patches.twitter.utils.Constants.PREF_DESCRIPTOR
+import app.crimera.patches.twitter.utils.enableSettings
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.InstructionLocation.MatchAfterWithin
+import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.methodCall
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patches.all.misc.resources.ResourceType
+import app.morphe.patches.all.misc.resources.resourceLiteral
+import app.morphe.patches.all.misc.resources.resourceMappingPatch
+import app.morphe.util.getReference
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+
+private object FullCoverDialogInflateFingerprint : Fingerprint(
+    definingClass = "Lcom/twitter/ui/dialog/fullcover/",
+    name = "<init>",
+    returnType = "V",
+    filters = listOf(
+        resourceLiteral(
+            type = ResourceType.LAYOUT,
+            name = "vdl_full_cover"
+        ),
+        resourceLiteral(
+            type = ResourceType.ID,
+            name = "dismiss_button"
+        ),
+        fieldAccess(
+            opcode = Opcode.IPUT_OBJECT,
+            definingClass = "this",
+            type = "Landroid/view/View;"
+        )
+    )
+)
+
+private fun getShowDialogFingerprint(dismissButtonField: FieldReference) = object : Fingerprint(
+    name = "get",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf(),
+    returnType = "Ljava/lang/Object;",
+    filters = listOf(
+        fieldAccess(
+            opcode = Opcode.IGET_OBJECT,
+            reference = dismissButtonField
+        ),
+        methodCall(
+            opcode = Opcode.INVOKE_VIRTUAL,
+            name = "setOnClickListener",
+            location = MatchAfterWithin(5)
+        )
+    )
+) {}
+
+
+@Suppress("unused")
+val blockUpdateScreenPatch =
+    bytecodePatch(
+        name = "Block update screen",
+        description = "Blocks the 'This app is out of date' update screen from being shown on launch",
+    ) {
+        compatibleWith(COMPATIBILITY_X)
+
+        dependsOn(
+            settingsPatch,
+            resourceMappingPatch
+        )
+
+        execute {
+            val dismissButtonField = FullCoverDialogInflateFingerprint
+                .instructionMatches
+                .last()
+                .instruction
+                .getReference<FieldReference>()!!
+
+            getShowDialogFingerprint(dismissButtonField).let {
+                it.method.apply {
+                    val match = it.instructionMatches.last()
+                    val index = match.index
+                    val register = match.instruction.registersUsed[0]
+
+                    addInstruction(
+                        index + 1,
+                        "invoke-static { v$register }, $PREF_DESCRIPTOR;->blockUpdateScreen(Landroid/view/View;)V"
+                    )
+                }
+            }
+
+            enableSettings("blockUpdateScreen")
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/utils/VersionCheckPatch.kt
@@ -30,6 +30,8 @@ var is_11_92_or_greater: Boolean by Delegates.notNull()
 // For blocking redirecting X Lite patch.
 var is_11_98_or_greater: Boolean by Delegates.notNull()
     private set
+var is_12_07_or_greater: Boolean by Delegates.notNull()
+    private set
 
 val versionCheckPatch =
     bytecodePatch {
@@ -45,5 +47,6 @@ val versionCheckPatch =
             is_11_92_or_greater = isEqualsOrGreaterThan(311920000)
 
             is_11_98_or_greater = isEqualsOrGreaterThan(311980000)
+            is_12_07_or_greater = isEqualsOrGreaterThan(312070000)
         }
     }

--- a/patches/src/main/resources/addresources/values/twitter/strings.xml
+++ b/patches/src/main/resources/addresources/values/twitter/strings.xml
@@ -150,6 +150,8 @@
     <string name="piko_pref_search_suggestion_desc">Hides search suggestion in explore section</string>
     <string name="piko_legacy_share_link">Legacy share links</string>
     <string name="piko_block_redirecting_to_x_lite">Block redirecting to X Lite</string>
+    <string name="piko_pref_block_update_screen">Block update screen</string>
+    <string name="piko_pref_block_update_screen_desc">Blocks the \'This app is out of date\' update screen from being shown on launch</string>
 
     <!-- Feature flags Settings -->
     <string name="piko_title_feature_flags">Feature flags</string>


### PR DESCRIPTION
### Description

This patch automatically closes the `This app is out of date` dialog.

<details>
<summary>Image</summary>
<img width="877" height="1899" alt="update_screen" src="https://github.com/user-attachments/assets/41f950d2-ed9d-4f10-bffe-fa506058ef59" />
</details>

### Additional Context

I also fixed an issue where the `Block redirecting to X Lite` patch failed in versions prior to 12.7.0-release.0.

### Test Results

Tested on 12.6.0-release.0 & 12.17.0-release.0.