### PR TITLE
improve(Instagram): Refine anonymous DM handling

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/MarkChatAsRead.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/dm/MarkChatAsRead.java
@@ -15,6 +15,7 @@ import app.morphe.extension.crimera.ObjectBrowser;
 
 import app.morphe.extension.instagram.entity.Entity;
 import app.morphe.extension.instagram.utils.Pref;
+import app.morphe.extension.shared.MarkChatAsReadScope;
 
 import com.instagram.model.direct.DirectThreadKey;
 import com.instagram.common.session.UserSession;
@@ -88,16 +89,13 @@ public class MarkChatAsRead {
 
     private static void markAsRead(UserSession userSession, Object unknown, DirectThreadKey directThreadKey){
         try{
-            Pref.setMarkChatAsReadIndicator(true);
+            MarkChatAsReadScope.run(() -> {
+                String threadId = directThreadKey.A00;
+                String messageId = MarkChatAsRead.getMessageCursorId(unknown);
+                String senderId = directThreadKey.A02.get(0).toString();
 
-            String threadId = directThreadKey.A00;
-            String messageId = MarkChatAsRead.getMessageCursorId(unknown);
-            String senderId = directThreadKey.A02.get(0).toString();
-
-            markAsSeenAPICall(userSession, threadId, messageId, senderId);
-
-            Pref.setMarkChatAsReadIndicator(false);
-
+                markAsSeenAPICall(userSession, threadId, messageId, senderId);
+            });
         } catch (Exception e) {
             PikoUtils.logger(e);
         }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/SettingsStatus.java
@@ -205,7 +205,7 @@ public class SettingsStatus {
     public static void unlimitedReplaysOnEphemeralMedia() {unlimitedReplaysOnEphemeralMedia = true;}
     public static boolean markChatAsRead = false;
     public static void markChatAsRead() { markChatAsRead = true; }
-    public static boolean dmSection(){ return markChatAsRead || unlimitedReplaysOnEphemeralMedia || disableTypingStatus || viewDmAnonymously || saveDeletedMessages ;}
+    public static boolean dmSection(){ return markChatAsRead || unlimitedReplaysOnEphemeralMedia || saveDeletedMessages ;}
 
     //Download section.
     public static boolean downloadMedia = false;

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -198,26 +198,6 @@ public class ScreenBuilder {
     public void dmSection() {
         if (!(SettingsStatus.dmSection())) return;
 
-        if (SettingsStatus.disableTypingStatus) {
-            addPreference(
-                    helper.switchPreference(
-                            str("piko_disable_typing_status"),
-                            "",
-                            Settings.DISABLE_TYPING_STATUS
-                    )
-            );
-        }
-
-        if (SettingsStatus.viewDmAnonymously) {
-            addPreference(
-                    helper.switchPreference(
-                            str("piko_view_dm_anonymously"),
-                            "",
-                            Settings.VIEW_DM_ANONYMOUSLY
-                    )
-            );
-        }
-
         if (SettingsStatus.unlimitedReplaysOnEphemeralMedia) {
             addPreference(
                     helper.switchPreference(
@@ -311,7 +291,7 @@ public class ScreenBuilder {
             addPreference(
                     helper.switchPreference(
                             str("piko_view_dm_anonymously"),
-                            "",
+                            str("piko_view_dm_anonymously_desc"),
                             Settings.VIEW_DM_ANONYMOUSLY
                     )
             );

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -14,17 +14,11 @@ import app.morphe.extension.instagram.settings.SettingsStatus;
 import app.morphe.extension.instagram.constants.Constants;
 
 import app.morphe.extension.crimera.sharedPreference.SharedPref;
+import app.morphe.extension.shared.MarkChatAsReadScope;
 
 @SuppressWarnings("unused")
 public class Pref {
     private static final int MAX_IMAGE_SIZE = 4096;
-    public static boolean SHOULD_MARK_CHAT_AS_READ;
-    static {
-        SHOULD_MARK_CHAT_AS_READ = false;
-    }
-    public static void setMarkChatAsReadIndicator(boolean bool) {
-        SHOULD_MARK_CHAT_AS_READ = bool;
-    }
 
     public static boolean clearAllPreferences() {
         return SharedPref.clearAll();
@@ -104,10 +98,22 @@ public class Pref {
     // Return false = call the message seen api.
     // Return true = blocks the message seen api.
     public static boolean viewDmAnonymously() {
-        if(enableMarkChatAsReadOption() && SHOULD_MARK_CHAT_AS_READ){
+        return shouldBlockDmSeen(
+                SharedPref.getBooleanPref(Settings.VIEW_DM_ANONYMOUSLY),
+                Pref.getTurnOnAllGhostModes(),
+                enableMarkChatAsReadOption()
+        );
+    }
+
+    static boolean shouldBlockDmSeen(
+            boolean viewDmAnonymously,
+            boolean allGhostModes,
+            boolean manualReadOptionEnabled
+    ) {
+        if (manualReadOptionEnabled && MarkChatAsReadScope.isActive()) {
             return false;
         }
-        return SharedPref.getBooleanPref(Settings.VIEW_DM_ANONYMOUSLY) || Pref.getTurnOnAllGhostModes();
+        return viewDmAnonymously || allGhostModes;
     }
 
     public static boolean disableVideoAutoplay() {

--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/MarkChatAsReadScope.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/MarkChatAsReadScope.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.shared;
+
+public final class MarkChatAsReadScope {
+    private static final ThreadLocal<Boolean> ACTIVE = new ThreadLocal<>();
+
+    private MarkChatAsReadScope() {
+    }
+
+    public static boolean isActive() {
+        return Boolean.TRUE.equals(ACTIVE.get());
+    }
+
+    public static void run(Operation operation) throws Exception {
+        ACTIVE.set(true);
+        try {
+            operation.run();
+        } finally {
+            ACTIVE.remove();
+        }
+    }
+
+    @FunctionalInterface
+    public interface Operation {
+        void run() throws Exception;
+    }
+}

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -40,6 +40,7 @@
     <string name="piko_disable_typing_status">Disable typing status</string>
     <string name="piko_disable_screenshot_detection">Disable screenshot detection</string>
     <string name="piko_view_dm_anonymously">View direct messages anonymously</string>
+    <string name="piko_view_dm_anonymously_desc">When enabled, others can\'t see when you\'ve read their messages. When both this setting and Turn on all ghost modes are disabled, Instagram\'s Show read receipts setting is used</string>
     <string name="piko_turn_on_all_ghost_modes">Turn on all ghost modes</string>
     <string name="piko_ghost_modes_on">Ghost mode: ON</string>
     <string name="piko_ghost_modes_default">Ghost mode: DEFAULT</string>
@@ -129,7 +130,7 @@
     <string name="piko_unlimited_replays">Make ephemeral media permanent</string>
     <string name="piko_unlimited_replays_desc">Changes unexpired view once, view twice media to permanent view</string>
     <string name="piko_enable_mark_chat_as_read">Enable mark chat as read option</string>
-    <string name="piko_enable_mark_chat_as_read_desc">Get an option, on long pressing the chat, to mark it as read</string>
+    <string name="piko_enable_mark_chat_as_read_desc">Get an option, on long pressing the chat, to mark it as read. When you mark a chat as read, others can see that you\'ve read their messages, even when View direct messages anonymously is enabled</string>
 
     <!-- Download Media Section -->
     <string name="piko_category_download_media">Download media</string>


### PR DESCRIPTION
Refines anonymous DM settings and manual read receipt handling. Disable typing status and View direct messages anonymously now appear only in the Ghost section instead of being duplicated in both the Ghost and DM settings. The temporary allowance used by Mark as read is now limited to the thread performing the action, it does not affect concurrent read operations. The updated descriptions explain how anonymous viewing works with manual read receipts and Instagram's native Show read receipts setting

## Testing
- `.\gradlew.bat test :patches:checkStringResources --no-daemon --console=plain`
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- Tested on Instagram v439.0.0.37.89 with Piko v3.9.0-dev.9
- Tested on Samsung Galaxy S26