### PR TITLE
feat(Instagram): Indicator for deleted messages and the ability to view content (images, videos, voice messages, etc.) externally

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -15,9 +15,12 @@ import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.util.TypedValue;
+import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import java.util.ArrayList;
 
@@ -135,6 +138,92 @@ public class UI {
             return imageView;
         } catch (Exception e) {
             Logger.printException(() -> "Failed addImageViewToViewGroup: ", e);
+        }
+        return null;
+    }
+
+    /**
+     * Same as {@link #addImageViewToViewGroup}, but wraps the icon in a FrameLayout so an
+     * optional small colored dot can be overlaid on its top-right corner — used for the
+     * unseen-deleted-message indicator on the DM history icon. The wrapper keeps this safe to
+     * use regardless of the actual parent ViewGroup type (LinearLayout, Toolbar, etc.), since the
+     * overlay only ever happens inside the FrameLayout we control.
+     */
+    public static ImageView addImageViewWithBadge(
+            ViewGroup viewGroup,
+            String iconDrawable,
+            Runnable action,
+            boolean showBadge,
+            int badgeColor,
+            int badgeStrokeColor,
+            int badgeStrokeWidth
+    ) {
+        try {
+            if (viewGroup == null) {
+                return null;
+            }
+
+            Context context = viewGroup.getContext();
+            ImageView imageView = new ImageView(context);
+
+            setThemedIcon(imageView, iconDrawable);
+            imageView.setLayoutParams(new FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+            if (action != null) {
+                imageView.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View v) {
+                        try {
+                            action.run();
+                        } catch (Exception ex) {
+                            Logger.printException(() -> "addImageViewWithBadge click failed: ", ex);
+                        }
+                    }
+                });
+            }
+            int padding = Dim.dp16;
+            imageView.setPadding(padding, padding, padding, padding);
+
+            FrameLayout wrapper = new FrameLayout(context);
+            wrapper.setLayoutParams(new ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+            ));
+            wrapper.addView(imageView);
+
+            if (showBadge) {
+                View badge = new View(context);
+                GradientDrawable dot = new GradientDrawable();
+                dot.setShape(GradientDrawable.OVAL);
+                dot.setColor(badgeColor);
+                if (badgeStrokeWidth > 0) {
+                    dot.setStroke(badgeStrokeWidth, badgeStrokeColor);
+                }
+                badge.setBackground(dot);
+                badge.setTag("piko_unseen_deleted_badge");
+
+                int badgeSize = Dim.dp8 + Dim.dp4;
+                FrameLayout.LayoutParams badgeParams = new FrameLayout.LayoutParams(badgeSize, badgeSize);
+                badgeParams.gravity = Gravity.END | Gravity.TOP;
+                // Sits just inside the icon's dp16 touch padding, over its top-right corner.
+                badgeParams.topMargin = Dim.dp8;
+                badgeParams.rightMargin = Dim.dp8;
+                badge.setLayoutParams(badgeParams);
+                wrapper.addView(badge);
+            }
+
+            int count = viewGroup.getChildCount();
+            int insertIndex = count - 1;
+            if (insertIndex < 0) {
+                insertIndex = 0;
+            }
+
+            viewGroup.addView(wrapper, insertIndex);
+            return imageView;
+        } catch (Exception e) {
+            Logger.printException(() -> "Failed addImageViewWithBadge: ", e);
         }
         return null;
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -16,12 +16,14 @@ import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.GradientDrawable;
+import android.graphics.Typeface;
 import android.util.TypedValue;
 import android.view.Gravity;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
+import android.widget.TextView;
 import java.util.ArrayList;
 
 import app.morphe.extension.crimera.PikoUtils;
