### PR TITLE
fix(Instagram): Preserve material you surface contrast

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
@@ -51,9 +51,12 @@ final class MaterialYouState {
 
     static int composeSearchRowOverrideArgb(
             ThemeMode mode,
-            int materialYouSearchRowArgb
+            int materialYouBackgroundArgb
     ) {
-        return hasMaterialYou(mode) ? materialYouSearchRowArgb : 0;
+        if (mode == ThemeMode.AMOLED_MATERIAL_YOU) {
+            return 0xff000000;
+        }
+        return mode == ThemeMode.MATERIAL_YOU ? materialYouBackgroundArgb : 0;
     }
 
     static long composeSearchRowBackground(

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouTheme.java
@@ -473,7 +473,6 @@ public final class MaterialYouTheme {
 
     private static void applyComposePrismMode(Context context, ThemeMode mode) {
         int materialYouBackgroundArgb = 0;
-        int materialYouSearchRowArgb = 0;
         if (MaterialYouState.hasMaterialYou(mode)) {
             int backgroundResourceId = ResourceUtils.getIdentifier(
                     context,
@@ -483,17 +482,6 @@ public final class MaterialYouTheme {
             if (backgroundResourceId != 0) {
                 try {
                     materialYouBackgroundArgb = context.getColor(backgroundResourceId);
-                } catch (Resources.NotFoundException ignored) {
-                }
-            }
-            int searchRowResourceId = ResourceUtils.getIdentifier(
-                    context,
-                    ResourceType.COLOR,
-                    "igds_prism_gray_09"
-            );
-            if (searchRowResourceId != 0) {
-                try {
-                    materialYouSearchRowArgb = context.getColor(searchRowResourceId);
                 } catch (Resources.NotFoundException ignored) {
                 }
             }
@@ -509,7 +497,7 @@ public final class MaterialYouTheme {
         lastComposeSearchRowOverrideArgb =
                 MaterialYouState.composeSearchRowOverrideArgb(
                         mode,
-                        materialYouSearchRowArgb
+                        materialYouBackgroundArgb
                 );
     }
 

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeOverlayTable.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeOverlayTable.kt
@@ -21,11 +21,14 @@ internal data class OverlayValues(
     val night: Map<String, String>,
     val dayApi34: Map<String, String>? = null,
     val nightApi34: Map<String, String>? = null,
+    val dayDrawables: Map<String, String> = emptyMap(),
+    val nightDrawables: Map<String, String> = emptyMap(),
 ) {
     init {
         require((dayApi34 == null) == (nightApi34 == null))
         require(dayApi34 == null || dayApi34.keys == day.keys)
         require(nightApi34 == null || nightApi34.keys == night.keys)
+        require(dayDrawables.keys == nightDrawables.keys)
     }
 }
 
@@ -63,6 +66,16 @@ internal fun buildThemeOverlayTable(
             targetPackage.resolve("res/values-night-v31/colors.xml"),
             values.night,
         )
+        writeTypedItemsXml(
+            targetPackage.resolve("res/values-v31/drawables.xml"),
+            "drawable",
+            values.dayDrawables,
+        )
+        writeTypedItemsXml(
+            targetPackage.resolve("res/values-night-v31/drawables.xml"),
+            "drawable",
+            values.nightDrawables,
+        )
         values.dayApi34?.let { api34Values ->
             writeValuesXml(
                 targetPackage.resolve("res/values-v34/colors.xml"),
@@ -85,6 +98,35 @@ internal fun buildThemeOverlayTable(
         return outputFile
     } finally {
         workRoot.deleteRecursively()
+    }
+}
+
+private fun writeTypedItemsXml(
+    output: File,
+    type: String,
+    values: Map<String, String>,
+) {
+    if (values.isEmpty()) return
+
+    output.parentFile.mkdirs()
+    val document = DocumentBuilderFactory.newInstance()
+        .newDocumentBuilder()
+        .newDocument()
+    val resources = document.createElement("resources")
+    document.appendChild(resources)
+
+    values.forEach { (name, value) ->
+        resources.appendChild(
+            document.createElement("item").apply {
+                setAttribute("type", type)
+                setAttribute("name", name)
+                textContent = value
+            },
+        )
+    }
+    TransformerFactory.newInstance().newTransformer().apply {
+        setOutputProperty(OutputKeys.INDENT, "yes")
+        transform(DOMSource(document), StreamResult(output))
     }
 }
 
@@ -132,11 +174,14 @@ private fun writePublicSubset(
     val required = mutableSetOf<PublicName>()
 
     values.day.keys.forEach { required += PublicName("color", it) }
+    values.dayDrawables.keys.forEach { required += PublicName("drawable", it) }
     (
         values.day.values +
             values.night.values +
             values.dayApi34.orEmpty().values +
-            values.nightApi34.orEmpty().values
+            values.nightApi34.orEmpty().values +
+            values.dayDrawables.values +
+            values.nightDrawables.values
     ).forEach { value ->
         collectLocalReferences(value, required)
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePalette.kt
@@ -188,7 +188,7 @@ private val materialYouSurfaceBaselineMappings =
         "igds_prism_gray_09" to "@color/piko_dynamic_pressed_background",
         "igds_prism_gray_13" to "@color/piko_dynamic_prism_black",
         "igds_prism_gray_14" to "@color/piko_dynamic_prism_black",
-        "igds_prism_gray_1500" to "@color/piko_dynamic_neutral_deep",
+        "igds_prism_gray_1500" to "@color/piko_dynamic_prism_black",
         "igds_prism_gray_09_alpha_95" to "@color/piko_dynamic_prism_black",
         "igds_prism_gray_10_alpha_95" to "@color/piko_dynamic_prism_black",
         "bds_grey_9_95_transparent" to "@color/piko_dynamic_prism_black",

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemePatch.kt
@@ -55,6 +55,9 @@ val themePatch =
                 val originalApi31Base = captureApi31Base()
 
                 forceWhiteOnMediaChrome()
+                preserveCreationButtonContrast()
+                preserveLightClipsComposerContrast()
+                preserveLightOverflowStampBackgrounds()
                 applyLegacyTheme(amoled == true)
 
                 restoreApi31Base(

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeResources.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/theme/ThemeResources.kt
@@ -14,6 +14,17 @@ import java.nio.file.Files
 import org.w3c.dom.Document
 import org.w3c.dom.Element
 
+private const val STOCK_PRISM_OVERFLOW_STAMP_BACKGROUND =
+    "piko_stock_prism_overflow_stamp_background"
+private const val STOCK_LEGACY_OVERFLOW_STAMP_BACKGROUND =
+    "piko_stock_legacy_overflow_stamp_background"
+private const val CREATION_BUTTON_BACKGROUND =
+    "piko_creation_button_background"
+private const val STOCK_CREATION_BUTTON_BACKGROUND = "#ff191c1f"
+private const val STOCK_CLIPS_COMPOSER_BACKGROUND =
+    "piko_stock_clips_composer_background"
+private const val STOCK_CLIPS_COMPOSER_BACKGROUND_COLOR = "#ff25292e"
+
 internal data class Api31BaseSnapshot(
     val dayColors: Map<String, String>,
     val nightColors: Map<String, String>,
@@ -46,6 +57,24 @@ private val amoledNightOverrides =
         "igds_prism_black" to "#ff000000",
     )
 
+private val stockLightOverflowStampBackgrounds =
+    mapOf(
+        "@color/igds_prism_gray_01" to
+            (STOCK_PRISM_OVERFLOW_STAMP_BACKGROUND to "#fff3f5f7"),
+        "@color/bds_grey_1" to
+            (STOCK_LEGACY_OVERFLOW_STAMP_BACKGROUND to "#ffefefef"),
+    )
+
+private val materialYouLightDrawableMappings =
+    mapOf(
+        "clips_composer_background" to "@drawable/$STOCK_CLIPS_COMPOSER_BACKGROUND",
+    )
+
+private val materialYouCreationButtonMappings =
+    mapOf(
+        CREATION_BUTTON_BACKGROUND to "@android:color/system_neutral2_800",
+    )
+
 internal fun Document.forceWhiteOnMediaChromeItems() {
     val items = getElementsByTagName("item")
     for (index in 0 until items.length) {
@@ -59,6 +88,117 @@ internal fun Document.forceWhiteOnMediaChromeItems() {
         ) {
             item.textContent = "@color/bds_white"
         }
+    }
+}
+
+internal fun Document.preserveCreationButtonContrastItems(): Int {
+    var replacements = 0
+    val items = getElementsByTagName("item")
+    for (index in 0 until items.length) {
+        val item = items.item(index) as? Element ?: continue
+        if (
+            item.getAttribute("name") == "igds_color_creation_button" &&
+            item.textContent == "@color/igds_prism_gray_1500"
+        ) {
+            item.textContent = "@color/$CREATION_BUTTON_BACKGROUND"
+            replacements++
+        }
+    }
+    return replacements
+}
+
+internal fun Document.preserveLightOverflowStampBackgroundItems(): Int {
+    var replacements = 0
+    val items = getElementsByTagName("item")
+    for (index in 0 until items.length) {
+        val item = items.item(index) as? Element ?: continue
+        if (item.getAttribute("name") != "igds_color_stamp_background") continue
+
+        val (resourceName) = stockLightOverflowStampBackgrounds[item.textContent] ?: continue
+        item.textContent = "@color/$resourceName"
+        replacements++
+    }
+    return replacements
+}
+
+internal fun ResourcePatchContext.preserveLightOverflowStampBackgrounds() {
+    ensureColorsXml("res/values")
+    document("res/values/colors.xml").use { document ->
+        stockLightOverflowStampBackgrounds.values.forEach { (name, value) ->
+            document.upsertColor(name, value)
+        }
+    }
+
+    var stampBackgroundReplacements = 0
+    listOf(
+        "res/values/styles.xml",
+        "res/values-night/styles.xml",
+    ).forEach { path ->
+        if (!get(path).exists()) return@forEach
+        document(path).use { document ->
+            stampBackgroundReplacements +=
+                document.preserveLightOverflowStampBackgroundItems()
+        }
+    }
+    check(stampBackgroundReplacements > 0) {
+        "Unable to preserve light overflow stamp backgrounds"
+    }
+}
+
+internal fun ResourcePatchContext.preserveCreationButtonContrast() {
+    ensureColorsXml("res/values")
+    document("res/values/colors.xml").use { document ->
+        document.upsertColor(
+            CREATION_BUTTON_BACKGROUND,
+            STOCK_CREATION_BUTTON_BACKGROUND,
+        )
+    }
+    document("res/values/public.xml").use { document ->
+        document.ensurePublicResource("color", CREATION_BUTTON_BACKGROUND)
+    }
+
+    var replacements = 0
+    listOf(
+        "res/values/styles.xml",
+        "res/values-night/styles.xml",
+    ).forEach { path ->
+        if (!get(path).exists()) return@forEach
+        document(path).use { document ->
+            replacements += document.preserveCreationButtonContrastItems()
+        }
+    }
+    check(replacements > 0) {
+        "Unable to preserve creation button contrast"
+    }
+}
+
+internal fun ResourcePatchContext.preserveLightClipsComposerContrast() {
+    val sourcePath = "res/drawable/clips_composer_background.xml"
+    val source = get(sourcePath)
+    check(source.isFile) {
+        "Unable to find the clips composer background"
+    }
+
+    val targetPath = "res/drawable/$STOCK_CLIPS_COMPOSER_BACKGROUND.xml"
+    source.copyTo(
+        get("res/drawable").resolve("$STOCK_CLIPS_COMPOSER_BACKGROUND.xml"),
+        overwrite = true,
+    )
+    document(targetPath).use { document ->
+        val solids = document.getElementsByTagName("solid")
+        check(solids.length == 1) {
+            "Unexpected clips composer background shape"
+        }
+        val solid = solids.item(0) as? Element
+            ?: error("Unable to read the clips composer background fill")
+        check(solid.getAttribute("android:color") == "?attr/igds_color_secondary_background") {
+            "Unexpected clips composer background fill"
+        }
+        // Material You remaps the source token, so keep Instagram's stock light fill.
+        solid.setAttribute("android:color", STOCK_CLIPS_COMPOSER_BACKGROUND_COLOR)
+    }
+    document("res/values/public.xml").use { document ->
+        document.ensurePublicResource("drawable", STOCK_CLIPS_COMPOSER_BACKGROUND)
     }
 }
 
@@ -113,13 +253,17 @@ internal fun ResourcePatchContext.restoreApi31Base(
 }
 
 internal fun materialYouOverlayValues(night: Boolean): OverlayValues {
-    val values = dynamicOverlayMappings(night)
+    val values = dynamicOverlayMappings(night) + materialYouCreationButtonMappings
     val api34Values = values + materialYouSwitchApi34Mappings(night)
+    val drawableMappings =
+        if (night) emptyMap() else materialYouLightDrawableMappings
     return OverlayValues(
         day = values,
         night = values,
         dayApi34 = api34Values,
         nightApi34 = api34Values,
+        dayDrawables = drawableMappings,
+        nightDrawables = drawableMappings,
     )
 }
 
@@ -152,7 +296,10 @@ internal fun ResourcePatchContext.writeAmoledOverlay(
     )
 
 internal fun amoledMaterialYouOverlayValues(): OverlayValues {
-    val values = amoledMaterialYouOverlayMappings() + amoledSplashMappings
+    val values =
+        amoledMaterialYouOverlayMappings() +
+            amoledSplashMappings +
+            materialYouCreationButtonMappings
     val api34Values = values + materialYouSwitchApi34Mappings(night = true)
     return OverlayValues(
         day = values,
@@ -296,6 +443,43 @@ private fun Document.upsertColor(name: String, value: String) {
             },
         )
     }
+}
+
+private fun Document.ensurePublicResource(type: String, name: String) {
+    val publicNodes = getElementsByTagName("public")
+    val typeIds = mutableListOf<Long>()
+    for (index in 0 until publicNodes.length) {
+        val resource = publicNodes.item(index) as? Element ?: continue
+        if (resource.getAttribute("name") == name) {
+            check(resource.getAttribute("type") == type) {
+                "Resource $name already exists with another type"
+            }
+            return
+        }
+        if (resource.getAttribute("type") == type) {
+            typeIds += resource.getAttribute("id").removePrefix("0x").toLong(16)
+        }
+    }
+
+    check(typeIds.isNotEmpty()) {
+        "Unable to allocate public $type resource $name"
+    }
+    val typePrefix = typeIds.first() and 0xffff0000L
+    check(typeIds.all { id -> id and 0xffff0000L == typePrefix }) {
+        "Unexpected public resource type IDs for $type"
+    }
+    val newId = typeIds.max() + 1L
+    check(newId and 0xffff0000L == typePrefix) {
+        "No public resource IDs remain for $type"
+    }
+
+    documentElement.appendChild(
+        createElement("public").apply {
+            setAttribute("type", type)
+            setAttribute("name", name)
+            setAttribute("id", "0x%08x".format(newId))
+        },
+    )
 }
 
 private fun Document.findColor(name: String): Element? {


### PR DESCRIPTION
Fixes the regressions reported in #1726 and improves where material you colors are applied

## Testing
- `./gradlew test`
- `./gradlew clean :patches:buildAndroid`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.9
- Tested on Samsung Galaxy S26

Closes #1726 