### PR TITLE
feat(instagram): copy media link in posts/reels overflow + strip shid from shared links

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -138,6 +138,8 @@ public class Links {
     public static String sanitizeUrl(String url){
         try{
             return url.replaceAll("([&?])igsh=[^&]*", "")
+                    .replaceAll("([&?])igshid=[^&]*", "")
+                    .replaceAll("([&?])shid=[^&]*", "")
                     .replaceAll("([&?])utm_source=[^&]*", "")
                     .replaceAll("([&?])utm_medium=[^&]*", "")
                     .replaceAll("([&?])utm_content=[^&]*", "")

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/copyMediaLink/CopyMediaLinkUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/copyMediaLink/CopyMediaLinkUtils.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.copyMediaLink;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+
+import java.util.ArrayList;
+
+import app.morphe.extension.instagram.entity.InstagramDialogBox;
+import app.morphe.extension.instagram.entity.MediaData;
+import app.morphe.extension.shared.Logger;
+import app.morphe.extension.shared.Utils;
+
+import com.instagram.common.session.UserSession;
+
+public class CopyMediaLinkUtils {
+
+    public static void copyMediaLinkDialog(Context context, UserSession userSession, Object mediaObject, int currentMediaIndex) {
+        try {
+            MediaData mediaData = new MediaData(mediaObject, userSession);
+            int carouselSize = mediaData.getCarouselSize();
+            boolean hasAudio = mediaData.getMediaAt(currentMediaIndex).hasAudio();
+
+            InstagramDialogBox dialog = new InstagramDialogBox(context);
+            ArrayList<String> options = new ArrayList<>();
+
+            options.add(str("piko_copy_current_media_link"));
+            if (hasAudio) {
+                options.add(str("piko_copy_audio_link"));
+            }
+            if (carouselSize > 1) {
+                options.add(str("piko_copy_all_media_links"));
+            }
+
+            CharSequence[] items = options.toArray(new CharSequence[0]);
+
+            dialog.addDialogMenuItems(items, new DialogInterface.OnClickListener() {
+                @Override
+                public void onClick(DialogInterface d, int which) {
+                    try {
+                        // Doing like this because options are dynamic.
+                        String selectedOption = options.get(which);
+                        String stringToCopy = null;
+
+                        if (selectedOption.equals(str("piko_copy_current_media_link"))) {
+                            stringToCopy = mediaData.getMediaAt(currentMediaIndex).getMediaLink();
+
+                        } else if (selectedOption.equals(str("piko_copy_audio_link"))) {
+                            stringToCopy = mediaData.getMediaAt(currentMediaIndex).getAudioMedia().getAudioUrl();
+
+                        } else if (selectedOption.equals(str("piko_copy_all_media_links"))) {
+                            StringBuilder builder = new StringBuilder();
+                            int size = mediaData.getCarouselSize();
+                            for (int index = 0; index < size; index++) {
+                                if (index > 0) {
+                                    builder.append('\n');
+                                }
+                                builder.append(mediaData.getMediaAt(index).getMediaLink());
+                            }
+                            stringToCopy = builder.toString();
+                        }
+
+                        if (stringToCopy != null && !stringToCopy.isEmpty()) {
+                            Utils.setClipboard(stringToCopy);
+                            Utils.showToastShort(str("piko_copied_media_link"));
+                        } else {
+                            Utils.showToastShort(str("piko_fail_no_file"));
+                        }
+                    } catch (Exception e) {
+                        Logger.printException(() -> "Error at copyMediaLinkDialog onClick", e);
+                        Utils.showToastShort(e.getMessage());
+                    }
+                }
+            });
+
+            dialog.setTitle(str("piko_copy_media_link"));
+            dialog.setCancelable(true);
+            dialog.setCanceledOnTouchOutside(true);
+
+            Dialog dlg = dialog.getDialog();
+            dlg.show();
+
+        } catch (Exception e) {
+            Utils.showToastShort(e.getMessage());
+            Logger.printException(() -> "copyMediaLinkDialog failure", e);
+        }
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/FeedButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/FeedButton.java
@@ -30,6 +30,7 @@ import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.entity.MediaData;
 import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.patches.download.DownloadUtils;
+import app.morphe.extension.instagram.patches.copyMediaLink.CopyMediaLinkUtils;
 import app.morphe.extension.instagram.patches.feed.MoreOptionsOnPostPatch;
 import app.morphe.extension.instagram.settings.ActivityHook;
 
@@ -55,6 +56,9 @@ public class FeedButton {
         }
         if(SettingsStatus.downloadWithExternalDownloader){
             additionalButtonsList.add(MediaOption$Option.PIKO_EXTERNAL_DOWNLOADER);
+        }
+        if(SettingsStatus.copyMediaLink){
+            additionalButtonsList.add(MediaOption$Option.PIKO_COPY_MEDIA_LINK);
         }
 
         int additionalButtonListSize = additionalButtonsList.size();
@@ -118,6 +122,10 @@ public class FeedButton {
         return FeedButton.initOverflowButton("PIKO_EXTERNAL_DOWNLOADER", 503, UI.DRAWABLE_DOWNLOAD_ICON);
     }
 
+    public static MediaOption$Option copyMediaLinkOverflowButton(){
+        return FeedButton.initOverflowButton("PIKO_COPY_MEDIA_LINK", 504, UI.DRAWABLE_LINK_ICON);
+    }
+
 
     private static void addDownloadButton(Object buttonAdderObject, ArrayList buttonlist) throws Exception {
         String DOWNLOAD_BUTTON_TEXT = str("piko_download_options");
@@ -138,6 +146,9 @@ public class FeedButton {
             if(Pref.downloadWithExternalDownloader()) {
                 addButton(MediaOption$Option.PIKO_EXTERNAL_DOWNLOADER, str("piko_download_with_external_downloader"), buttonAdderObject, buttonlist);
             }
+            if(Pref.copyMediaLink()) {
+                addButton(MediaOption$Option.PIKO_COPY_MEDIA_LINK, str("piko_copy_media_link"), buttonAdderObject, buttonlist);
+            }
             if(Pref.moreOptionsOnPost()) {
                 addButton(MediaOption$Option.PIKO_MORE_POST_OPTION, str("piko_more_options"), buttonAdderObject, buttonlist);
             }
@@ -151,7 +162,8 @@ public class FeedButton {
                 pressedButton.equals(MediaOption$Option.PIKO_DEBUG) ||
                 (SettingsStatus.downloadMedia && pressedButton.equals(MediaOption$Option.PIKO_DOWNLOAD)) ||
                 (SettingsStatus.moreOptionsOnPost && pressedButton.equals(MediaOption$Option.PIKO_MORE_POST_OPTION)) ||
-                (SettingsStatus.downloadWithExternalDownloader && pressedButton.equals(MediaOption$Option.PIKO_EXTERNAL_DOWNLOADER))
+                (SettingsStatus.downloadWithExternalDownloader && pressedButton.equals(MediaOption$Option.PIKO_EXTERNAL_DOWNLOADER)) ||
+                (SettingsStatus.copyMediaLink && pressedButton.equals(MediaOption$Option.PIKO_COPY_MEDIA_LINK))
         );
     }
 
@@ -168,6 +180,9 @@ public class FeedButton {
 
             } else if (SettingsStatus.downloadWithExternalDownloader && pressedButton.equals(MediaOption$Option.PIKO_EXTERNAL_DOWNLOADER)) {
                 DownloadUtils.externalDownloader(mediaObject,currentMediaIndex);
+
+            } else if (SettingsStatus.copyMediaLink && pressedButton.equals(MediaOption$Option.PIKO_COPY_MEDIA_LINK)) {
+                CopyMediaLinkUtils.copyMediaLinkDialog(context, userSession, mediaObject, currentMediaIndex);
 
             }
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/AddReelButton.java
@@ -28,6 +28,7 @@ import app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons.D
 import app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons.DebugButton;
 import app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons.InfoButton;
 import app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons.ExternalDownloadButton;
+import app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons.CopyMediaLinkButton;
 
 public class AddReelButton {
 
@@ -97,6 +98,16 @@ public class AddReelButton {
         AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
     }
 
+    private static void addCopyMediaLinkButton(Context context, Object helperObject, Object mediaObject){
+        String icon = UI.DRAWABLE_LINK_ICON;
+        ReelButton reelButton = new CopyMediaLinkButton(context,mediaObject);
+        String buttonText = str("piko_copy_media_link");
+
+        ReelOverflowButton reelOverflowButton = new ReelOverflowButton(icon,reelButton,buttonText);
+
+        AddReelButton.addReelButton(context,reelOverflowButton,helperObject);
+    }
+
     public static void includeCustomReelOverflowButtons(Context context, Object helperObject, Object mediaObject){
         if(Pref.pikoDebug()){
             AddReelButton.addDebugButton(context, helperObject, mediaObject);
@@ -106,6 +117,9 @@ public class AddReelButton {
         }
         if(Pref.downloadWithExternalDownloader()){
             AddReelButton.addExternalDownloadButton(context, helperObject, mediaObject);
+        }
+        if(Pref.copyMediaLink()){
+            AddReelButton.addCopyMediaLinkButton(context, helperObject, mediaObject);
         }
         if(Pref.moreOptionsOnPost()){
             AddReelButton.addInfoButton(context, helperObject, mediaObject);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/CopyMediaLinkButton.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/overflowMenuButton/reels/buttons/CopyMediaLinkButton.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.overflowMenuButton.reels.buttons;
+
+import android.view.View;
+import android.content.Context;
+import app.morphe.extension.instagram.patches.copyMediaLink.CopyMediaLinkUtils;
+
+public class CopyMediaLinkButton extends ReelButton {
+    public CopyMediaLinkButton(Context context, Object mediaObject) {
+        super(context, mediaObject);
+    }
+
+    @Override
+    public void onClick(View view) {
+        CopyMediaLinkUtils.copyMediaLinkDialog(this.context, null, this.mediaObject, 0);
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -70,6 +70,7 @@ public class Settings {
     public static final StringSetting CUSTOM_DOWNLOAD_PATH = new StringSetting("custom_download_path", "");
     public static final StringSetting EXTERNAL_DOWNLOADER_PACKAGE_NAME = new StringSetting("external_downloader_package_name", "");
     public static final BooleanSetting DOWNLOAD_WITH_EXTERNAL_DOWNLOADER = new BooleanSetting("download_with_external_downloader", true);
+    public static final BooleanSetting COPY_MEDIA_LINK = new BooleanSetting("copy_media_link", true);
 
     public static final BooleanSetting HIDE_NAVIGATION_FEED = new BooleanSetting("hide_navigation_feed", false);
     public static final BooleanSetting HIDE_NAVIGATION_REELS = new BooleanSetting("hide_navigation_reels", false);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -55,7 +55,7 @@ public class SettingsStatus {
     public static boolean sanitizeShareLinks = false;
     public static void sanitizeShareLinks() {sanitizeShareLinks = true;}
     public static boolean linksSection() {
-        return (openLinksExternally || sanitizeShareLinks);
+        return (openLinksExternally || sanitizeShareLinks || copyMediaLink);
     }
 
 
@@ -204,6 +204,10 @@ public class SettingsStatus {
     public static void downloadWithExternalDownloader() { downloadWithExternalDownloader = true; }
     public static boolean downloadSection(){return (SettingsStatus.downloadMedia || SettingsStatus.downloadWithExternalDownloader);}
 
+    //Copy media link.
+    public static boolean copyMediaLink = false;
+    public static void copyMediaLink() { copyMediaLink = true; }
+
     public static boolean hideNavigationButtons = false;
     public static void hideNavigationButtons() { hideNavigationButtons = true; }
 
@@ -264,6 +268,7 @@ public class SettingsStatus {
 
         FLAGS.put(str("piko_sanitize_share_links"),SettingsStatus.sanitizeShareLinks);
         FLAGS.put(str("piko_open_links_externally"),SettingsStatus.openLinksExternally);
+        FLAGS.put(str("piko_copy_media_link"),SettingsStatus.copyMediaLink);
         FLAGS.put(str("piko_download_voice_media"),SettingsStatus.downloadVoiceMessage);
         FLAGS.put(str("piko_download_with_external_downloader"),SettingsStatus.downloadWithExternalDownloader);
         FLAGS.put(str("piko_more_profile_options"),SettingsStatus.moreOptionsOnProfile);

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -305,6 +305,15 @@ public class ScreenBuilder {
                     )
             );
         }
+        if (SettingsStatus.copyMediaLink) {
+            addPreference(
+                    helper.switchPreference(
+                            str("piko_copy_media_link"),
+                            "",
+                            Settings.COPY_MEDIA_LINK
+                    )
+            );
+        }
     }
 
     public void distractionFreeSection() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -285,6 +285,10 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.DOWNLOAD_WITH_EXTERNAL_DOWNLOADER) && SettingsStatus.downloadWithExternalDownloader;
     }
 
+    public static boolean copyMediaLink() {
+        return SharedPref.getBooleanPref(Settings.COPY_MEDIA_LINK) && SettingsStatus.copyMediaLink;
+    }
+
     public static String externalDownloaderPackageName() {
         return SharedPref.getStringPref(Settings.EXTERNAL_DOWNLOADER_PACKAGE_NAME);
     }

--- a/extensions/instagram/stub/src/main/java/com/instagram/feed/media/mediaoption/MediaOption$Option.java
+++ b/extensions/instagram/stub/src/main/java/com/instagram/feed/media/mediaoption/MediaOption$Option.java
@@ -12,6 +12,7 @@ public class MediaOption$Option {
     public static final MediaOption$Option PIKO_MORE_POST_OPTION = new MediaOption$Option("", 0, 0);
     public static final MediaOption$Option PIKO_DEBUG = new MediaOption$Option("", 0, 0);
     public static final MediaOption$Option PIKO_EXTERNAL_DOWNLOADER = new MediaOption$Option("", 0, 0);
+    public static final MediaOption$Option PIKO_COPY_MEDIA_LINK = new MediaOption$Option("", 0, 0);
 
     public static final MediaOption$Option[] $values(){
         return null;

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/copyMediaLink/CopyMediaLinkPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/copyMediaLink/CopyMediaLinkPatch.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.links.copyMediaLink
+
+import app.crimera.patches.instagram.misc.overflowMenuButton.posts.addOverflowMenuButtonAttributes
+import app.crimera.patches.instagram.misc.overflowMenuButton.posts.debugOverflowButton.debugOverflowMenuButtonPatch
+import app.crimera.patches.instagram.misc.overflowMenuButton.posts.hookOverflowMenuButton
+import app.crimera.patches.instagram.misc.overflowMenuButton.reels.hookReelOverflowMenuButton
+import app.crimera.patches.instagram.misc.settings.settingsPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.enableSettings
+import app.morphe.patcher.patch.bytecodePatch
+
+@Suppress("unused")
+val copyMediaLinkPatch =
+    bytecodePatch(
+        name = "Copy media link",
+        description = "Adds a button to copy the direct media link (CDN URL) of posts and reels to the clipboard",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+        dependsOn(settingsPatch, hookOverflowMenuButton, debugOverflowMenuButtonPatch, hookReelOverflowMenuButton)
+        execute {
+
+            addOverflowMenuButtonAttributes("PIKO_COPY_MEDIA_LINK", "copyMediaLinkOverflowButton")
+
+            enableSettings("copyMediaLink")
+        }
+    }

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -137,6 +137,9 @@ Note: On a clean install, the \'Tip\' animation may appear but will stop on its 
     <string name="piko_download_options">Download options</string>
     <string name="piko_copy_media_link">Copy media link</string>
     <string name="piko_copied_media_link">Copied media link</string>
+    <string name="piko_copy_current_media_link">Copy current media link</string>
+    <string name="piko_copy_audio_link">Copy audio link</string>
+    <string name="piko_copy_all_media_links">Copy all media links</string>
     <string name="piko_download_all">Download all</string>
     <string name="piko_downloading_media">Downloading: </string>
     <string name="piko_downloaded_media">Downloaded: </string>


### PR DESCRIPTION
## Summary
- **Copy media link** — new option in the posts overflow menu and reels ⋮ popup (external-downloader slot) that copies the **direct CDN media URL** to the clipboard
  - Single media → copies immediately
  - Carousel → dialog: *current media link* / *all links (newline-separated)* / *audio link* (when audio exists)
- **Sanitize share links: strip `?shid=`** — `sanitizeUrl()` now removes `shid` and `igshid` tracking params alongside the existing `igsh`/`utm_*` list
- Settings toggle `copy_media_link` (Links section, default on)

## Implementation
| Piece | File |
|---|---|
| Bytecode patch | `patches/.../links/copyMediaLink/CopyMediaLinkPatch.kt` |
| Dialog + copy logic | `extensions/.../patches/copyMediaLink/CopyMediaLinkUtils.java` |
| Reels button | `extensions/.../reels/buttons/CopyMediaLinkButton.java` |
| Posts enum slot | `MediaOption$Option` stub + `FeedButton` (5 hooks) |
| Reels wiring | `AddReelButton` |
| Settings | `Settings`/`SettingsStatus`/`Pref`/`ScreenBuilder` + 3 strings |

## Notes
- `getMediaLink()` on a video returns the mp4 CDN URL, so no separate "video link" option is needed.
- Compiles against stubs; runtime reflection matches existing `DownloadUtils` patterns (same entity layer).
- Local Gradle build blocked: Morphe registry (GitHub Packages) needs `read:packages` scope not present on the current token — CI on this PR is the compile check.
