### PR TITLE
feat(Instagram): Embed metadata in downloaded videos

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
 plugins {
     alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.shadow) apply false
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/entity/MediaData.java
@@ -122,6 +122,10 @@ public class MediaData extends Entity {
         return (String) super.getMethod("methodName");
     }
 
+    public Long getTakenAtSeconds() throws Exception {
+        return (Long) super.getMethod(this.getExtendedData(), "taken_at");
+    }
+
     public boolean isVideo() throws Exception {
         return (boolean) super.getMethod(this.obj, "methodName");
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -234,8 +234,10 @@ public class Links {
     }
 
     public static String generatePostLink(Object mediaObject, int position) throws Exception {
-        MediaData mediaData = new MediaData(mediaObject);
+        return generatePostLink(new MediaData(mediaObject), position);
+    }
 
+    public static String generatePostLink(MediaData mediaData, int position) throws Exception {
         String postShortCode = mediaData.getShortcode();
         PostType postType = mediaData.getPostType();
 

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/download/DownloadUtils.java
@@ -9,15 +9,12 @@ package app.morphe.extension.instagram.patches.download;
 
 import static app.morphe.extension.instagram.utils.IgStr.str;
 
-import android.os.Build;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
-import android.app.Activity;
 
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Arrays;
 
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.Pref;
@@ -34,6 +31,7 @@ import app.morphe.extension.instagram.settings.ActivityHook;
 import app.morphe.extension.instagram.patches.Links;
 import app.morphe.extension.crimera.ObjectBrowser;
 import app.morphe.extension.crimera.downloader.MediaDownloader;
+import app.morphe.extension.crimera.downloader.DownloadMetadata;
 import app.morphe.extension.crimera.downloader.DownloadRequest;
 import app.morphe.extension.crimera.downloader.MediaType;
 import app.morphe.extension.crimera.PikoUtils;
@@ -47,8 +45,14 @@ public class DownloadUtils {
         return SPLIT_BY_USERNAME ? username : null;
     }
 
-    private static void buildVariantDialogBox(Context context, MediaData currentMediaData, MediaType mediaType) throws Exception {
-        String username = currentMediaData.getUserData().getUsername();
+    private static void buildVariantDialogBox(
+            Context context,
+            MediaData mediaInfo,
+            int position,
+            MediaType mediaType
+    ) throws Exception {
+        MediaData currentMediaData = mediaInfo.getMediaAt(position);
+        String username = mediaInfo.getUserData().getUsername();
         List<MediaInterface> variantList;
         String title = "";
         if(mediaType.equals(MediaType.VIDEO)){
@@ -70,10 +74,18 @@ public class DownloadUtils {
                 MediaInterface data = variantList.get(which);
 
                 try {
-                    String filename = username + "_"+currentMediaData.getVariantFileName(data);
-                    String mediaUrl = data.getUrl();
                     String subFolder = getSubfolderName(username);
-                    downloadMediaUrl(context,mediaUrl,subFolder,filename);
+                    String fileName = username + "_" + currentMediaData.getVariantFileName(data);
+                    DownloadRequest request = buildMediaRequest(
+                            mediaInfo,
+                            currentMediaData,
+                            position,
+                            data.getMediaType(),
+                            data.getUrl(),
+                            subFolder,
+                            fileName
+                    );
+                    enqueueDownload(context, request);
                 } catch (Exception e) {
                     PikoUtils.logger(e);
                     Logger.printException(() -> "Error at buildVariantDialogBox", e);
@@ -145,10 +157,10 @@ public class DownloadUtils {
                         downloadMedia(context, mediaInfo, position, MediaType.AUDIO);
 
                     } else if (selectedOption.equals(str("piko_video_variants"))) {
-                        buildVariantDialogBox(context, currentMediaData, MediaType.VIDEO);
+                        buildVariantDialogBox(context, mediaInfo, position, MediaType.VIDEO);
 
                     } else if (selectedOption.equals(str("piko_image_variants"))) {
-                        buildVariantDialogBox(context, currentMediaData, MediaType.IMAGE);
+                        buildVariantDialogBox(context, mediaInfo, position, MediaType.IMAGE);
 
                     }
                 } catch (Exception e) {
@@ -210,18 +222,34 @@ public class DownloadUtils {
             } else {
                 mediaUrl = mediaData.getMediaLink();
             }
-            String fileName = username+"_"+mediaData.getDownloadFilename(mediaType);
-
-            downloader.enqueue(new DownloadRequest(mediaUrl, subFolder, fileName));
+            String fileName = username + "_" + mediaData.getDownloadFilename(mediaType);
+            downloader.enqueue(buildMediaRequest(
+                    mediaInfo,
+                    mediaData,
+                    position,
+                    mediaType,
+                    mediaUrl,
+                    subFolder,
+                    fileName
+            ));
 
         } else if (position == -1) {
             int carouselSize = mediaInfo.getCarouselSize();
 
             for (int index = 0; index < carouselSize; index++) {
                 MediaData currentMediaData = mediaInfo.getMediaAt(index);
-                String fileName = username+"_"+currentMediaData.getDownloadFilename(MediaType.ANY);
+                String fileName = username + "_"
+                        + currentMediaData.getDownloadFilename(MediaType.ANY);
                 String mediaUrl = currentMediaData.getMediaLink();
-                downloader.enqueue(new DownloadRequest(mediaUrl, subFolder, fileName));
+                downloader.enqueue(buildMediaRequest(
+                        mediaInfo,
+                        currentMediaData,
+                        index,
+                        MediaType.ANY,
+                        mediaUrl,
+                        subFolder,
+                        fileName
+                ));
             }
         } else {
             Utils.showToastShort("There is nothing to download");
@@ -229,14 +257,57 @@ public class DownloadUtils {
 
     }
 
+    private static DownloadRequest buildMediaRequest(
+            MediaData rootMediaData,
+            MediaData childMediaData,
+            int carouselIndex,
+            MediaType mediaType,
+            String mediaUrl,
+            String subFolder,
+            String fileName
+    ) throws Exception {
+        DownloadRequest request = new DownloadRequest(mediaUrl, subFolder, fileName);
+        boolean isVideo = mediaType.equals(MediaType.VIDEO)
+                || (mediaType.equals(MediaType.ANY) && childMediaData.isVideo());
+        if (!isVideo || !Pref.embedDownloadMetadata()) {
+            return request;
+        }
+
+        try {
+            String username = rootMediaData.getUserData().getUsername();
+            Long takenAtSeconds = rootMediaData.getTakenAtSeconds();
+            Long uploadTimestampMillis = takenAtSeconds == null
+                    ? null
+                    : takenAtSeconds * 1000L;
+            DownloadMetadata metadata = new DownloadMetadata(
+                    rootMediaData.getDescriptionText(),
+                    Links.generatePostLink(rootMediaData, carouselIndex),
+                    username,
+                    uploadTimestampMillis
+            );
+            return new DownloadRequest(mediaUrl, subFolder, fileName, metadata);
+        } catch (Exception | LinkageError metadataException) {
+            PikoUtils.logger(metadataException);
+            Logger.printException(
+                    () -> "Could not collect download metadata",
+                    metadataException
+            );
+            return request;
+        }
+    }
+
 
     public static void downloadMediaUrl(Context context, String mediaUrl, String subFolder, String fileName) throws Exception {
+        enqueueDownload(context, new DownloadRequest(mediaUrl, subFolder, fileName));
+    }
+
+    private static void enqueueDownload(Context context, DownloadRequest request) {
         if(!Utils.isNetworkConnected()){
             Utils.showToastShort(str("piko_no_internet"));
             return;
         }
         MediaDownloader downloader = new MediaDownloader(context);
-        downloader.enqueue(new DownloadRequest(mediaUrl, subFolder, fileName));
+        downloader.enqueue(request);
     }
 
     public static void externalDownloader(Object mediaObject, int currentMediaIndex){

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -74,6 +74,7 @@ public class Settings {
     public static final BooleanSetting ENABLE_DOWNLOAD = new BooleanSetting("enable_download", true);
     public static final BooleanSetting ENABLE_DIRECT_DOWNLOAD = new BooleanSetting("enable_direct_download", false);
     public static final BooleanSetting DOWNLOAD_USERNAME_FOLDER = new BooleanSetting("download_username_folder", false);
+    public static final BooleanSetting EMBED_DOWNLOAD_METADATA = new BooleanSetting("embed_download_metadata", false);
     // Should be kept empty by default as its handled in `StorageUtils.java`
     public static final StringSetting CUSTOM_DOWNLOAD_PATH = new StringSetting("custom_download_path", "");
     public static final StringSetting EXTERNAL_DOWNLOADER_PACKAGE_NAME = new StringSetting("external_downloader_package_name", "");

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -687,6 +687,13 @@ public class ScreenBuilder {
         );
 
         addPreference(
+                helper.switchPreference(
+                        str("piko_embed_download_metadata"),
+                        str("piko_embed_download_metadata_desc"),
+                        Settings.EMBED_DOWNLOAD_METADATA
+                )
+        );
+        addPreference(
                 helper.buttonPreference(
                         str("piko_download_set_path"),
                         StorageUtils.getCustomPathForDisplay(),

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -241,6 +241,10 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.DOWNLOAD_USERNAME_FOLDER);
     }
 
+    public static boolean embedDownloadMetadata() {
+        return SharedPref.getBooleanPref(Settings.EMBED_DOWNLOAD_METADATA);
+    }
+
     public static boolean hideNavigationFeed() {
         return SharedPref.getBooleanPref(Settings.HIDE_NAVIGATION_FEED);
     }

--- a/extensions/proguard-rules.pro
+++ b/extensions/proguard-rules.pro
@@ -10,3 +10,10 @@
 -keep class com.google.** {
   *;
 }
+
+# Media3 and Guava retain descriptors for compile-time-only annotations after relocation.
+-dontwarn app.morphe.extension.crimera.internal.google.errorprone.annotations.**
+-dontwarn app.morphe.extension.crimera.internal.google.j2objc.annotations.**
+-dontwarn javax.annotation.**
+-dontwarn kotlin.annotations.jvm.**
+-dontwarn org.checkerframework.**

--- a/extensions/shared/library/build.gradle.kts
+++ b/extensions/shared/library/build.gradle.kts
@@ -20,4 +20,8 @@ dependencies {
     implementation(libs.morphe.extensions.library)
     compileOnly(libs.annotation)
     compileOnly(libs.appcompat)
+    implementation(project(
+        path = ":extensions:shared:media3",
+        configuration = "shadowedMedia3"
+    ))
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/DownloadMetadata.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/DownloadMetadata.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.crimera.downloader;
+
+import androidx.annotation.Nullable;
+
+public final class DownloadMetadata {
+    @Nullable public final String caption;
+    @Nullable public final String postUrl;
+    @Nullable public final String performer;
+    @Nullable public final Long uploadTimestampMillis;
+
+    public DownloadMetadata(
+            @Nullable String caption,
+            @Nullable String postUrl,
+            @Nullable String performer,
+            @Nullable Long uploadTimestampMillis
+    ) {
+        this.caption = caption;
+        this.postUrl = postUrl;
+        this.performer = performer;
+        this.uploadTimestampMillis = uploadTimestampMillis;
+    }
+}

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/DownloadRequest.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/DownloadRequest.java
@@ -11,10 +11,21 @@ public class DownloadRequest {
     public String url;
     public String subFolder; 
     public String fileName;
+    public DownloadMetadata metadata;
 
     public DownloadRequest(String url, String subFolder, String fileName) {
+        this(url, subFolder, fileName, null);
+    }
+
+    public DownloadRequest(
+            String url,
+            String subFolder,
+            String fileName,
+            DownloadMetadata metadata
+    ) {
         this.url = url;
         this.subFolder = subFolder;
         this.fileName = fileName;
+        this.metadata = metadata;
     }
 }

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MediaDownloader.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MediaDownloader.java
@@ -16,9 +16,14 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.ParcelFileDescriptor;
 import android.provider.DocumentsContract;
 
 import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -85,6 +90,7 @@ public class MediaDownloader {
     private void runDownloadTask(DownloadRequest request) {
         int notificationId = (int) System.currentTimeMillis();
         Uri outputDocumentUri = null;
+        File cacheFile = null;
         boolean downloadCompleted = false;
         Notification.Builder builder;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -126,36 +132,27 @@ public class MediaDownloader {
                 conn.connect();
 
                 int length = conn.getContentLength();
-                try (InputStream input = new BufferedInputStream(conn.getInputStream());
-                     OutputStream output = context.getContentResolver().openOutputStream(outputDocumentUri)) {
-                    if (output == null) {
-                        throw new IOException("Could not open download file");
-                    }
-
-                    byte[] buffer = new byte[8192];
-                    long total = 0;
-                    int count;
-                    long lastUpdateTime = 0;
-                    while ((count = input.read(buffer)) != -1) {
-                        total += count;
-                        output.write(buffer, 0, count);
-
-                        if (length > 0) {
-                            int per = (int) (total * 100 / length);
-
-                            // Cap the percentage at 99 inside the loop so it NEVER shows 100% until it actually completes
-                            if (per >= 100) per = 99;
-
-                            // Performance optimization: Only notify the system every 200ms to avoid clogging the OS thread
-                            long currentTime = System.currentTimeMillis();
-                            if (currentTime - lastUpdateTime > 200) {
-                                builder.setProgress(100, per, false);
-                                notificationManager.notify(notificationId, builder.build());
-                                lastUpdateTime = currentTime;
-                            }
+                if (request.metadata == null) {
+                    try (InputStream input = new BufferedInputStream(conn.getInputStream());
+                         OutputStream output = context.getContentResolver().openOutputStream(outputDocumentUri)) {
+                        if (output == null) {
+                            throw new IOException("Could not open download file");
                         }
+                        copyDownload(input, output, length, builder, notificationId);
                     }
-                    output.flush();
+                } else {
+                    cacheFile = File.createTempFile("piko-download-", ".mp4", context.getCacheDir());
+                    try (InputStream input = new BufferedInputStream(conn.getInputStream());
+                         OutputStream output = new BufferedOutputStream(new FileOutputStream(cacheFile))) {
+                        copyDownload(input, output, length, builder, notificationId);
+                    }
+
+                    try {
+                        writeMetadata(cacheFile, outputDocumentUri, request.metadata);
+                    } catch (Exception | LinkageError remuxException) {
+                        PikoUtils.logger(remuxException);
+                        copyRawFile(cacheFile, outputDocumentUri);
+                    }
                 }
             } finally {
                 if (conn != null) {
@@ -191,8 +188,75 @@ public class MediaDownloader {
             notificationManager.cancel(notificationId);
             PikoUtils.logger(e);
         } finally {
+            if (cacheFile != null && cacheFile.exists() && !cacheFile.delete()) {
+                PikoUtils.logger(new IOException("Could not delete download cache file"));
+            }
             isDownloading = false;
             processNext();
+        }
+    }
+
+    private void copyDownload(
+            InputStream input,
+            OutputStream output,
+            int length,
+            Notification.Builder builder,
+            int notificationId
+    ) throws IOException {
+        byte[] buffer = new byte[8192];
+        long total = 0;
+        int count;
+        long lastUpdateTime = 0;
+        while ((count = input.read(buffer)) != -1) {
+            total += count;
+            output.write(buffer, 0, count);
+
+            if (length > 0) {
+                int percent = (int) (total * 100 / length);
+                if (percent >= 100) percent = 99;
+
+                long currentTime = System.currentTimeMillis();
+                if (currentTime - lastUpdateTime > 200) {
+                    builder.setProgress(100, percent, false);
+                    notificationManager.notify(notificationId, builder.build());
+                    lastUpdateTime = currentTime;
+                }
+            }
+        }
+        output.flush();
+    }
+
+    private void writeMetadata(File inputFile, Uri outputUri, DownloadMetadata metadata)
+            throws IOException {
+        ParcelFileDescriptor descriptor = context.getContentResolver()
+                .openFileDescriptor(outputUri, "rwt");
+        if (descriptor == null) {
+            throw new IOException("Could not open download file");
+        }
+        MetadataMuxer.write(
+                inputFile,
+                new ParcelFileDescriptor.AutoCloseOutputStream(descriptor),
+                metadata
+        );
+    }
+
+    private void copyRawFile(File inputFile, Uri outputUri) throws IOException {
+        try (InputStream input = new BufferedInputStream(new FileInputStream(inputFile))) {
+            ParcelFileDescriptor descriptor = context.getContentResolver()
+                    .openFileDescriptor(outputUri, "rwt");
+            if (descriptor == null) {
+                throw new IOException("Could not reopen download file");
+            }
+            try (OutputStream output = new BufferedOutputStream(
+                    new ParcelFileDescriptor.AutoCloseOutputStream(descriptor)
+            )) {
+                byte[] buffer = new byte[8192];
+                int count;
+                while ((count = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, count);
+                }
+                output.flush();
+            }
         }
     }
 

--- a/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MetadataMuxer.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/crimera/downloader/MetadataMuxer.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.crimera.downloader;
+
+import android.media.MediaExtractor;
+import android.media.MediaFormat;
+
+import app.morphe.extension.crimera.internal.media3.common.C;
+import app.morphe.extension.crimera.internal.media3.common.Metadata;
+import app.morphe.extension.crimera.internal.media3.common.util.MediaFormatUtil;
+import app.morphe.extension.crimera.internal.media3.common.util.UnstableApi;
+import app.morphe.extension.crimera.internal.media3.container.MdtaMetadataEntry;
+import app.morphe.extension.crimera.internal.media3.container.Mp4TimestampData;
+import app.morphe.extension.crimera.internal.media3.muxer.BufferInfo;
+import app.morphe.extension.crimera.internal.media3.muxer.FileOutputStreamSeekableMuxerOutput;
+import app.morphe.extension.crimera.internal.media3.muxer.Mp4Muxer;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@UnstableApi
+public final class MetadataMuxer {
+    private static final int INITIAL_BUFFER_SIZE = 1024 * 1024;
+    private static final DateTimeFormatter DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("yyyyMMdd").withZone(ZoneOffset.UTC);
+
+    private MetadataMuxer() {
+    }
+
+    public static void write(File inputFile, FileOutputStream output, DownloadMetadata metadata)
+            throws IOException {
+        MediaExtractor extractor = new MediaExtractor();
+        try (FileOutputStream outputStream = output) {
+            extractor.setDataSource(inputFile.getAbsolutePath());
+            try (Mp4Muxer muxer = new Mp4Muxer.Builder(
+                    new FileOutputStreamSeekableMuxerOutput(outputStream)
+            ).build()) {
+                Map<Integer, Integer> outputTracks = addTracks(extractor, muxer);
+                if (outputTracks.isEmpty()) {
+                    throw new IOException("Input MP4 has no audio or video tracks");
+                }
+
+                for (Metadata.Entry entry : buildMetadataEntries(metadata)) {
+                    muxer.addMetadataEntry(entry);
+                }
+                copySamples(extractor, muxer, outputTracks);
+            }
+        } catch (IOException e) {
+            throw e;
+        } catch (Exception | LinkageError e) {
+            throw new IOException("Could not embed MP4 metadata", e);
+        } finally {
+            extractor.release();
+        }
+    }
+
+    private static List<Metadata.Entry> buildMetadataEntries(DownloadMetadata metadata) {
+        List<Metadata.Entry> entries = new ArrayList<>();
+        addDescription(entries, metadata.caption);
+        addTextPair(entries, "comment", "purl", metadata.postUrl);
+        addTextPair(entries, "artist", "performer", metadata.performer);
+
+        if (metadata.uploadTimestampMillis != null) {
+            Instant uploadTime = Instant.ofEpochMilli(metadata.uploadTimestampMillis);
+            addText(entries, "date", DATE_FORMATTER.format(uploadTime));
+            addText(entries, "creation_time", uploadTime.toString());
+            long mp4Time = Mp4TimestampData.unixTimeToMp4TimeSeconds(metadata.uploadTimestampMillis);
+            entries.add(new Mp4TimestampData(mp4Time, mp4Time));
+        }
+        return entries;
+    }
+
+    private static void addDescription(List<Metadata.Entry> entries, String value) {
+        if (value == null || value.trim().isEmpty()) {
+            return;
+        }
+        addText(entries, "description", value);
+        addText(entries, "longdescription", value);
+        addText(entries, "synopsis", value);
+    }
+
+    private static Map<Integer, Integer> addTracks(MediaExtractor extractor, Mp4Muxer muxer)
+            throws Exception {
+        Map<Integer, Integer> outputTracks = new HashMap<>();
+        for (int trackIndex = 0; trackIndex < extractor.getTrackCount(); trackIndex++) {
+            MediaFormat mediaFormat = extractor.getTrackFormat(trackIndex);
+            String mimeType = mediaFormat.getString(MediaFormat.KEY_MIME);
+            if (mimeType == null || (!mimeType.startsWith("audio/") && !mimeType.startsWith("video/"))) {
+                continue;
+            }
+            extractor.selectTrack(trackIndex);
+            outputTracks.put(trackIndex, muxer.addTrack(
+                    MediaFormatUtil.createFormatFromMediaFormat(mediaFormat)
+            ));
+        }
+        return outputTracks;
+    }
+
+    private static void copySamples(
+            MediaExtractor extractor,
+            Mp4Muxer muxer,
+            Map<Integer, Integer> outputTracks
+    ) throws Exception {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(INITIAL_BUFFER_SIZE);
+        while (true) {
+            int sourceTrack = extractor.getSampleTrackIndex();
+            if (sourceTrack < 0) {
+                return;
+            }
+
+            long sampleSize = extractor.getSampleSize();
+            if (sampleSize > Integer.MAX_VALUE) {
+                throw new IOException("MP4 sample is too large");
+            }
+            if (sampleSize > buffer.capacity()) {
+                int capacity = buffer.capacity();
+                while (capacity < sampleSize && capacity <= Integer.MAX_VALUE / 2) {
+                    capacity *= 2;
+                }
+                if (capacity < sampleSize) {
+                    capacity = (int) sampleSize;
+                }
+                buffer = ByteBuffer.allocateDirect(capacity);
+            }
+
+            buffer.clear();
+            int bytesRead = extractor.readSampleData(buffer, 0);
+            if (bytesRead < 0) {
+                return;
+            }
+            buffer.position(0);
+            buffer.limit(bytesRead);
+            int flags = (extractor.getSampleFlags() & MediaExtractor.SAMPLE_FLAG_SYNC) != 0
+                    ? C.BUFFER_FLAG_KEY_FRAME
+                    : 0;
+            muxer.writeSampleData(
+                    outputTracks.get(sourceTrack),
+                    buffer,
+                    new BufferInfo(extractor.getSampleTime(), bytesRead, flags)
+            );
+            extractor.advance();
+        }
+    }
+
+    private static void addTextPair(
+            List<Metadata.Entry> entries,
+            String firstKey,
+            String secondKey,
+            String value
+    ) {
+        if (value == null || value.trim().isEmpty()) {
+            return;
+        }
+        addText(entries, firstKey, value);
+        addText(entries, secondKey, value);
+    }
+
+    private static void addText(List<Metadata.Entry> entries, String key, String value) {
+        entries.add(new MdtaMetadataEntry(
+                key,
+                value.getBytes(StandardCharsets.UTF_8),
+                MdtaMetadataEntry.TYPE_INDICATOR_STRING
+        ));
+    }
+}

--- a/extensions/shared/media3/build.gradle.kts
+++ b/extensions/shared/media3/build.gradle.kts
@@ -1,0 +1,90 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJvmEnvironment
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.ZipFile
+
+plugins {
+    base
+}
+
+val media3Artifacts = configurations.create("media3Artifacts") {
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes {
+        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.LIBRARY))
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+        attribute(
+            TargetJvmEnvironment.TARGET_JVM_ENVIRONMENT_ATTRIBUTE,
+            objects.named(TargetJvmEnvironment.ANDROID)
+        )
+    }
+}
+
+dependencies {
+    media3Artifacts(libs.media3.muxer) {
+        exclude(group = "androidx.annotation")
+        exclude(group = "org.jetbrains.kotlin")
+    }
+}
+
+val extractedClasses = layout.buildDirectory.dir("media3-classes")
+val extractMedia3Classes = tasks.register("extractMedia3Classes") {
+    inputs.files(media3Artifacts)
+    outputs.dir(extractedClasses)
+
+    doLast {
+        val destination = extractedClasses.get().asFile
+        delete(destination)
+        destination.mkdirs()
+
+        media3Artifacts.files.sortedBy(File::getName).forEach { artifact ->
+            if (artifact.extension == "aar") {
+                ZipFile(artifact).use { archive ->
+                    val classesEntry = archive.getEntry("classes.jar")
+                        ?: error("${artifact.name} does not contain classes.jar")
+                    val classesJar = temporaryDir.resolve("${artifact.nameWithoutExtension}.jar")
+                    archive.getInputStream(classesEntry).use { input ->
+                        Files.copy(
+                            input,
+                            classesJar.toPath(),
+                            StandardCopyOption.REPLACE_EXISTING
+                        )
+                    }
+                    copy {
+                        from(zipTree(classesJar))
+                        into(destination)
+                    }
+                }
+            } else if (artifact.extension == "jar") {
+                copy {
+                    from(zipTree(artifact))
+                    into(destination)
+                }
+            }
+        }
+    }
+}
+
+val shadowMedia3 = tasks.register<ShadowJar>("shadowMedia3") {
+    dependsOn(extractMedia3Classes)
+    from(extractedClasses)
+    archiveBaseName.set("media3-isolated")
+    archiveClassifier.set("")
+    relocate(
+        "androidx.media3",
+        "app.morphe.extension.crimera.internal.media3"
+    )
+    relocate(
+        "com.google",
+        "app.morphe.extension.crimera.internal.google"
+    )
+}
+
+configurations.create("shadowedMedia3") {
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    outgoing.artifact(shadowMedia3)
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ smali = "d92701d947"
 gson = "2.14.0"
 annotation = "1.9.1"
 appcompat = "1.7.1"
+media3 = "1.11.0"
+shadow = "9.5.1"
 
 [libraries]
 morphe-patches-library = { module = "app.morphe:morphe-patches-library", version.ref = "morphe-patches-library" }
@@ -13,6 +15,8 @@ morphe-extensions-library = { module = "app.morphe:morphe-extensions-library", v
 annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+media3-muxer = { module = "androidx.media3:media3-muxer", version.ref = "media3" }
 
 [plugins]
 android-library = { id = "com.android.library" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/Fingerprint.kt
@@ -83,6 +83,11 @@ internal object GetMediaPkIdExtensionFingerprint : Fingerprint(
     name = "getMediaPkId",
 )
 
+internal object GetTakenAtSecondsExtensionFingerprint : Fingerprint(
+    definingClass = EXTENSION_CLASS_DESCRIPTOR,
+    name = "getTakenAtSeconds",
+)
+
 internal object GetDescriptionTextExtensionFingerprint : Fingerprint(
     definingClass = EXTENSION_CLASS_DESCRIPTOR,
     name = "getDescriptionText",

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/entity/mediadata/MediaDataEntity.kt
@@ -124,6 +124,25 @@ val mediaDataEntity =
                 GetMediaPkIdExtensionFingerprint.changeFirstString(mediaPkIdMethodName)
             }
 
+            val takenAtCandidates =
+                mutableClassDefBy { it.type == mediaModelClass }
+                    .methods
+                    .filter { method ->
+                        method.parameters.isEmpty() &&
+                            method.returnType == "Ljava/lang/Long;" &&
+                            method.instructions.any { instruction ->
+                                (instruction.opcode == Opcode.CONST_STRING ||
+                                    instruction.opcode == Opcode.CONST_STRING_JUMBO) &&
+                                    instruction.getReference<StringReference>()?.string == "taken_at"
+                            }
+                    }
+            if (takenAtCandidates.size != 1) {
+                throw PatchException(
+                    "Expected exactly one taken_at getter in $mediaModelClass, found ${takenAtCandidates.size}",
+                )
+            }
+            GetTakenAtSecondsExtensionFingerprint.changeFirstString(takenAtCandidates.single().name)
+
             // Extraction of user data used in extended media class.
             GetUserDataWithoutUserSessionExtensionFingerprint.changeFirstString(LiveTreeMediaDictGetUserFingerprint.method.name)
 

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -138,6 +138,8 @@
     <string name="piko_enable_direct_download_desc">Downloads the current viewing media without asking for options</string>
     <string name="piko_download_username_folder">Split media by username</string>
     <string name="piko_download_username_folder_desc">Creates subfolders based on username</string>
+    <string name="piko_embed_download_metadata">Embed video metadata</string>
+    <string name="piko_embed_download_metadata_desc">Adds the caption, post link, creator, and upload date to downloaded MP4 files</string>
     <string name="piko_download_current_media">Download current media</string>
     <string name="piko_download_as_image">Download as image</string>
     <string name="piko_video_variants">Video variants</string>


### PR DESCRIPTION
Adds a setting to embed metadata in downloaded Instagram videos
- Write the caption to the video description
- Write the post URL, creator and upload date to the corresponding MP4 metadata fields
- Apply metadata only to MP4 video downloads
- Save the original video if metadata embedding fails

Closes #1093