### PR TITLE
fix(Twitter): Rewrite repost share links with original author

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/links/Urls.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/links/Urls.java
@@ -12,12 +12,15 @@ import app.morphe.extension.twitter.Pref;
 import app.morphe.extension.twitter.settings.SettingsStatus;
 import app.morphe.extension.crimera.PikoUtils;
 import com.x.models.ContextualPost;
-import com.x.models.CanonicalPost;
-import com.x.models.UserResult;
-import com.x.models.XUser;
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Urls {
+    private static final Pattern POST_URL_PATTERN = Pattern.compile(
+            "^(https://(?:x\\.com|twitter\\.com)/)[^/]+(/status/.*)$",
+            Pattern.CASE_INSENSITIVE
+    );
     private static final boolean unShortUrl;
     static {
         unShortUrl = SettingsStatus.unshortenlink && Pref.unShortUrl();
@@ -56,13 +59,20 @@ public class Urls {
         return urlString;
     }
 
+    private static String rewritePostUrl(ContextualPost contextualPost, String link) {
+        Matcher matcher = POST_URL_PATTERN.matcher(link);
+        if (!matcher.matches()) {
+            return link;
+        }
+
+        String username = contextualPost.getCanonicalPost().getAuthor().getScreenName();
+        return matcher.group(1) + username + matcher.group(2);
+    }
+
     public static String hookShareSheetLink(ContextualPost contextualPost, String link){
         try {
             if (SettingsStatus.legacyShareLink) {
-                CanonicalPost canonicalPost = contextualPost.getCanonicalPost();
-                XUser userResult = canonicalPost.getAuthor();
-                String username = userResult.getScreenName();
-                link = link.replace("/i/", "/" + username + "/");
+                link = rewritePostUrl(contextualPost, link);
             }
         }catch (Exception ex) {
             PikoUtils.logger(ex);

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/links/Urls.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/links/Urls.java
@@ -59,20 +59,14 @@ public class Urls {
         return urlString;
     }
 
-    private static String rewritePostUrl(ContextualPost contextualPost, String link) {
-        Matcher matcher = POST_URL_PATTERN.matcher(link);
-        if (!matcher.matches()) {
-            return link;
-        }
-
-        String username = contextualPost.getCanonicalPost().getAuthor().getScreenName();
-        return matcher.group(1) + username + matcher.group(2);
-    }
-
     public static String hookShareSheetLink(ContextualPost contextualPost, String link){
         try {
             if (SettingsStatus.legacyShareLink) {
-                link = rewritePostUrl(contextualPost, link);
+                Matcher matcher = POST_URL_PATTERN.matcher(link);
+                if (matcher.matches()) {
+                    String username = contextualPost.getCanonicalPost().getAuthor().getScreenName();
+                    link = matcher.group(1) + username + matcher.group(2);
+                }
             }
         }catch (Exception ex) {
             PikoUtils.logger(ex);


### PR DESCRIPTION
Fixes the non-native share menu copying links to retweeted posts with the username of the account that retweeted them on 12.17.0-release.0

## Testing
- `.\gradlew.bat :extensions:twitter:compileReleaseJavaWithJavac --console=plain --no-daemon`
- `.\gradlew.bat clean :patches:buildAndroid --console=plain --no-daemon`
- Tested on Twitter v12.17.0-release.0 with Piko v3.9.0-dev.9
- Tested on Samsung Galaxy S26

Closes #1753 