### PR TITLE
feat(Instagram): Restore classic search recents (up to 25)

### DIFF
--- a/docs/mappings/piko_recommended_flags_v3.json
+++ b/docs/mappings/piko_recommended_flags_v3.json
@@ -128,5 +128,47 @@
     "name" : "Add Meta AI reels description pills",
     "desc" : "",
     "code" : "80654"
+  },
+  {
+    "name" : "Meta AI suggestions in search",
+    "desc" : "Disable to show recent profile searches instead.",
+    "code" : "111509::3"
+  },
+  {
+    "name" : "Collapsible recent searches",
+    "desc" : "Disable to stop the recent searches list from collapsing.",
+    "code" : "111509::9"
+  },
+  {
+    "name" : "Horizontal scroll for recent searches",
+    "desc" : "Disable to show recent searches in a vertical list instead.",
+    "code" : "111509::21"
+  },
+  {
+    "name" : "Search bar hint carousel",
+    "desc" : "",
+    "code" : "111509::25"
+  },
+  {
+    "name" : "Search bar hint carousel (dynamic)",
+    "desc" : "",
+    "code" : "111509::26"
+  },
+  {
+    "name" : "Suggested users in search null state",
+    "desc" : "Disable to hide suggested accounts from the search screen.",
+    "code" : "63806::0"
+  },
+  {
+    "name" : "Max recent searches shown (Android)",
+    "desc" : "Number of recent profiles kept in search history. Classic value was 25.",
+    "code" : "111509::17",
+    "type" : "long"
+  },
+  {
+    "name" : "Max recent searches shown",
+    "desc" : "Number of recent profiles kept in search history. Classic value was 25.",
+    "code" : "111509::1",
+    "type" : "long"
   }
 ]

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
@@ -15,14 +15,21 @@ public class Flag {
 
     private String name;
     private String desc;
-    private String type;
+    private FlagType type;
     private StringSetting code;
 
     public Flag(JSONObject jsonObject) {
         try {
             this.name = jsonObject.optString("name");
             this.desc = jsonObject.optString("desc");
-            this.type = jsonObject.optString("type", "bool");
+            String rawType = jsonObject.optString("type", "bool");
+            this.type = FlagType.BOOL;
+            for (FlagType candidate : FlagType.values()) {
+                if (candidate.toString().equals(rawType)) {
+                    this.type = candidate;
+                    break;
+                }
+            }
             String codeKey = jsonObject.optString("code");
             // No override by default -- both bool and long flags use FlagState.DEFAULT
             // as the "no override" sentinel, so dev-options and override-backup restores
@@ -41,7 +48,7 @@ public class Flag {
     }
 
     public boolean isLongType() {
-        return "long".equals(type);
+        return type == FlagType.LONG;
     }
 
     public StringSetting getCode() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
@@ -24,11 +24,10 @@ public class Flag {
             this.desc = jsonObject.optString("desc");
             this.type = jsonObject.optString("type", "bool");
             String codeKey = jsonObject.optString("code");
-            // Long-typed flags default to an empty override (rendered as a blank
-            // numeric field) instead of the "default" sentinel bool flags use,
-            // since showing the literal word "default" in a number box reads wrong.
-            String defaultValue = isLongType() ? "" : FlagState.DEFAULT.toString();
-            this.code = new StringSetting(codeKey, defaultValue);
+            // No override by default -- both bool and long flags use FlagState.DEFAULT
+            // as the "no override" sentinel, so dev-options and override-backup restores
+            // (which don't touch this store) remain free to take effect unopposed.
+            this.code = new StringSetting(codeKey, FlagState.DEFAULT.toString());
         } catch (Exception e) {
         }
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/Flag.java
@@ -15,14 +15,20 @@ public class Flag {
 
     private String name;
     private String desc;
+    private String type;
     private StringSetting code;
 
     public Flag(JSONObject jsonObject) {
         try {
             this.name = jsonObject.optString("name");
             this.desc = jsonObject.optString("desc");
+            this.type = jsonObject.optString("type", "bool");
             String codeKey = jsonObject.optString("code");
-            this.code = new StringSetting(codeKey,FlagState.DEFAULT.toString());
+            // Long-typed flags default to an empty override (rendered as a blank
+            // numeric field) instead of the "default" sentinel bool flags use,
+            // since showing the literal word "default" in a number box reads wrong.
+            String defaultValue = isLongType() ? "" : FlagState.DEFAULT.toString();
+            this.code = new StringSetting(codeKey, defaultValue);
         } catch (Exception e) {
         }
     }
@@ -33,6 +39,10 @@ public class Flag {
 
     public String getDesc() {
         return desc;
+    }
+
+    public boolean isLongType() {
+        return "long".equals(type);
     }
 
     public StringSetting getCode() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagType.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagType.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.devFlags;
+
+public enum FlagType {
+    BOOL,
+    LONG;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagsSharedPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagsSharedPref.java
@@ -47,10 +47,35 @@ public class FlagsSharedPref extends BaseSharedPref {
             while (keys.hasNext()) {
                 String key = keys.next();
                 String flagState = (String) flags.get(key);
-                if (flagState.equals(FlagState.DEFAULT.toString())) continue;
+                // Long-typed flags share this same pref file, so their stored
+                // value (a number, or empty) won't match either bool state --
+                // only treat it as a bool override if it actually looks like one.
+                if (!flagState.equals(FlagState.ENABLE.toString()) && !flagState.equals(FlagState.DISABLE.toString())) continue;
                 Boolean value = flagState.equals(FlagState.ENABLE.toString()) ? true:false;
                 PikoUtils.logger(key+" : "+Boolean.valueOf(value));
                 outFlags.put(key, value);
+            }
+        } catch (Exception e) {
+
+        }
+        return outFlags;
+    }
+
+    public static Map<String, Long> getAllLong(){
+        Map<String, Long> outFlags = new HashMap();
+        try {
+            JSONObject flags = INSTANCE.all();
+            Iterator<String> keys = flags.keys();
+            while (keys.hasNext()) {
+                String key = keys.next();
+                String flagState = (String) flags.get(key);
+                try {
+                    Long value = Long.parseLong(flagState);
+                    PikoUtils.logger(key+" : "+value);
+                    outFlags.put(key, value);
+                } catch (NumberFormatException ignored) {
+                    // Not a long override (empty, or a bool flag's own state) -- skip.
+                }
             }
         } catch (Exception e) {
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagsSharedPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/FlagsSharedPref.java
@@ -52,7 +52,7 @@ public class FlagsSharedPref extends BaseSharedPref {
                 // only treat it as a bool override if it actually looks like one.
                 if (!flagState.equals(FlagState.ENABLE.toString()) && !flagState.equals(FlagState.DISABLE.toString())) continue;
                 Boolean value = flagState.equals(FlagState.ENABLE.toString()) ? true:false;
-                PikoUtils.logger(key+" : "+Boolean.valueOf(value));
+                // PikoUtils.logger(key+" : "+Boolean.valueOf(value));
                 outFlags.put(key, value);
             }
         } catch (Exception e) {
@@ -71,7 +71,6 @@ public class FlagsSharedPref extends BaseSharedPref {
                 String flagState = (String) flags.get(key);
                 try {
                     Long value = Long.parseLong(flagState);
-                    PikoUtils.logger(key+" : "+value);
                     outFlags.put(key, value);
                 } catch (NumberFormatException ignored) {
                     // Not a long override (empty, or a bool flag's own state) -- skip.

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/HookFlags.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/devFlags/HookFlags.java
@@ -19,6 +19,7 @@ import app.morphe.extension.instagram.settings.SettingsStatus;
 
 public class HookFlags {
     private static Map<String, Boolean> BOOL_FLAGS = new HashMap<>();
+    private static Map<String, Long> LONG_FLAGS = new HashMap<>();
     private static DeveloperOptions developerOptions = new DeveloperOptions();
 
     private static void onboardingPermissionPromptFlags() {
@@ -31,7 +32,7 @@ public class HookFlags {
         BOOL_FLAGS.put("117613::0", true); //ig_overflow_menu_icon::use_more_lines_icon
         BOOL_FLAGS.put("100002", true); //ig_igds_android_prism_overflow_sheet
     }
-   
+
     private static void adsFlags() {
 //        BOOL_FLAGS.put("58206::0", false); //is_acp_enabled
 //        BOOL_FLAGS.put("72396::0", false); //is_mae_exclusion_feed_enabled
@@ -82,6 +83,8 @@ public class HookFlags {
         if(SettingsStatus.recommendedFlags) {
             Map<String, Boolean> recFlags = FlagsSharedPref.getAll();
             BOOL_FLAGS.putAll(recFlags);
+            Map<String, Long> recLongFlags = FlagsSharedPref.getAllLong();
+            LONG_FLAGS.putAll(recLongFlags);
         }
     }
 
@@ -101,6 +104,23 @@ public class HookFlags {
 
             String configId = developerOptionsItem.getConfigId();
             return BOOL_FLAGS.getOrDefault(configId, null);
+        } catch (Exception e) {
+            PikoUtils.logger(e);
+        }
+        return null;
+    }
+
+    // mobileConfig has no dedicated int type, hence the integer-valued flags (counts, limits) are stored and returned.
+    // as long instead of boolean
+    public static Long handleLongFlags(long mobileConfigSpecifier) {
+        try {
+            DeveloperOptionsItem developerOptionsItem = new DeveloperOptionsItem(mobileConfigSpecifier);
+            String universalId = developerOptionsItem.getUniversalId();
+            Long universalFlag = LONG_FLAGS.getOrDefault(universalId, null);
+            if(universalFlag!=null) return universalFlag;
+
+            String configId = developerOptionsItem.getConfigId();
+            return LONG_FLAGS.getOrDefault(configId, null);
         } catch (Exception e) {
             PikoUtils.logger(e);
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -891,13 +891,23 @@ public class ScreenBuilder {
         // rather than triggering new build
         // for every a new flag.
         for(Flag flag : recFlags) {
-            addPreference(
-                    helper.listPreference(
-                            flag.getName(),
-                            flag.getDesc(),
-                            flag.getCode()
-                    )
-            );
+            if (flag.isLongType()) {
+                addPreference(
+                        helper.editTextNumPreference(
+                                flag.getName(),
+                                flag.getDesc(),
+                                flag.getCode()
+                        )
+                );
+            } else {
+                addPreference(
+                        helper.listPreference(
+                                flag.getName(),
+                                flag.getDesc(),
+                                flag.getCode()
+                        )
+                );
+            }
         }
     }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
@@ -13,12 +13,15 @@ import android.preference.Preference;
 import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.EditText;
 import app.morphe.extension.instagram.patches.Links;
+import app.morphe.extension.instagram.patches.devFlags.FlagState;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.Helper;
 
 public class EditTextPref extends EditTextPreference {
     private static Helper helper;
+    private boolean numericOnly;
 
     public EditTextPref(Context context) {
         super(InstagramPreferenceStyle.dialogContext(context));
@@ -37,6 +40,7 @@ public class EditTextPref extends EditTextPreference {
         init();
     }
     public void setNumericOnly(boolean numericOnly) {
+        this.numericOnly = numericOnly;
         if (numericOnly) {
             getEditText().setInputType(InputType.TYPE_CLASS_NUMBER);
             getEditText().setSingleLine(true);
@@ -69,5 +73,16 @@ public class EditTextPref extends EditTextPreference {
     @Override
     protected void onBindView(View view) {
         InstagramPreferenceStyle.bindText(this, view);
+    }
+
+    @Override
+    protected void onAddEditTextToDialogView(View dialogView, EditText editText) {
+        super.onAddEditTextToDialogView(dialogView, editText);
+        // Numeric (long-typed) dev flags persist FlagState.DEFAULT ("default") as
+        // their "no override" sentinel; blank the field here so the number box
+        // shows empty instead of the literal word "default".
+        if (numericOnly && FlagState.DEFAULT.toString().equals(editText.getText().toString())) {
+            editText.setText("");
+        }
     }
 }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/hookFlags/HookFlagsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/hookFlags/HookFlagsPatch.kt
@@ -60,6 +60,33 @@ val hookFlagsPatch =
                                 """.trimIndent(),
                             )
                         }
+
+                    methods
+                        .first {
+                            it.returnType == "J" && it.parameters.size == 3 &&
+                                it.parameters[0].type == configValueSourceWrapperClassType
+                        }.apply {
+                            val isStaticMethod = AccessFlags.STATIC.isSet(method.accessFlags)
+
+                            var configSpecifierRegister = parameters.indexOfFirst { it.type == "J" }
+                            if (!isStaticMethod) {
+                                configSpecifierRegister += 1
+                            }
+                            addInstructions(
+                                0,
+                                """
+                                invoke-static/range {p$configSpecifierRegister .. p${configSpecifierRegister + 1}}, $HOOK_FLAGS_DESCRIPTOR->handleLongFlags(J)Ljava/lang/Long;
+                                move-result-object v0
+                                # 1. Check if the result is NULL
+                                if-eqz v0, :piko
+                                invoke-virtual {v0}, Ljava/lang/Long;->longValue()J
+                                move-result-wide v1
+                                return-wide v1
+                                :piko
+                                nop
+                                """.trimIndent(),
+                            )
+                        }
                 }
             }
         }


### PR DESCRIPTION
Search used to show up to 25 recent profiles on the empty-state screen. Newer builds swapped that for Meta AI suggestions plus a collapsed list you have to tap "show more" on this brings the old one back.

One thing had to happen first: the flag hook only did boolean MobileConfig overrides, and the recent count values are `long` (MobileConfig has no real int type). Extended the hook to cover long-returning flags too. Same accessor class as the boolean one already hooked, same method shape, just `J` instead of `Z`.

Tested on 439.0.0.37.89.