### PR TITLE
feat(Instagram): Add `Force system font` patch

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/font/ForceSystemFontPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/font/ForceSystemFontPatch.java
@@ -8,6 +8,7 @@ package app.morphe.extension.instagram.patches.font;
 
 import android.content.Context;
 import android.graphics.Typeface;
+import android.os.Build;
 
 import java.util.Locale;
 
@@ -38,15 +39,24 @@ public final class ForceSystemFontPatch {
         }
 
         if (resourceName.equals("iguibetav9_regular")) {
-            return Typeface.create(Typeface.DEFAULT, 400, false);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                return Typeface.create(Typeface.DEFAULT, 400, false);
+            }
+            return Typeface.create(Typeface.DEFAULT, Typeface.NORMAL);
         }
 
         if (resourceName.equals("iguibetav9_semibold")) {
-            return Typeface.create(Typeface.DEFAULT, 600, false);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                return Typeface.create(Typeface.DEFAULT, 600, false);
+            }
+            return Typeface.create(Typeface.DEFAULT, Typeface.BOLD);
         }
 
         if (resourceName.equals("iguibetav9_bold")) {
-            return Typeface.create(Typeface.DEFAULT, 700, false);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                return Typeface.create(Typeface.DEFAULT, 700, false);
+            }
+            return Typeface.create(Typeface.DEFAULT, Typeface.BOLD);
         }
 
         if (resourceName.equals("prism_sans")) {
@@ -59,10 +69,19 @@ public final class ForceSystemFontPatch {
     public static Typeface getSystemTypefaceForWeight(int weight) {
         int normalizedWeight = Math.max(1, Math.min(1000, weight));
 
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            return Typeface.create(
+                    Typeface.DEFAULT,
+                    normalizedWeight,
+                    false
+            );
+        }
+
         return Typeface.create(
                 Typeface.DEFAULT,
-                normalizedWeight,
-                false
+                normalizedWeight >= 600
+                        ? Typeface.BOLD
+                        : Typeface.NORMAL
         );
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/font/ForceSystemFontPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/font/ForceSystemFontPatch.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.font;
+
+import android.content.Context;
+import android.graphics.Typeface;
+
+import java.util.Locale;
+
+@SuppressWarnings("unused")
+public final class ForceSystemFontPatch {
+
+    private ForceSystemFontPatch() {
+    }
+
+    public static Typeface getSystemTypeface(
+            Context context,
+            int resourceId,
+            int style
+    ) {
+        if (context == null) {
+            return null;
+        }
+
+        String resourceName;
+
+        try {
+            resourceName = context
+                    .getResources()
+                    .getResourceEntryName(resourceId)
+                    .toLowerCase(Locale.ROOT);
+        } catch (Exception ignored) {
+            return null;
+        }
+
+        if (resourceName.equals("iguibetav9_regular")) {
+            return Typeface.create(Typeface.DEFAULT, 400, false);
+        }
+
+        if (resourceName.equals("iguibetav9_semibold")) {
+            return Typeface.create(Typeface.DEFAULT, 600, false);
+        }
+
+        if (resourceName.equals("iguibetav9_bold")) {
+            return Typeface.create(Typeface.DEFAULT, 700, false);
+        }
+
+        if (resourceName.equals("prism_sans")) {
+            return Typeface.create(Typeface.DEFAULT, style);
+        }
+
+        return null;
+    }
+
+    public static Typeface getSystemTypefaceForWeight(int weight) {
+        int normalizedWeight = Math.max(1, Math.min(1000, weight));
+
+        return Typeface.create(
+                Typeface.DEFAULT,
+                normalizedWeight,
+                false
+        );
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/Fingerprints.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.font
+
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.string
+import com.android.tools.smali.dexlib2.AccessFlags
+
+internal object ResourcesCompatGetFontFingerprint : Fingerprint(
+    returnType = "Landroid/graphics/Typeface;",
+    filters = listOf(
+        string("ResourcesCompat"),
+        string("res/"),
+    ),
+    custom = { method, _ ->
+        AccessFlags.STATIC.isSet(method.accessFlags) &&
+            method.parameters.size == 7 &&
+            method.parameters[0].type == "Landroid/content/Context;" &&
+            method.parameters[1].type == "Landroid/util/TypedValue;" &&
+            method.parameters[2].type.startsWith("L") &&
+            method.parameters[3].type == "I" &&
+            method.parameters[4].type == "I" &&
+            method.parameters[5].type == "Z" &&
+            method.parameters[6].type == "Z"
+    },
+)
+
+internal object ReactNativeFontRegistrationFingerprint : Fingerprint(
+    strings = listOf("Optimistic VF App Lite "),
+    custom = { method, _ ->
+        method.parameters.isEmpty() &&
+            method.returnType.startsWith("L")
+    },
+)

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
@@ -131,11 +131,7 @@ val forceSystemFontPatch =
                     move/from16 v1, p3
                     move/from16 v2, p4
 
-                    invoke-static {v0, v1, v2},
-                        $EXTENSION_CLASS->getSystemTypeface(
-                            Landroid/content/Context;
-                            II
-                        )Landroid/graphics/Typeface;
+                    invoke-static {v0, v1, v2}, $EXTENSION_CLASS->getSystemTypeface(Landroid/content/Context;II)Landroid/graphics/Typeface;
 
                     move-result-object v0
 
@@ -283,8 +279,7 @@ val forceSystemFontPatch =
             reactNativeMethod.addInstructions(
                 typefaceFactoryIndex + 2,
                 """
-                    invoke-static {v$weightRegister},
-                        $EXTENSION_CLASS->getSystemTypefaceForWeight(I)Landroid/graphics/Typeface;
+                    invoke-static {v$weightRegister}, $EXTENSION_CLASS->getSystemTypefaceForWeight(I)Landroid/graphics/Typeface;
 
                     move-result-object v$resultRegister
                 """.trimIndent(),

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
@@ -8,98 +8,19 @@ package app.crimera.patches.instagram.misc.font
 
 import app.crimera.patches.instagram.misc.extension.sharedExtensionPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.crimera.patches.instagram.utils.Constants.PATCHES_DESCRIPTOR
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.registersUsed
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
-import app.morphe.patcher.patch.resourcePatch
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.MethodReference
-import org.w3c.dom.Element
 
 private const val EXTENSION_CLASS =
-    "Lapp/morphe/extension/instagram/patches/font/ForceSystemFontPatch;"
-
-/*
- * Changes Instagram's default theme font from prism_sans
- * to the Android system sans-serif font.
- */
-private val forceSystemFontThemePatch =
-    resourcePatch(
-        name = "Force system font theme",
-        description = "Internal dependency patch for Instagram's default theme font.",
-        default = true,
-    ) {
-        compatibleWith(COMPATIBILITY_INSTAGRAM)
-
-        execute {
-            document("res/values/styles.xml").use { stylesDocument ->
-
-                val styles =
-                    stylesDocument.getElementsByTagName("style")
-
-                var fontFamilyItem: Element? = null
-
-                for (styleIndex in 0 until styles.length) {
-
-                    val style =
-                        styles.item(styleIndex) as? Element
-                            ?: continue
-
-                    if (
-                        style.getAttribute("name") !=
-                        "Base.Theme.Instagram"
-                    ) {
-                        continue
-                    }
-
-                    val items =
-                        style.getElementsByTagName("item")
-
-                    for (itemIndex in 0 until items.length) {
-
-                        val item =
-                            items.item(itemIndex) as? Element
-                                ?: continue
-
-                        if (
-                            item.getAttribute("name") !=
-                            "android:fontFamily"
-                        ) {
-                            continue
-                        }
-
-                        if (fontFamilyItem != null) {
-                            throw PatchException(
-                                "Found multiple Instagram theme font declarations."
-                            )
-                        }
-
-                        fontFamilyItem = item
-                    }
-                }
-
-                val item =
-                    fontFamilyItem
-                        ?: throw PatchException(
-                            "Could not find Instagram's default theme font declaration."
-                        )
-
-                if (
-                    item.textContent.trim() !=
-                    "@font/prism_sans"
-                ) {
-                    throw PatchException(
-                        "Instagram's default theme font has an unexpected value."
-                    )
-                }
-
-                item.textContent = "sans-serif"
-            }
-        }
-    }
+    "$PATCHES_DESCRIPTOR/font/ForceSystemFontPatch;"
 
 /*
  * Forces Instagram's custom fonts to use
@@ -203,7 +124,7 @@ val forceSystemFontPatch =
                 (
                     instructions[typefaceFactoryIndex]
                         as ReferenceInstruction
-                    ).reference as MethodReference
+                ).reference as MethodReference
 
             /*
              * Find the variable font weight setter.
@@ -262,12 +183,10 @@ val forceSystemFontPatch =
                 )
             }
 
-            val weightInstruction =
-                instructions[weightSetterIndex]
-                    as FiveRegisterInstruction
-
             val weightRegister =
-                weightInstruction.registerD
+                instructions[weightSetterIndex]
+                    .registersUsed
+                    .last()
 
             val resultRegister =
                 resultInstruction.registerA

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontPatch.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.font
+
+import app.crimera.patches.instagram.misc.extension.sharedExtensionPatch
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.resourcePatch
+import com.android.tools.smali.dexlib2.Opcode
+import com.android.tools.smali.dexlib2.iface.instruction.FiveRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OneRegisterInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import org.w3c.dom.Element
+
+private const val EXTENSION_CLASS =
+    "Lapp/morphe/extension/instagram/patches/font/ForceSystemFontPatch;"
+
+/*
+ * Changes Instagram's default theme font from prism_sans
+ * to the Android system sans-serif font.
+ */
+private val forceSystemFontThemePatch =
+    resourcePatch(
+        name = "Force system font theme",
+        description = "Internal dependency patch for Instagram's default theme font.",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            document("res/values/styles.xml").use { stylesDocument ->
+
+                val styles =
+                    stylesDocument.getElementsByTagName("style")
+
+                var fontFamilyItem: Element? = null
+
+                for (styleIndex in 0 until styles.length) {
+
+                    val style =
+                        styles.item(styleIndex) as? Element
+                            ?: continue
+
+                    if (
+                        style.getAttribute("name") !=
+                        "Base.Theme.Instagram"
+                    ) {
+                        continue
+                    }
+
+                    val items =
+                        style.getElementsByTagName("item")
+
+                    for (itemIndex in 0 until items.length) {
+
+                        val item =
+                            items.item(itemIndex) as? Element
+                                ?: continue
+
+                        if (
+                            item.getAttribute("name") !=
+                            "android:fontFamily"
+                        ) {
+                            continue
+                        }
+
+                        if (fontFamilyItem != null) {
+                            throw PatchException(
+                                "Found multiple Instagram theme font declarations."
+                            )
+                        }
+
+                        fontFamilyItem = item
+                    }
+                }
+
+                val item =
+                    fontFamilyItem
+                        ?: throw PatchException(
+                            "Could not find Instagram's default theme font declaration."
+                        )
+
+                if (
+                    item.textContent.trim() !=
+                    "@font/prism_sans"
+                ) {
+                    throw PatchException(
+                        "Instagram's default theme font has an unexpected value."
+                    )
+                }
+
+                item.textContent = "sans-serif"
+            }
+        }
+    }
+
+/*
+ * Forces Instagram's custom fonts to use
+ * Android's system Typeface.
+ */
+@Suppress("unused")
+val forceSystemFontPatch =
+    bytecodePatch(
+        name = "Force system font",
+        description = "Renders Instagram UI text using the device system font.",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        dependsOn(
+            forceSystemFontThemePatch,
+            sharedExtensionPatch,
+        )
+
+        execute {
+
+            /*
+             * Hook AndroidX ResourcesCompat.getFont(...)
+             */
+            ResourcesCompatGetFontFingerprint.method.addInstructions(
+                0,
+                """
+                    move-object/from16 v0, p0
+                    move/from16 v1, p3
+                    move/from16 v2, p4
+
+                    invoke-static {v0, v1, v2},
+                        $EXTENSION_CLASS->getSystemTypeface(
+                            Landroid/content/Context;
+                            II
+                        )Landroid/graphics/Typeface;
+
+                    move-result-object v0
+
+                    if-eqz v0, :original
+
+                    return-object v0
+
+                    :original
+                    nop
+                """.trimIndent(),
+            )
+
+            /*
+             * Hook Instagram's React Native
+             * variable font registration.
+             */
+            val reactNativeMethod =
+                ReactNativeFontRegistrationFingerprint.method
+
+            val instructions =
+                reactNativeMethod
+                    .implementation
+                    ?.instructions
+                    ?: throw PatchException(
+                        "React Native font registration has no implementation."
+                    )
+
+            val registrationStringIndex =
+                ReactNativeFontRegistrationFingerprint
+                    .stringMatches
+                    .single()
+                    .index
+
+            val searchStart =
+                maxOf(0, registrationStringIndex - 12)
+
+            /*
+             * Find Typeface factory call.
+             */
+            val typefaceFactoryIndex =
+                (searchStart until registrationStringIndex)
+                    .lastOrNull { index ->
+
+                        val instruction =
+                            instructions[index]
+
+                        val reference =
+                            (instruction as? ReferenceInstruction)
+                                ?.reference as? MethodReference
+
+                        instruction.opcode ==
+                            Opcode.INVOKE_VIRTUAL &&
+
+                            instruction is FiveRegisterInstruction &&
+
+                            reference?.returnType ==
+                                "Landroid/graphics/Typeface;" &&
+
+                            reference.parameterTypes.size == 1 &&
+
+                            reference.parameterTypes[0].toString() ==
+                                "Landroid/content/Context;"
+                    }
+                    ?: throw PatchException(
+                        "Could not find React Native's variable-font factory call."
+                    )
+
+            val typefaceReference =
+                (
+                    instructions[typefaceFactoryIndex]
+                        as ReferenceInstruction
+                    ).reference as MethodReference
+
+            /*
+             * Find the variable font weight setter.
+             */
+            val weightSetterIndex =
+                (
+                    maxOf(
+                        searchStart,
+                        typefaceFactoryIndex - 4,
+                    ) until typefaceFactoryIndex
+                )
+                    .lastOrNull { index ->
+
+                        val instruction =
+                            instructions[index]
+
+                        val reference =
+                            (instruction as? ReferenceInstruction)
+                                ?.reference as? MethodReference
+
+                        instruction.opcode ==
+                            Opcode.INVOKE_VIRTUAL &&
+
+                            instruction is FiveRegisterInstruction &&
+
+                            reference?.definingClass ==
+                                typefaceReference.definingClass &&
+
+                            reference.returnType == "V" &&
+
+                            reference.parameterTypes.size == 1 &&
+
+                            reference.parameterTypes[0].toString() == "I"
+                    }
+                    ?: throw PatchException(
+                        "Could not find React Native's variable-font weight setter."
+                    )
+
+            /*
+             * The Typeface factory should be
+             * immediately followed by move-result-object.
+             */
+            val resultInstruction =
+                instructions.getOrNull(
+                    typefaceFactoryIndex + 1
+                )
+
+            if (
+                resultInstruction?.opcode !=
+                    Opcode.MOVE_RESULT_OBJECT ||
+
+                resultInstruction !is OneRegisterInstruction
+            ) {
+                throw PatchException(
+                    "React Native's variable-font result has an unexpected shape."
+                )
+            }
+
+            val weightInstruction =
+                instructions[weightSetterIndex]
+                    as FiveRegisterInstruction
+
+            val weightRegister =
+                weightInstruction.registerD
+
+            val resultRegister =
+                resultInstruction.registerA
+
+            /*
+             * Replace the Typeface returned by Instagram
+             * with our system Typeface.
+             */
+            reactNativeMethod.addInstructions(
+                typefaceFactoryIndex + 2,
+                """
+                    invoke-static {v$weightRegister},
+                        $EXTENSION_CLASS->getSystemTypefaceForWeight(I)Landroid/graphics/Typeface;
+
+                    move-result-object v$resultRegister
+                """.trimIndent(),
+            )
+        }
+    }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontThemePatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/font/ForceSystemFontThemePatch.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.instagram.misc.font
+
+import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.patch.resourcePatch
+import org.w3c.dom.Element
+
+/*
+ * Changes Instagram's default theme font from prism_sans
+ * to the Android system sans-serif font.
+ */
+internal val forceSystemFontThemePatch =
+    resourcePatch(
+        name = "Use system font in theme",
+        description = "Internal dependency patch for Instagram's default theme font.",
+        default = true,
+    ) {
+        compatibleWith(COMPATIBILITY_INSTAGRAM)
+
+        execute {
+            document("res/values/styles.xml").use { stylesDocument ->
+
+                val styles =
+                    stylesDocument.getElementsByTagName("style")
+
+                var fontFamilyItem: Element? = null
+
+                for (styleIndex in 0 until styles.length) {
+
+                    val style =
+                        styles.item(styleIndex) as? Element
+                            ?: continue
+
+                    if (
+                        style.getAttribute("name") !=
+                        "Base.Theme.Instagram"
+                    ) {
+                        continue
+                    }
+
+                    val items =
+                        style.getElementsByTagName("item")
+
+                    for (itemIndex in 0 until items.length) {
+
+                        val item =
+                            items.item(itemIndex) as? Element
+                                ?: continue
+
+                        if (
+                            item.getAttribute("name") !=
+                            "android:fontFamily"
+                        ) {
+                            continue
+                        }
+
+                        if (fontFamilyItem != null) {
+                            throw PatchException(
+                                "Found multiple Instagram theme font declarations."
+                            )
+                        }
+
+                        fontFamilyItem = item
+                    }
+                }
+
+                val item =
+                    fontFamilyItem
+                        ?: throw PatchException(
+                            "Could not find Instagram's default theme font declaration."
+                        )
+
+                if (
+                    item.textContent.trim() !=
+                    "@font/prism_sans"
+                ) {
+                    throw PatchException(
+                        "Instagram's default theme font has an unexpected value."
+                    )
+                }
+
+                item.textContent = "sans-serif"
+            }
+        }
+    }


### PR DESCRIPTION
This patch will allow users to use their system font in Instagram, which was removed by Meta in recent builds.

OG Patch from [ch3thanhs/stylus](https://github.com/ch3thanhs/stylus)