### PR TITLE
docs: Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 <div align="center">
 
-<p align="center">
-    <img src="https://socialify.git.ci/crimera/piko/image?forks=1&language=1&name=1&owner=1&pattern=Circuit%20Board&stargazers=1&theme=Auto" alt="piko" width="640" height="320" />
-</p>
+<img src="https://socialify.git.ci/crimera/piko/image?forks=1&language=1&name=1&owner=1&pattern=Circuit%20Board&stargazers=1&theme=Auto" alt="piko" width="640" height="320" />
 
-<h1 align="center">
+<h1>
     Morphe patches focused on Twitter/X & Instagram<br>
     <a href="https://t.me/pikopatches">
-        <img src="https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white"/>
+        <img src="https://img.shields.io/badge/Telegram-2CA5E0?style=for-the-badge&logo=telegram&logoColor=white" alt="Telegram"/>
     </a>
     <a href="https://crowdin.com/project/piko">
-        <img src="https://img.shields.io/badge/Crowdin-1B263B?style=for-the-badge&logo=crowdin&logoColor=white"/>
+        <img src="https://img.shields.io/badge/Crowdin-1B263B?style=for-the-badge&logo=crowdin&logoColor=white" alt="Crowdin"/>
     </a>
 </h1>
 
@@ -18,39 +16,36 @@
 
 ## 🕹️ Usage
 
-> Starting with patches v3.0.0, Piko patches use [Morphe](https://morphe.software).
+Starting with patches v3.0.0, Piko patches use [Morphe](https://morphe.software).
 
-**Morphe Manager**
+### Morphe Manager
 
-<details>
-<summary>Show steps</summary>
+Tap the link to add Piko as a patch source in Morphe Manager:
 
-Use the deep link to add Piko as a patch source in Morphe Manager:
-
-[➕ Add Piko to Morphe](https://morphe.software/add-source?github=crimera/piko)
+[**➕ Add Piko to Morphe**](https://morphe.software/add-source?github=crimera/piko)
 
 Then patch Twitter/X or Instagram:
 1. Tap X or Instagram app icon in Morphe
 2. Download original APKM file from ApkMirror. Do _not_ unspilt or modify the file, Morphe patches APKM directly
 3. Wait for patching to complete, install
 
-
-
-</details>
-
-**Morphe CLI**
+### Morphe CLI
 
 ```sh
 java -jar cli.jar patch --patches piko.mpp input.apkm
 ```
 
-
-**X-Shim**
+### X-Shim
 
 Starting `12.5.0-release.0` **you need not** apply X-Shim along with Piko patches. X login and XChat will work fine without X-Shim patches.
 
+<details>
+
+<summary>Open old information</summary>
+
 <del>
-To patch with Twitter/X version 11.88 and above, you must include patches from another repo/project called [Piko-Shim](https://gitlab.com/inotia00/piko-shim/) developed by [@inotia00](https://github.com/inotia00)
+
+To patch with Twitter/X version 11.88 to 12.4, you must include patches from another repo/project called [X-Shim](https://gitlab.com/inotia00/x-shim) developed by [@inotia00](https://github.com/inotia00)
 
 [➕ Add X-Shim to Morphe](https://morphe.software/add-source?gitlab=inotia00/x-shim)
 
@@ -68,6 +63,8 @@ To patch with Twitter/X version 11.88 and above, you must include patches from a
 > For an up-to-date patching guide, [follow this Reddit guide](https://www.reddit.com/r/MorpheApp/comments/1r4xt24/x_twitter_can_now_be_patched_with_piko_patches/).
 
 </del>
+
+</details>
 
 ## ⚙️ Patch Details
 


### PR DESCRIPTION
* Organize HTML tags
* Change "Morphe Manager" and "Morphe CLI" headers from simple bold text to actual headers
* Do not hide the Morphe Manager steps inside an details tag
  * This is the most important and in-demand part of this README, so there is no need to hide it
* Make the "Add Piko to Morphe" deep link bold
* Hide the X-Shim related information into "Open old Information" details tag
  * This makes Readme cleaner, and reduces the burden on the reader
  * While the entire X-Shim section can be removed in the future, the upcoming v3.9.0 stable release will be the first version without X-Shim for general users, so it is best to keep it inside the details tag for the time being