### PR TITLE
feat(Twitter): Add GirthyX into unofficial instances for deeplinks

### DIFF
--- a/patches/src/main/kotlin/app/crimera/patches/twitter/link/customDeeplinks/CustomDeepLinksPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/link/customDeeplinks/CustomDeepLinksPatch.kt
@@ -57,6 +57,7 @@ val customDeepLinksPatch =
                             "yiffx.com",
                             "mpregx.com",
                             "skibidix.com",
+                            "girthyx.com",
                         ),
                     )
             }


### PR DESCRIPTION
[girthyx.com](girthyx.com) leads to [ludojed.itch.io/girthdeluxe](ludojed.itch.io/girthdeluxe), aka le funny game (not an ad)

And it has been working for some time; https://girthyx.com/i/status/2096040046784819439