@@ -144,19 +146,20 @@ public class UI {
 
     /**
      * Same as {@link #addImageViewToViewGroup}, but wraps the icon in a FrameLayout so an
-     * optional small colored dot can be overlaid on its top-right corner — used for the
-     * unseen-deleted-message indicator on the DM history icon. The wrapper keeps this safe to
+     * optional small counter badge can be overlaid on its top-right corner — used for the
+     * unseen-deleted-message count on the DM history icon. The wrapper keeps this safe to
      * use regardless of the actual parent ViewGroup type (LinearLayout, Toolbar, etc.), since the
      * overlay only ever happens inside the FrameLayout we control.
+     *
+     * @param badgeCount 0 (or less) hides the badge entirely; otherwise shows the count, capped
+     *                   at "99+" so it never overflows the pill.
      */
     public static ImageView addImageViewWithBadge(
             ViewGroup viewGroup,
             String iconDrawable,
             Runnable action,
-            boolean showBadge,
-            int badgeColor,
-            int badgeStrokeColor,
-            int badgeStrokeWidth
+            int badgeCount,
+            int badgeColor
     ) {
         try {
             if (viewGroup == null) {
@@ -193,23 +196,41 @@ public class UI {
             ));
             wrapper.addView(imageView);
 
-            if (showBadge) {
-                View badge = new View(context);
-                GradientDrawable dot = new GradientDrawable();
-                dot.setShape(GradientDrawable.OVAL);
-                dot.setColor(badgeColor);
-                if (badgeStrokeWidth > 0) {
-                    dot.setStroke(badgeStrokeWidth, badgeStrokeColor);
-                }
-                badge.setBackground(dot);
+            if (badgeCount > 0) {
+                TextView badge = new TextView(context);
                 badge.setTag("piko_unseen_deleted_badge");
+                badge.setText((badgeCount > 99 ? "99" : String.valueOf(badgeCount)) + "+");
+                badge.setTextColor(Color.WHITE);
+                badge.setTextSize(TypedValue.COMPLEX_UNIT_SP, 11);
+                badge.setTypeface(Typeface.create("sans-serif-medium", Typeface.NORMAL));
+                badge.setGravity(Gravity.CENTER);
+                badge.setIncludeFontPadding(false);
 
-                int badgeSize = Dim.dp8 + Dim.dp4;
-                FrameLayout.LayoutParams badgeParams = new FrameLayout.LayoutParams(badgeSize, badgeSize);
+                GradientDrawable pill = new GradientDrawable();
+                pill.setShape(GradientDrawable.OVAL);
+                pill.setColor(badgeColor);
+                // No border — a hard stroke made it look heavy/detached from the icon. A flat
+                // fill reads as a badge on its own without needing an outline.
+                badge.setBackground(pill);
+
+                // Fixed height keeps it circular for a single digit; horizontal padding lets it
+                // stretch into a pill for "99+" without the text getting clipped.
+                int badgeMinSize = Dim.dp8 + Dim.dp6;
+                badge.setMinWidth(badgeMinSize);
+                badge.setMinHeight(badgeMinSize);
+                int horizontalPadding = Dim.dp2;
+                badge.setPadding(horizontalPadding, 0, horizontalPadding, 0);
+
+                FrameLayout.LayoutParams badgeParams = new FrameLayout.LayoutParams(
+                        ViewGroup.LayoutParams.WRAP_CONTENT, badgeMinSize);
                 badgeParams.gravity = Gravity.END | Gravity.TOP;
-                // Sits just inside the icon's dp16 touch padding, over its top-right corner.
-                badgeParams.topMargin = Dim.dp8;
-                badgeParams.rightMargin = Dim.dp8;
+                // The icon itself has Dim.dp16 padding around its visible glyph (for a bigger
+                // touch target), so a small margin here sits near the wrapper's outer edge —
+                // far from the icon you actually see. Compensating most of that padding puts the
+                // badge right against the visible icon's corner instead.
+                int badgeInset = Dim.dp16 - Dim.dp4;
+                badgeParams.topMargin = badgeInset;
+                badgeParams.rightMargin = badgeInset;
                 badge.setLayoutParams(badgeParams);
                 wrapper.addView(badge);
             }
@@ -226,6 +247,17 @@ public class UI {
             Logger.printException(() -> "Failed addImageViewWithBadge: ", e);
         }
         return null;
+    }
+
+    /** System Material You accent color (Android 12+), or the given fallback on older devices
+     *  or if the dynamic color resource can't be resolved for any reason. */
+    public static int resolveDynamicOrFallbackColor(Context context, int fallbackColor) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+            try {
+                return context.getColor(android.R.color.system_accent1_600);
+            } catch (Exception ignored) {}
+        }
+        return fallbackColor;
     }
 
     public static void pikoSettingsGear(ViewGroup viewGroup) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
@@ -18,7 +18,7 @@ import java.util.List;
 public class PikoMessageDb extends SQLiteOpenHelper {
 
     private static final String DB_NAME = "piko_dm_vault.db";
-    private static final int DB_VERSION = 2;
+    private static final int DB_VERSION = 3;
     private static final String TABLE = "saved_messages";
     // sender_id → username directory. MQTT-delivered items carry only a numeric sender_id;
     // the REST path occasionally carries a full UserInfo. Every time we resolve a username we
@@ -54,7 +54,8 @@ public class PikoMessageDb extends SQLiteOpenHelper {
             "content TEXT," +
             "message_type TEXT," +
             "timestamp INTEGER NOT NULL," +
-            "is_deleted INTEGER DEFAULT 0" +
+            "is_deleted INTEGER DEFAULT 0," +
+            "is_seen INTEGER DEFAULT 0" +
             ")"
         );
         db.execSQL("CREATE INDEX idx_thread_id ON " + TABLE + "(thread_id)");
@@ -73,8 +74,9 @@ public class PikoMessageDb extends SQLiteOpenHelper {
 
     @Override
     public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
-        // Additive upgrade: keep captured messages, just add the new directory table.
+        // Additive upgrade: keep captured messages, just add the new directory table / columns.
         if (oldVersion < 2) createDirTable(db);
+        if (oldVersion < 3) db.execSQL("ALTER TABLE " + TABLE + " ADD COLUMN is_seen INTEGER DEFAULT 0");
     }
 
     /**
@@ -221,6 +223,30 @@ public class PikoMessageDb extends SQLiteOpenHelper {
         ContentValues cv = new ContentValues();
         cv.put("is_deleted", 1);
         db.update(TABLE, cv, "message_id = ?", new String[]{messageId});
+    }
+
+    /** True when a thread has at least one deleted message the user hasn't opened the
+     *  deleted-messages screen for yet. Drives the unseen-deletion badge next to the thread's
+     *  history icon inside the conversation. */
+    public boolean hasUnseenDeletedMessages(String threadId) {
+        if (threadId == null || threadId.isEmpty()) return false;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.query(TABLE, new String[]{"message_id"},
+                "thread_id = ? AND is_deleted = 1 AND is_seen = 0" + HAS_CONTENT,
+                new String[]{threadId}, null, null, null, "1");
+        boolean unseen = c.moveToFirst();
+        c.close();
+        return unseen;
+    }
+
+    /** Marks every deleted message in a thread as seen — call when the user opens the
+     *  thread-scoped deleted-messages screen, so the badge clears. */
+    public void markThreadSeen(String threadId) {
+        if (threadId == null || threadId.isEmpty()) return;
+        SQLiteDatabase db = getWritableDatabase();
+        ContentValues cv = new ContentValues();
+        cv.put("is_seen", 1);
+        db.update(TABLE, cv, "thread_id = ? AND is_deleted = 1", new String[]{threadId});
     }
 
     /** Returns sender_username if non-empty, else sender_id (numeric), else null. */

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/db/PikoMessageDb.java
@@ -239,6 +239,22 @@ public class PikoMessageDb extends SQLiteOpenHelper {
         return unseen;
     }
 
+    /** How many deleted messages in a thread the user hasn't seen yet — drives the counter
+     *  badge next to the thread's history icon. Resets to 0 once {@link #markThreadSeen}
+     *  runs, and counts back up from there for messages deleted after that point. */
+    public int getUnseenDeletedCount(String threadId) {
+        if (threadId == null || threadId.isEmpty()) return 0;
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor c = db.rawQuery(
+                "SELECT COUNT(*) FROM " + TABLE
+                        + " WHERE thread_id = ? AND is_deleted = 1 AND is_seen = 0" + HAS_CONTENT,
+                new String[]{threadId});
+        int count = 0;
+        if (c.moveToFirst()) count = c.getInt(0);
+        c.close();
+        return count;
+    }
+
     /** Marks every deleted message in a thread as seen — call when the user opens the
      *  thread-scoped deleted-messages screen, so the badge clears. */
     public void markThreadSeen(String threadId) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -259,18 +259,52 @@ public class MediaData extends Entity {
 
     public String getVideoLink() throws Exception {
         List<VideoData> videoDataList = this.getVideoVariants();
-        if(videoDataList!=null){
-            return videoDataList.get(0).getUrl();
-        }
-        return null;
+        VideoData best = highestResolutionVideo(videoDataList);
+        return best != null ? best.getUrl() : null;
     }
-    
+
     public String getImageLink() throws Exception {
         List<ImageData> imageDataList = this.getImageVariants();
-        if(imageDataList!=null){
-            return imageDataList.get(0).getUrl();
+        ImageData best = highestResolutionImage(imageDataList);
+        return best != null ? best.getUrl() : null;
+    }
+
+    /** Picks the variant with the largest width*height, falling back to index 0 if any
+     *  dimension lookup fails (variant lists aren't guaranteed to be sorted by resolution). */
+    private static VideoData highestResolutionVideo(List<VideoData> variants) {
+        if (variants == null || variants.isEmpty()) return null;
+        VideoData best = variants.get(0);
+        long bestArea = -1;
+        for (VideoData variant : variants) {
+            try {
+                long area = (long) variant.getWidth() * (long) variant.getHeight();
+                if (area > bestArea) {
+                    bestArea = area;
+                    best = variant;
+                }
+            } catch (Exception ignored) {
+                // Keep whatever "best" already holds; a variant we can't measure never wins.
+            }
         }
-        return null;
+        return best;
+    }
+
+    private static ImageData highestResolutionImage(List<ImageData> variants) {
+        if (variants == null || variants.isEmpty()) return null;
+        ImageData best = variants.get(0);
+        long bestArea = -1;
+        for (ImageData variant : variants) {
+            try {
+                long area = (long) variant.getWidth() * (long) variant.getHeight();
+                if (area > bestArea) {
+                    bestArea = area;
+                    best = variant;
+                }
+            } catch (Exception ignored) {
+                // Keep whatever "best" already holds; a variant we can't measure never wins.
+            }
+        }
+        return best;
     }
 
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -24,8 +24,10 @@ import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.entity.ProfileInfo;
 import app.morphe.extension.instagram.patches.userprofile.ProfileMoreOption;
 import app.morphe.extension.instagram.patches.dm.SavedMessagesHook;
+import app.morphe.extension.instagram.db.PikoMessageDb;
 import app.morphe.extension.instagram.entity.UserData;
 import app.morphe.extension.instagram.constants.Constants;
+import app.morphe.extension.shared.ui.Dim;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.Utils;
@@ -140,8 +142,14 @@ public class ActionBarPatch {
 
             if(SettingsStatus.saveDeletedMessages) {
                 Context context = viewGroup.getContext();
-                UI.addImageViewToViewGroup(viewGroup, UI.DRAWABLE_HISTORY_ICON,
-                        () -> SavedMessagesHook.openDeletedMessages(context));
+                String threadId = SavedMessagesHook.resolveOpenThreadId();
+                boolean hasUnseen = threadId != null
+                        && PikoMessageDb.getInstance(context).hasUnseenDeletedMessages(threadId);
+                int badgeColor = android.graphics.Color.parseColor("#FFD400");
+                int badgeStrokeColor = android.graphics.Color.BLACK;
+                UI.addImageViewWithBadge(viewGroup, UI.DRAWABLE_HISTORY_ICON,
+                        () -> SavedMessagesHook.openDeletedMessages(context),
+                        hasUnseen, badgeColor, badgeStrokeColor, Dim.dp2);
             }
 
         } catch (Exception e) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/actionbar/ActionBarPatch.java
@@ -27,7 +27,7 @@ import app.morphe.extension.instagram.patches.dm.SavedMessagesHook;
 import app.morphe.extension.instagram.db.PikoMessageDb;
 import app.morphe.extension.instagram.entity.UserData;
 import app.morphe.extension.instagram.constants.Constants;
-import app.morphe.extension.shared.ui.Dim;
+import app.morphe.extension.instagram.theme.MaterialYouTheme;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.Utils;
@@ -142,14 +142,24 @@ public class ActionBarPatch {
 
             if(SettingsStatus.saveDeletedMessages) {
                 Context context = viewGroup.getContext();
-                String threadId = SavedMessagesHook.resolveOpenThreadId();
-                boolean hasUnseen = threadId != null
-                        && PikoMessageDb.getInstance(context).hasUnseenDeletedMessages(threadId);
-                int badgeColor = android.graphics.Color.parseColor("#FFD400");
-                int badgeStrokeColor = android.graphics.Color.BLACK;
-                UI.addImageViewWithBadge(viewGroup, UI.DRAWABLE_HISTORY_ICON,
-                        () -> SavedMessagesHook.openDeletedMessages(context),
-                        hasUnseen, badgeColor, badgeStrokeColor, Dim.dp2);
+                // Deferred: Hook 5 (noteOpenThreadId) and this icon's own injection point live in
+                // the same patched method but at different instruction offsets, so their relative
+                // order isn't guaranteed. Posting reads the thread id on the next UI frame, after
+                // the whole method (and both injected calls) has already finished running.
+                viewGroup.post(() -> {
+                    String threadId = SavedMessagesHook.resolveOpenThreadId();
+                    int unseenCount = threadId != null
+                            ? PikoMessageDb.getInstance(context).getUnseenDeletedCount(threadId)
+                            : 0;
+                    // Blue by default; only follows the system's dynamic accent color when the
+                    // user has Piko's own "Material You theme" setting turned on.
+                    int badgeColor = MaterialYouTheme.isMaterialYouEnabled()
+                            ? UI.resolveDynamicOrFallbackColor(context, android.graphics.Color.parseColor("#1E88E5"))
+                            : android.graphics.Color.parseColor("#1E88E5");
+                    UI.addImageViewWithBadge(viewGroup, UI.DRAWABLE_HISTORY_ICON,
+                            () -> SavedMessagesHook.openDeletedMessages(context),
+                            unseenCount, badgeColor);
+                });
             }
 
         } catch (Exception e) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/DeletedMessagesActivity.java
@@ -28,6 +28,7 @@ import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.db.PikoMessageDb;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
+import app.morphe.extension.instagram.settings.ActivityHook;
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.ui.Dim;
@@ -57,6 +58,9 @@ public class DeletedMessagesActivity extends Activity {
         messages = threadId != null
             ? PikoMessageDb.getInstance(this).getDeletedMessagesForThread(threadId)
             : PikoMessageDb.getInstance(this).getDeletedMessages();
+
+        // Clears the unseen-deletion badge shown next to the history icon in the conversation.
+        if (threadId != null) PikoMessageDb.getInstance(this).markThreadSeen(threadId);
 
         String titleText = threadId != null ? str("piko_deleted_in_chat") : str("piko_all_deleted_messages");
 
@@ -208,7 +212,12 @@ public class DeletedMessagesActivity extends Activity {
         try {
             final boolean isAudio = "voice_media".equals(type) || "audio".equals(type)
                     || url.matches("(?i).*\\.(m4a|aac|mp3|ogg)(\\?.*)?$");
-            final boolean isVideo = "video".equals(type) || "clip".equals(type) || "xma_clip".equals(type);
+            // item_type alone can't tell photo from video — a plain photo and a plain video DM
+            // both come through as "media" (or "raven_media" for disappearing media); the actual
+            // type lives on the Media object, not the DirectItem. "clip"/"xma_clip" cover reel
+            // shares, but for everything else we fall back to sniffing the real CDN url extension.
+            final boolean isVideo = "clip".equals(type) || "xma_clip".equals(type)
+                    || url.matches("(?i).*\\.(mp4|mov|m4v|webm)(\\?.*)?$");
             // A shared post/reel is stored as an instagram.com permalink and opens inside the IG app,
             // so label its action "Open in Instagram" rather than "open externally".
             final boolean isShare = url.contains("instagram.com/reel/")
@@ -233,29 +242,26 @@ public class DeletedMessagesActivity extends Activity {
                         } else if (which == 2) {
                             Utils.setClipboard(url);
                             Utils.showToastShort(str("piko_copied_media_link"));
-                        } else {
+                        } else if (isShare) {
                             android.net.Uri uri = android.net.Uri.parse(url);
-                            // Reels/posts are stored as instagram.com permalinks — open them inside
-                            // the Instagram app itself (setPackage) so they render natively; only fall
-                            // back to a browser chooser if IG can't handle the link.
-                            boolean igLink = url.contains("instagram.com/reel/")
-                                    || url.contains("instagram.com/p/")
-                                    || url.contains("instagram.com/tv/");
-                            boolean opened = false;
-                            if (igLink) {
-                                try {
-                                    startActivity(new android.content.Intent(
-                                            android.content.Intent.ACTION_VIEW, uri)
-                                            .setPackage("com.instagram.android"));
-                                    opened = true;
-                                } catch (android.content.ActivityNotFoundException ignored) {}
+                            try {
+                                startActivity(new android.content.Intent(
+                                        android.content.Intent.ACTION_VIEW, uri)
+                                        .setPackage("com.instagram.android"));
+                            } catch (android.content.ActivityNotFoundException ignored) {
+                                startActivity(android.content.Intent.createChooser(
+                                        new android.content.Intent(android.content.Intent.ACTION_VIEW, uri), null));
                             }
-                            if (!opened) {
-                                android.content.Intent i = new android.content.Intent(
-                                        android.content.Intent.ACTION_VIEW, uri);
-                                if (isAudio) i.setDataAndType(uri, "audio/*");
-                                startActivity(android.content.Intent.createChooser(i, null));
-                            }
+                        } else if (isAudio) {
+                            android.net.Uri uri = android.net.Uri.parse(url);
+                            android.content.Intent i = new android.content.Intent(android.content.Intent.ACTION_VIEW, uri);
+                            i.setDataAndType(uri, "audio/*");
+                            startActivity(android.content.Intent.createChooser(i, null));
+                        } else {
+                            // Photo/video: same helper used for regular post media downloads/open —
+                            // it takes care of getting a local/content URI so gallery apps can open it,
+                            // instead of handing them a raw remote CDN url.
+                            ActivityHook.handleUrlIntent(isVideo, url);
                         }
                     } catch (Exception e) {
                         android.util.Log.e("piko", "showMediaOptions action: " + e);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/SavedMessagesHook.java
@@ -69,7 +69,8 @@ public class SavedMessagesHook {
         }});
     }
 
-    private static String resolveOpenThreadId() {
+    /** The currently-open DM thread id, or null when unknown (e.g. before any thread has loaded). */
+    public static String resolveOpenThreadId() {
         return (sCurrentThreadId != null && !sCurrentThreadId.isEmpty()) ? sCurrentThreadId : null;
     }
 
@@ -374,7 +375,7 @@ public class SavedMessagesHook {
                 String stored = vault.getStoredContent(itemId);
                 boolean isMedia = stored == null || stored.isEmpty()
                         || stored.startsWith("http") || stored.startsWith("[");
-                String notifBody = isMedia ? describeMediaType(messageType) : stored;
+                String notifBody = isMedia ? describeMediaType(messageType, stored) : stored;
                 String storedThreadId = vault.getThreadIdOf(itemId);
                 String name = vault.getThreadUsername(storedThreadId);
                 if (name == null) name = openChatTitleFor(vault, storedThreadId);
@@ -386,14 +387,27 @@ public class SavedMessagesHook {
         }
     }
 
-    private static String describeMediaType(String type) {
+    /** @param url the stored CDN url, when the deleted item was media (may be null). */
+    private static String describeMediaType(String type, String url) {
         if (type == null) return str("piko_media_deleted_generic");
+
+        // item_type alone can't tell a photo from a video — both come through as "media" (or
+        // "raven_media" for disappearing media); the actual type lives on the Media object, not
+        // the DirectItem. Sniff the real CDN url extension instead, same as DeletedMessagesActivity.
+        String effectiveType = type;
+        if (("media".equals(type) || "raven_media".equals(type))
+                && url != null && url.matches("(?i).*\\.(mp4|mov|m4v|webm)(\\?.*)?$")) {
+            effectiveType = "video";
+        }
+
         String label;
-        switch (type) {
+        switch (effectiveType) {
             case "media":
             case "image":           label = str("piko_media_photo"); break;
             case "raven_media":     label = str("piko_media_disappearing_photo"); break;
             case "video":           label = str("piko_media_video"); break;
+            case "clip":
+            case "xma_clip":        label = str("piko_media_reel"); break;
             case "voice_media":
             case "audio":           label = str("piko_media_voice"); break;
             case "animated_media":  label = str("piko_media_gif"); break;
@@ -403,7 +417,7 @@ public class SavedMessagesHook {
             case "like":            label = str("piko_media_like"); break;
             case "link":            label = str("piko_media_link"); break;
             case "action_log":      label = str("piko_media_activity"); break;
-            default:                label = type; break;
+            default:                label = effectiveType; break;
         }
         return String.format(str("piko_media_deleted"), label);
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/ActivityHook.java
@@ -9,15 +9,23 @@ package app.morphe.extension.instagram.settings;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
+import android.app.DownloadManager;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
+import android.os.Handler;
+import android.os.Looper;
 
 import app.morphe.extension.crimera.PikoUtils;
 import app.morphe.extension.instagram.settings.preference.fragments.BackupPrefActivity;
 import app.morphe.extension.instagram.settings.preference.fragments.RestorePrefActivity;
 import app.morphe.extension.crimera.downloader.FolderPickerActivity;
 import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
 import app.morphe.extension.instagram.constants.Constants;
 
 @SuppressWarnings("deprecation")
@@ -57,19 +65,124 @@ public class ActivityHook {
         }
     }
 
-    public static void handleUrlIntent(Boolean isVideo,String mediaUrl) {
-        String dataType = "image/*";
-        String exportHeaderString = str("piko_open_image_with");
-        if(isVideo){
-            dataType = "video/*";
-            exportHeaderString = str("piko_open_video_with");
-        }
+    // How long a temp-opened file is kept before DownloadManager deletes it — gives the external
+    // viewer app time to actually load/cache it before we drop it.
+    private static final long TEMP_MEDIA_TTL_MS = 5 * 60 * 1000L;
 
-        Uri uri = Uri.parse(mediaUrl);
-        Intent intent = new Intent(Intent.ACTION_VIEW);
-        intent.setDataAndType(uri, dataType);
-        Intent chooserIntent = Intent.createChooser(intent, exportHeaderString);
-        PikoUtils.launchIntent(chooserIntent);
+    public static void handleUrlIntent(Boolean isVideo, String mediaUrl) {
+        try {
+            Context context = PikoUtils.getContext();
+            if (context == null || mediaUrl == null) return;
+
+            String dataType = isVideo ? "video/*" : "image/*";
+            String chooserTitle = str(isVideo ? "piko_open_video_with" : "piko_open_image_with");
+            String extension = isVideo ? ".mp4" : ".jpg";
+            String fileName = "piko_tmp_" + System.currentTimeMillis() + extension;
+
+            DownloadManager downloadManager =
+                    (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
+            if (downloadManager == null) return;
+
+            // Registered BEFORE enqueue: a fast download (small image, good connection) can
+            // complete before the next line runs, and we'd miss the completion broadcast.
+            DownloadManager.Request request = new DownloadManager.Request(Uri.parse(mediaUrl));
+            // App-private, scoped destination: no storage permission needed, and it never shows
+            // up in the user's own Downloads app or Gallery — genuinely temporary.
+            request.setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS,
+                    "piko_tmp/" + fileName);
+            // VISIBILITY_HIDDEN requires the DOWNLOAD_WITHOUT_NOTIFICATION permission, which we
+            // don't declare — this is the closest allowed option: no notification while
+            // downloading, just a brief one on completion (cleared once we remove the entry).
+            request.setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_ONLY_COMPLETION);
+            request.setAllowedOverMetered(true);
+            request.setAllowedOverRoaming(true);
+
+            long[] downloadIdHolder = new long[1];
+            registerCompletionReceiver(context, downloadManager, downloadIdHolder, dataType, chooserTitle);
+
+            downloadIdHolder[0] = downloadManager.enqueue(request);
+            String mediaLabel = str(isVideo ? "piko_media_video" : "piko_media_photo");
+            Utils.showToastShort(String.format(str("piko_opening_media"), mediaLabel));
+        } catch (Exception e) {
+            Logger.printException(() -> "handleUrlIntent failure", e);
+            PikoUtils.logger(e);
+        }
+    }
+
+    /** Registers the completion listener before the download is enqueued, so a fast download
+     *  can never finish before we're listening. downloadIdHolder[0] is filled in by the caller
+     *  right after enqueue() returns — always before the download can actually complete. */
+    private static void registerCompletionReceiver(
+            Context context,
+            DownloadManager downloadManager,
+            long[] downloadIdHolder,
+            String dataType,
+            String chooserTitle
+    ) {
+        Context appContext = context.getApplicationContext();
+        BroadcastReceiver[] receiverHolder = new BroadcastReceiver[1];
+
+        receiverHolder[0] = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                long finishedId = intent.getLongExtra(DownloadManager.EXTRA_DOWNLOAD_ID, -1);
+                long downloadId = downloadIdHolder[0];
+                if (downloadId == 0 || finishedId != downloadId) return;
+                try {
+                    appContext.unregisterReceiver(receiverHolder[0]);
+                } catch (Exception ignored) {}
+
+                try {
+                    Uri contentUri = downloadManager.getUriForDownloadedFile(downloadId);
+                    if (contentUri == null) {
+                        Utils.showToastShort(str("piko_download_error"));
+                        downloadManager.remove(downloadId);
+                        return;
+                    }
+
+                    Intent viewIntent = new Intent(Intent.ACTION_VIEW);
+                    viewIntent.setDataAndType(contentUri, dataType);
+                    viewIntent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                    viewIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    Intent chooserIntent = Intent.createChooser(viewIntent, chooserTitle);
+                    // Launching from a BroadcastReceiver, not an Activity — NEW_TASK is mandatory
+                    // here or startActivity throws, and we don't rely on PikoUtils.launchIntent
+                    // having already set it.
+                    chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+                    try {
+                        PikoUtils.launchIntent(chooserIntent);
+                    } catch (Exception launchEx) {
+                        // Fallback in case PikoUtils.launchIntent expects an Activity context
+                        // internally — start it directly off the application context instead.
+                        Logger.printException(() -> "launchIntent failed, falling back", launchEx);
+                        appContext.startActivity(chooserIntent);
+                    }
+
+                    // Genuinely temporary — never left behind permanently.
+                    new Handler(Looper.getMainLooper()).postDelayed(
+                            () -> {
+                                try {
+                                    downloadManager.remove(downloadId);
+                                } catch (Exception ignored) {}
+                            },
+                            TEMP_MEDIA_TTL_MS
+                    );
+                } catch (Exception e) {
+                    Logger.printException(() -> "temp media open failure", e);
+                    Utils.showToastShort(str("piko_download_error"));
+                }
+            }
+        };
+
+        // ACTION_DOWNLOAD_COMPLETE is sent by the system's download provider process, not by
+        // this app — RECEIVER_NOT_EXPORTED would silently drop it on API 33+ since that flag
+        // blocks broadcasts from other apps/processes, which is exactly what this is.
+        IntentFilter filter = new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            appContext.registerReceiver(receiverHolder[0], filter, Context.RECEIVER_EXPORTED);
+        } else {
+            appContext.registerReceiver(receiverHolder[0], filter);
+        }
     }
 
 }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -216,6 +216,8 @@
     <string name="piko_open_video_externally">Open video externally</string>
     <string name="piko_open_image_with">Open image with</string>
     <string name="piko_open_video_with">Open video with</string>
+    <string name="piko_opening_media">Opening %s\u2026</string>
+    <string name="piko_download_error">Could not open media</string>
 
     <!-- Like Animation Section -->
     <string name="piko_change_like_animation">Change like animation</string>


### PR DESCRIPTION
**An indicator for unseen deleted messages in a conversation, as well as the ability to view the deleted content externally, as shown in the image and video below.** _I added this because I felt it was missing from Piko compared to other mods (like Honista)._

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8bcd7b76-f1b9-426c-ac18-aaeb405bf6f6" />


https://github.com/user-attachments/assets/6b7190a5-3a6b-424e-824c-22eb2c615c7f


