### PR TITLE
fix(Twitter): address client shutdown behind update screen

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
@@ -144,8 +144,12 @@ public class Pref {
 
     public static boolean redirect(TabLayout$g g) {return Utils.redirect(g);}
 
+    public static boolean blockUpdateScreen() {
+        return Utils.getBooleanPref(Settings.MISC_BLOCK_UPDATE_SCREEN);
+    }
+
     public static void blockUpdateScreen(View view) {
-        if (Utils.getBooleanPref(Settings.MISC_BLOCK_UPDATE_SCREEN) && view != null) {
+        if (blockUpdateScreen() && view != null) {
             if (view.getParent() instanceof ViewGroup container &&
                     container.getParent() instanceof ViewGroup scrollView) {
                 // Hide the alert dialog container first

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
@@ -144,12 +144,8 @@ public class Pref {
 
     public static boolean redirect(TabLayout$g g) {return Utils.redirect(g);}
 
-    public static boolean blockUpdateScreen() {
-        return Utils.getBooleanPref(Settings.MISC_BLOCK_UPDATE_SCREEN);
-    }
-
     public static void blockUpdateScreen(View view) {
-        if (blockUpdateScreen() && view != null) {
+        if (Utils.blockUpdateScreen() && view != null) {
             if (view.getParent() instanceof ViewGroup container &&
                     container.getParent() instanceof ViewGroup scrollView) {
                 // Hide the alert dialog container first

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Utils.java
@@ -172,6 +172,10 @@ public class Utils {
         return sp.getBoolean(setting.key, setting.defaultValue);
     }
 
+    public static boolean blockUpdateScreen() {
+        return getBooleanPref(Settings.MISC_BLOCK_UPDATE_SCREEN);
+    }
+
     public static String getAll(boolean no_flags) {
         JSONObject prefs = sp.getAll();
         prefs.remove(Settings.LAST_CHANGELOG.key);

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
@@ -9,6 +9,7 @@ package app.crimera.patches.twitter.misc.blockUpdateScreen
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.Constants.PREF_DESCRIPTOR
+import app.crimera.patches.twitter.utils.Constants.UTILS_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
@@ -49,14 +50,20 @@ private object FullCoverDialogInflateFingerprint : Fingerprint(
     )
 )
 
-private object ClientShutdownStateFingerprint : Fingerprint(
+private object ClientShutdownStateConstructorFingerprint : Fingerprint(
+    definingClass = "Lcom/twitter/subsystem/clientshutdown/",
     name = "<init>",
     returnType = "V",
     strings = listOf("is_shutdown", "shutdown_min_version"),
-    custom = { _, classDef ->
-        classDef.type.startsWith("Lcom/twitter/subsystem/clientshutdown/")
-    },
 )
+
+private fun getClientShutdownStateFingerprint(definingClass: String) = object : Fingerprint(
+    definingClass = definingClass,
+    name = "isShutdown",
+    accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
+    parameters = listOf(),
+    returnType = "Z",
+) {}
 
 private fun getShowDialogFingerprint(dismissButtonField: FieldReference) = object : Fingerprint(
     name = "get",
@@ -90,18 +97,15 @@ val blockUpdateScreenPatch =
         )
 
         execute {
-            val isShutdownMethod =
-                ClientShutdownStateFingerprint.classDef.methods.single { method ->
-                    method.name == "isShutdown" &&
-                        method.parameters.isEmpty() &&
-                        method.returnType == "Z"
-                }
+            val isShutdownMethod = getClientShutdownStateFingerprint(
+                ClientShutdownStateConstructorFingerprint.classDef.type
+            ).method
             val originalIsShutdownInstruction = isShutdownMethod.getInstruction(0)
 
             isShutdownMethod.addInstructionsWithLabels(
                 0,
                 """
-                invoke-static {}, $PREF_DESCRIPTOR;->blockUpdateScreen()Z
+                invoke-static {}, $UTILS_DESCRIPTOR;->blockUpdateScreen()Z
                 move-result v0
                 if-eqz v0, :piko_continue
                 const/4 v0, 0x0

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/blockUpdateScreen/BlockUpdateScreenPatch.kt
@@ -13,9 +13,12 @@ import app.crimera.patches.twitter.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.InstructionLocation.MatchAfterWithin
 import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
 import app.morphe.patcher.fieldAccess
 import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.smali.ExternalLabel
 import app.morphe.patches.all.misc.resources.ResourceType
 import app.morphe.patches.all.misc.resources.resourceLiteral
 import app.morphe.patches.all.misc.resources.resourceMappingPatch
@@ -44,6 +47,15 @@ private object FullCoverDialogInflateFingerprint : Fingerprint(
             type = "Landroid/view/View;"
         )
     )
+)
+
+private object ClientShutdownStateFingerprint : Fingerprint(
+    name = "<init>",
+    returnType = "V",
+    strings = listOf("is_shutdown", "shutdown_min_version"),
+    custom = { _, classDef ->
+        classDef.type.startsWith("Lcom/twitter/subsystem/clientshutdown/")
+    },
 )
 
 private fun getShowDialogFingerprint(dismissButtonField: FieldReference) = object : Fingerprint(
@@ -78,6 +90,26 @@ val blockUpdateScreenPatch =
         )
 
         execute {
+            val isShutdownMethod =
+                ClientShutdownStateFingerprint.classDef.methods.single { method ->
+                    method.name == "isShutdown" &&
+                        method.parameters.isEmpty() &&
+                        method.returnType == "Z"
+                }
+            val originalIsShutdownInstruction = isShutdownMethod.getInstruction(0)
+
+            isShutdownMethod.addInstructionsWithLabels(
+                0,
+                """
+                invoke-static {}, $PREF_DESCRIPTOR;->blockUpdateScreen()Z
+                move-result v0
+                if-eqz v0, :piko_continue
+                const/4 v0, 0x0
+                return v0
+                """.trimIndent(),
+                ExternalLabel("piko_continue", originalIsShutdownInstruction),
+            )
+
             val dismissButtonField = FullCoverDialogInflateFingerprint
                 .instructionMatches
                 .last()


### PR DESCRIPTION
## Scope

This PR extends the existing **Block update screen** patch. The fix is the combination of two protections:

1. The existing full-cover UI hook hides and dismisses the update screen.
2. This PR makes the underlying client-shutdown state report `false` while the same setting is enabled.

The state guard must not be shipped as a standalone backport without the full-cover UI hook.

## Why both hooks are needed

X persists `is_shutdown` after its remote minimum-version check. That state is consumed outside the dialog path by launcher-entry handling and the client-shutdown network interceptor. Handling only the visible dialog can therefore leave the shutdown state active.

Conversely, an earlier local compatibility build contained only the state guard. That incomplete backport regressed account-switch navigation: switching profiles could land on a root-level update screen that Back no longer escaped. That build has been withdrawn. The corrected compatibility build combines the existing UI hook with the state guard.

The `dev` base of this PR already contains the full-cover UI hook; this diff adds the complementary state guard.

## Change

- Identify the shutdown-state class by its stable `is_shutdown` and `shutdown_min_version` preference keys.
- Fingerprint its `isShutdown()` method directly within that resolved class.
- When **Block update screen** is enabled, return `false` to client-shutdown consumers.
- When disabled, continue through X's original stored-state path.
- Keep the visible full-cover fallback tied to the same setting.
- Place the shared setting lookup in `Utils`, following maintainer review.

## Verification

- Final revision: `:patches:buildAndroid` succeeds.
- The combined implementation was applied to a compatible local X package and both injected hooks were confirmed in the installed DEX.
- Cold launch stayed on the normal main activity.
- Profile switching was exercised in both directions without the update screen, update-only activity, or a fatal runtime signal.
- The reviewer-requested organization/fingerprint refactor does not change the injected runtime branch; its final revision is build-verified.

Addresses #1747 and the continued report in #1717.