### PR TITLE
fix(Instagram): Prevent newlines in text preferences

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/EditTextPref.java
@@ -10,15 +10,26 @@ import android.content.Context;
 import android.preference.EditTextPreference;
 import android.util.AttributeSet;
 import android.preference.Preference;
+import android.text.InputFilter;
 import android.text.InputType;
 import android.view.View;
 import android.view.ViewGroup;
+import java.util.Arrays;
 import app.morphe.extension.instagram.patches.Links;
 import app.morphe.extension.instagram.settings.Settings;
 import app.morphe.extension.instagram.settings.preference.Helper;
 
 public class EditTextPref extends EditTextPreference {
+    private static final InputFilter SINGLE_LINE_FILTER = (source, start, end, dest, dstart, dend) -> {
+        CharSequence input = source.subSequence(start, end);
+        String sanitized = removeLineBreaks(input.toString());
+        return sanitized.contentEquals(input) ? null : sanitized;
+    };
     private static Helper helper;
+
+    private static String removeLineBreaks(String value) {
+        return value.replace("\r", "").replace("\n", "");
+    }
 
     public EditTextPref(Context context) {
         super(InstagramPreferenceStyle.dialogContext(context));
@@ -46,6 +57,12 @@ public class EditTextPref extends EditTextPreference {
     }
 
     private void init() {
+        getEditText().setSingleLine(true);
+        InputFilter[] filters = getEditText().getFilters();
+        InputFilter[] singleLineFilters = Arrays.copyOf(filters, filters.length + 1);
+        singleLineFilters[filters.length] = SINGLE_LINE_FILTER;
+        getEditText().setFilters(singleLineFilters);
+
         setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -20,6 +20,10 @@ import app.morphe.extension.shared.MarkChatAsReadScope;
 public class Pref {
     private static final int MAX_IMAGE_SIZE = 4096;
 
+    private static String removeLineBreaks(String value) {
+        return value.replace("\r", "").replace("\n", "");
+    }
+
     public static boolean clearAllPreferences() {
         return SharedPref.clearAll();
     }
@@ -60,7 +64,7 @@ public class Pref {
     }
 
     public static String customSharingDomain() {
-        return SharedPref.getStringPref(Settings.CUSTOM_SHARING_DOMAIN);
+        return removeLineBreaks(SharedPref.getStringPref(Settings.CUSTOM_SHARING_DOMAIN));
     }
 
     public static boolean getTurnOnAllGhostModes() {
@@ -305,7 +309,7 @@ public class Pref {
     }
 
     public static String externalDownloaderPackageName() {
-        return SharedPref.getStringPref(Settings.EXTERNAL_DOWNLOADER_PACKAGE_NAME);
+        return removeLineBreaks(SharedPref.getStringPref(Settings.EXTERNAL_DOWNLOADER_PACKAGE_NAME));
     }
 
     public static Set<String> mainFeedActionBarButtons() {


### PR DESCRIPTION
Prevents the custom sharing domain and external downloader package name preferences from accepting line breaks. Existing CR and LF characters are removed when the values are read, keeping their summaries and trailing chevrons on one line