### PR TITLE
fix(Twitter): Restore timeline position on startup

### DIFF
--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/Pref.java
@@ -69,6 +69,11 @@ public class Pref {
     public static boolean showSourceLabel() {
         return Utils.getBooleanPref(Settings.TIMELINE_SHOW_SOURCE_LABEL);
     }
+
+    public static boolean disableAutoTimelineScroll() {
+        return Utils.getBooleanPref(Settings.TIMELINE_DISABLE_AUTO_SCROLL);
+    }
+
     public static boolean hideCommBadge() {
         return Utils.getBooleanPref(Settings.TIMELINE_HIDE_COMM_BADGE);
     }

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelinePosition.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/TimelinePosition.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.twitter.patches;
+
+import android.view.View;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import app.morphe.extension.twitter.Pref;
+
+/** Preserves the For You reading position across automatic updates and native view recreation. */
+public final class TimelinePosition {
+    public static int initialLoadCount(int configured, int normal, int type, int forYouType) {
+        return type == forYouType && configured > 0 && Pref.disableAutoTimelineScroll()
+                ? Math.max(configured, normal) : configured;
+    }
+
+    public static void preserveCache(List<?> instructions, Class<?> clearCache, int fetchType) {
+        if (fetchType == 4 && Pref.disableAutoTimelineScroll()) instructions.removeIf(clearCache::isInstance);
+    }
+
+    private static final WeakHashMap<Object, State> STATES = new WeakHashMap<>();
+    private static final WeakHashMap<View, WeakReference<Object>> LISTS = new WeakHashMap<>();
+    private static Binding binding;
+
+    private TimelinePosition() {}
+
+    private static final class State {
+        boolean pending;
+        boolean abandoned;
+        List<?> positions;
+    }
+
+    private static Binding binding(Object controller) throws ReflectiveOperationException {
+        if (binding == null) binding = new Binding(controller.getClass().getClassLoader());
+        return binding;
+    }
+
+    public static boolean restore(Object controller, List<?> positions) {
+        try {
+            Binding b = binding(controller);
+            if (!b.enabled(controller)) return false;
+            Object provider = b.provider.get(controller);
+            Object view = b.view.get(controller);
+            View recycler = (View) b.recycler.get(b.list.get(view));
+            LISTS.put(recycler, new WeakReference<>(provider));
+            State state = STATES.computeIfAbsent(provider, key -> new State());
+            if (state.abandoned) return false;
+            state.pending = !positions.isEmpty();
+            state.positions = state.pending ? positions : null;
+
+            // Keep native row-ID priority, including the offsets of secondary visible rows.
+            for (Object position : positions) {
+                long row = b.id.getLong(position);
+                if (row < 0) continue;
+                int index = (Integer) b.lookup.invoke(controller, row);
+                if (index >= 0) {
+                    b.scroll.invoke(view, index, b.offset.getInt(position), false);
+                    state.pending = false;
+                    state.positions = null;
+                    return true;
+                }
+            }
+
+            Object adapter = b.adapter.invoke(view);
+            int count = (Integer) b.count.invoke(adapter);
+            for (Object position : positions) {
+                Object metadata = b.metadata.get(position);
+                if (metadata == null || b.metadataType.getInt(metadata) != b.forYouType) continue;
+                String entry = (String) b.entry.get(metadata);
+                String group = (String) b.group.get(metadata);
+                if (!valid(entry) || !valid(group) || b.metadataRow.getLong(metadata) != b.id.getLong(position)) continue;
+                long match = -1;
+                boolean ambiguous = false;
+                for (int i = 0; i < count; i++) {
+                    Object item = b.item.invoke(adapter, i);
+                    if (item == null || !entry.equals(b.itemEntry.invoke(item)) || !group.equals(b.itemGroup.invoke(item))) continue;
+                    long row = b.itemRow.getLong(item);
+                    if (row <= 0) continue;
+                    if (match != -1) { ambiguous = true; break; }
+                    match = row;
+                }
+                if (ambiguous || match < 0) continue;
+                int index = (Integer) b.lookup.invoke(controller, match);
+                if (index < 0) continue;
+                b.scroll.invoke(view, index, b.offset.getInt(position), false);
+                state.pending = false;
+                state.positions = null;
+                return true;
+            }
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        }
+        return false;
+    }
+
+    public static void afterRender(Object controller) {
+        try {
+            Binding b = binding(controller);
+            if (!b.enabled(controller)) return;
+            State state = STATES.get(b.provider.get(controller));
+            if (state == null || !state.pending || state.abandoned || state.positions == null) return;
+            // Native startup restoration runs before later collections contain the saved row.
+            restore(controller, state.positions);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        }
+    }
+
+    public static boolean keep(Object controller) {
+        try {
+            Binding b = binding(controller);
+            if (!b.enabled(controller)) return false;
+            State state = STATES.get(b.provider.get(controller));
+            return state != null && (state.pending || state.abandoned);
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            return false;
+        }
+    }
+
+    public static boolean canSave(Object controller) {
+        try {
+            Binding b = binding(controller);
+            if (!b.enabled(controller)) return true;
+            State state = STATES.get(b.provider.get(controller));
+            return state == null || !state.pending;
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+            return true;
+        }
+    }
+
+    public static void prepare(Object controller, List<?> positions) {
+        try {
+            Binding b = binding(controller);
+            if (!b.enabled(controller)) return;
+            Object adapter = b.adapter.invoke(b.view.get(controller));
+            int count = (Integer) b.count.invoke(adapter);
+            Map<Long, Object> items = new HashMap<>(positions.size());
+            for (Object position : positions) {
+                // An adapter index may describe new data while the bound view still shows an old row.
+                // Attach identity only after matching the captured row ID in the current data.
+                b.metadata.set(position, null);
+                long row = b.id.getLong(position);
+                if (row > 0) items.put(row, null);
+            }
+            int remaining = items.size();
+            for (int i = 0; i < count && remaining > 0; i++) {
+                Object item = b.item.invoke(adapter, i);
+                if (item == null) continue;
+                long row = b.itemRow.getLong(item);
+                if (items.containsKey(row) && items.get(row) == null) {
+                    items.put(row, item);
+                    remaining--;
+                }
+            }
+            for (Object position : positions) {
+                long row = b.id.getLong(position);
+                Object item = items.get(row);
+                if (item == null) continue;
+                String entry = (String) b.itemEntry.invoke(item);
+                String group = (String) b.itemGroup.invoke(item);
+                if (!valid(entry) || !valid(group)) continue;
+                Object info = b.itemInfo.invoke(item);
+                if (info == null) continue;
+                b.metadata.set(position, b.constructor.newInstance(entry, group, b.sort.getLong(info), row, b.forYouType));
+            }
+            STATES.remove(b.provider.get(controller));
+        } catch (ReflectiveOperationException | RuntimeException ignored) {
+        }
+    }
+
+    public static void onScrollStateChanged(View recycler, int state) {
+        if (state != 1) return; // A user drag supersedes a deferred startup restore.
+        WeakReference<Object> reference = LISTS.get(recycler);
+        Object provider = reference == null ? null : reference.get();
+        State pending = provider == null ? null : STATES.get(provider);
+        if (pending != null && pending.pending) {
+            pending.pending = false;
+            pending.abandoned = true;
+            pending.positions = null;
+        }
+    }
+
+    private static boolean valid(String value) {
+        return value != null && !value.isEmpty() && !"unspecified".equals(value);
+    }
+
+    private static final class Binding {
+        final int forYouType;
+        final Field type, view, list, recycler, provider, id, offset, metadata;
+        final Field entry, group, metadataRow, metadataType, itemRow, sort;
+        final Method adapter, count, item, itemEntry, itemGroup, itemInfo, lookup, scroll;
+        final Constructor<?> constructor;
+
+        Binding(ClassLoader loader) throws ReflectiveOperationException {
+            // Placeholders are replaced with verified native descriptors at patch time.
+            forYouType = Integer.parseInt("piko_timeline_forYouType");
+            type = field(loader, "piko_timeline_type");
+            view = field(loader, "piko_timeline_view");
+            list = field(loader, "piko_timeline_list");
+            recycler = field(loader, "piko_timeline_recycler");
+            provider = field(loader, "piko_timeline_provider");
+            id = field(loader, "piko_timeline_id");
+            offset = field(loader, "piko_timeline_offset");
+            metadata = field(loader, "piko_timeline_metadata");
+            entry = field(loader, "piko_timeline_entry");
+            group = field(loader, "piko_timeline_group");
+            metadataRow = field(loader, "piko_timeline_metadataRow");
+            metadataType = field(loader, "piko_timeline_metadataType");
+            itemRow = field(loader, "piko_timeline_itemRow");
+            sort = field(loader, "piko_timeline_sort");
+            adapter = method(loader, "piko_timeline_adapter");
+            count = method(loader, "piko_timeline_count");
+            item = method(loader, "piko_timeline_item", int.class);
+            itemEntry = method(loader, "piko_timeline_itemEntry");
+            itemGroup = method(loader, "piko_timeline_itemGroup");
+            itemInfo = method(loader, "piko_timeline_itemInfo");
+            lookup = method(loader, "piko_timeline_lookup", long.class);
+            scroll = method(loader, "piko_timeline_scroll", int.class, int.class, boolean.class);
+            constructor = metadata.getType().getConstructor(String.class, String.class, long.class, long.class, int.class);
+        }
+
+        boolean enabled(Object controller) throws IllegalAccessException {
+            return type.getInt(controller) == forYouType && Pref.disableAutoTimelineScroll();
+        }
+
+        private static Class<?> type(ClassLoader loader, String descriptor) throws ClassNotFoundException {
+            return Class.forName(descriptor.substring(1, descriptor.length() - 1).replace('/', '.'), false, loader);
+        }
+
+        private static Field field(ClassLoader loader, String descriptor) throws ReflectiveOperationException {
+            int arrow = descriptor.indexOf("->");
+            return type(loader, descriptor.substring(0, arrow)).getField(descriptor.substring(arrow + 2, descriptor.indexOf(':', arrow)));
+        }
+
+        private static Method method(ClassLoader loader, String descriptor, Class<?>... parameters) throws ReflectiveOperationException {
+            int arrow = descriptor.indexOf("->");
+            return type(loader, descriptor.substring(0, arrow)).getMethod(descriptor.substring(arrow + 2, descriptor.indexOf('(', arrow)), parameters);
+        }
+    }
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/DisableAutoScrollPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/DisableAutoScrollPatch.kt
@@ -8,22 +8,56 @@ package app.crimera.patches.twitter.timeline.disableAutoScroll
 
 import app.crimera.patches.twitter.misc.settings.settingsPatch
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
+import app.crimera.patches.twitter.utils.Constants.PATCHES_DESCRIPTOR
+import app.crimera.patches.twitter.utils.Constants.PREF_DESCRIPTOR
 import app.crimera.patches.twitter.utils.enableSettings
-import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.fieldAccess
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.methodCall
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableField.Companion.toMutable
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.getReference
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.instruction.OffsetInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import com.android.tools.smali.dexlib2.iface.reference.TypeReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableField
+import com.android.tools.smali.dexlib2.Opcode
 
 private object DisableAutoScrollFingerprint : Fingerprint(
     returnType = "V",
-    strings =
-        listOf(
-            "applicationManager",
-            "releaseCompletable",
-            "preferences",
-            "twSystemClock",
-            "launchTracker",
-            "cold_start_launch_time_millis",
-        ),
+    strings = listOf(
+        "applicationManager", "releaseCompletable", "preferences", "twSystemClock",
+        "launchTracker", "cold_start_launch_time_millis",
+    ),
+)
+
+internal object HomeTimelineRestoreFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = emptyList(),
+    strings = listOf("home_timeline_disable_home_scroll_position_restoration_on_cold_launch_enabled"),
+)
+
+private object HomeTimelineRenderFingerprint : Fingerprint(
+    classFingerprint = HomeTimelineRestoreFingerprint,
+    returnType = "V",
+    filters = listOf(
+        fieldAccess(opcode = Opcode.SGET_OBJECT, name = "RENDERING_STARTED"),
+        methodCall(opcode = Opcode.INVOKE_VIRTUAL, parameters = listOf("I", "I", "Z"), returnType = "V"),
+        fieldAccess(opcode = Opcode.SGET_OBJECT, name = "RENDERING_COMPLETED"),
+    ),
 )
 
 // credits to @Ouxyl
@@ -36,15 +70,242 @@ val disableAutoScrollPatch =
         dependsOn(settingsPatch)
 
         execute {
-            val method = DisableAutoScrollFingerprint.classDef.methods.last()
-
-            method.addInstructions(
-                0,
-                """
-                const v0,0x0
+            val coldStart = DisableAutoScrollFingerprint.matchAll(1..1).single().classDef.methods.singleOrNull {
+                it.returnType == "Z" && it.parameterTypes.isEmpty() &&
+                    !AccessFlags.STATIC.isSet(it.accessFlags) && (it.implementation?.registerCount ?: 0) > 1
+            } ?: throw PatchException("Could not uniquely resolve the home cold-start decision")
+            // Preserve the original patch's shared home decision only while the setting is enabled.
+            coldStart.addInstructionsWithLabels(0, """
+                invoke-static {}, $PREF_DESCRIPTOR;->disableAutoTimelineScroll()Z
+                move-result v0
+                if-eqz v0, :native
+                const/4 v0, 0x0
                 return v0
-                """.trimIndent(),
-            )
+            """.trimIndent(), ExternalLabel("native", coldStart.getInstruction(0)))
+
+            val (scope, forYouType) = preserveTimelinePosition()
+            HomeTimelineRenderFingerprint.matchAll(1..1).single().method.apply {
+                val scrollIndex = instructions.withIndex().filter { (_, instruction) ->
+                    instruction.opcode == Opcode.INVOKE_VIRTUAL &&
+                        instruction.getReference<MethodReference>()?.let {
+                            it.parameterTypes == listOf("I", "I", "Z") && it.returnType == "V"
+                        } == true
+                }.singleOrNull()?.index
+                    ?: throw PatchException("Could not uniquely resolve automatic timeline navigation")
+
+                val scrollRegisters = getInstruction(scrollIndex).registersUsed
+                val zeroRegister = scrollRegisters.getOrNull(1)
+                    ?: throw PatchException("Missing automatic timeline scroll arguments")
+                val zero = getInstruction(scrollIndex - 1)
+                val clear = getInstruction(scrollIndex + 1)
+                val store = getInstruction(scrollIndex + 2)
+                if (scrollRegisters.size != 4 || scrollRegisters[0] == zeroRegister ||
+                    scrollRegisters.drop(1).any { it != zeroRegister } ||
+                    zero.opcode != Opcode.CONST_4 || zero.registersUsed.singleOrNull() != zeroRegister ||
+                    (zero as? NarrowLiteralInstruction)?.narrowLiteral != 0 ||
+                    clear.opcode != Opcode.CONST_4 || (clear as? NarrowLiteralInstruction)?.narrowLiteral != 0 ||
+                    store.opcode != Opcode.IPUT_OBJECT || store.registersUsed.size != 2 ||
+                    clear.registersUsed.singleOrNull() != store.registersUsed[0]
+                ) {
+                    throw PatchException("Unexpected automatic timeline navigation or cleanup")
+                }
+
+                // Automatic refresh responses can request a jump independently of the cold-start decision.
+                // A false setting result preserves the shared zero arguments; either path consumes the request.
+                addInstructionsWithLabels(
+                    scrollIndex,
+                    """
+                    invoke-virtual/range {p0 .. p0}, $scope
+                    move-result v$zeroRegister
+                    if-nez v$zeroRegister, :consume_navigation
+                    """.trimIndent(),
+                    ExternalLabel("consume_navigation", clear),
+                )
+                instructions.withIndex().filter { it.value.opcode == Opcode.RETURN_VOID }.map { it.index }
+                    .reversed().forEach {
+                        replaceInstruction(it, "invoke-virtual/range {p0 .. p0}, $definingClass->pikoRetryTimelinePosition()V")
+                        addInstructions(it + 1, "return-void")
+                    }
+            }
+
+            preserveTimelineCache(forYouType)
+            preserveInitialTimelineLoad(forYouType)
+
             enableSettings("disableAutoTimelineScroll")
         }
     }
+
+private object HomeRequestFactoryFingerprint : Fingerprint(
+    strings = listOf("requestConfig", "urtCursorProvider", "home_timeline_send_seen_ids_ignore_network_state"),
+)
+
+private object TimelineResponseFingerprint : Fingerprint(
+    strings = listOf("globalObjects", "responseObjects", "urt_replace_entry"),
+)
+
+private object TimelineInstructionParserFingerprint : Fingerprint(
+    name = "<clinit>",
+    strings = listOf("clearCache", "TimelineClearCache", "addEntries", "TimelineAddEntries"),
+)
+
+context(context: BytecodePatchContext)
+internal fun preserveTimelineCache(forYouType: Int) {
+    val response = TimelineResponseFingerprint.matchAll(1..1).single()
+    val factory = HomeRequestFactoryFingerprint.matchAll(1..1).single().method
+    val parser = TimelineInstructionParserFingerprint.matchAll(1..1).single().method.instructions.toList()
+    val cacheName = parser.indexOfFirst { it.getReference<StringReference>()?.string == "clearCache" }
+    val cacheClass = parser.take(cacheName).lastOrNull { it.opcode == Opcode.CONST_CLASS }
+        ?.getReference<TypeReference>()?.type
+        ?: throw PatchException("Could not resolve the clear-cache instruction type")
+    if (response.method.instructions.count {
+            it.opcode == Opcode.INSTANCE_OF && it.getReference<TypeReference>()?.type == cacheClass
+        } != 1
+    ) throw PatchException("Unexpected clear-cache instruction dispatch")
+
+    val fieldName = "pikoHomeFetchType"
+    val field = "${response.classDef.type}->$fieldName:I"
+    if (response.classDef.fields.any { it.name == fieldName }) {
+        throw PatchException("Home request type field already exists")
+    }
+
+    val factoryCode = factory.instructions.toList()
+    val processorRead = factoryCode.singleOrNull {
+        it.opcode == Opcode.IGET_OBJECT && it.getReference<FieldReference>()?.type == response.classDef.type
+    } ?: throw PatchException("Could not uniquely resolve the home response processor")
+    val requestRegister = processorRead.registersUsed[1]
+    val fetchIndex = factoryCode.withIndex().filter { (index, instruction) ->
+        instruction.opcode == Opcode.IGET &&
+            instruction.getReference<FieldReference>()?.definingClass == factory.parameterTypes.getOrNull(1) &&
+            factoryCode.getOrNull(index + 1)?.let {
+                it.opcode == Opcode.CONST_4 && (it as? NarrowLiteralInstruction)?.narrowLiteral == 2
+            } == true && factoryCode.getOrNull(index + 2)?.opcode == Opcode.IF_NE
+    }.singleOrNull()?.index ?: throw PatchException("Could not uniquely resolve the home fetch type")
+    val fetchRegister = factoryCode[fetchIndex].registersUsed[0]
+    val temporary = factoryCode[fetchIndex + 1].registersUsed.single()
+    val processorRegister = processorRead.registersUsed[0]
+    val configRegister = factoryCode[fetchIndex].registersUsed[1]
+    val identifierIndex = factoryCode.indexOfFirst { it.getReference<StringReference>()?.string == "timelineIdentifier" }
+    val identifierRead = factoryCode.getOrNull(identifierIndex - 1)
+    val identifier = identifierRead?.getReference<FieldReference>()
+    if (identifierRead?.opcode != Opcode.IGET_OBJECT || identifier == null || identifier.definingClass != factory.parameterTypes.getOrNull(1) ||
+        identifierRead.registersUsed.getOrNull(1) != configRegister
+    ) throw PatchException("Could not resolve the home timeline identifier")
+    val requestScope = factoryCode.filter { it.opcode == Opcode.IGET_OBJECT }
+        .mapNotNull { it.getReference<FieldReference>() }.singleOrNull { it.definingClass == identifier.type }
+        ?: throw PatchException("Could not uniquely resolve the request timeline scope")
+    val requestType = factoryCode.filter { it.opcode == Opcode.IGET }
+        .mapNotNull { it.getReference<FieldReference>() }.singleOrNull { it.definingClass == requestScope.type }
+        ?: throw PatchException("Could not uniquely resolve the request timeline type")
+    if (setOf(requestRegister, fetchRegister, temporary).size != 3 ||
+        listOf(requestRegister, fetchRegister, temporary).any { it !in 0..15 } ||
+        processorRegister !in 0..15 || processorRegister in listOf(fetchRegister, temporary) ||
+        configRegister !in 0..15 || configRegister == temporary ||
+        factoryCode.last().opcode != Opcode.RETURN_OBJECT ||
+        factoryCode.last().registersUsed.singleOrNull() != requestRegister ||
+        factoryCode.subList(factoryCode.indexOf(processorRead) + 1, fetchIndex + 1).any {
+            it.opcode.setsRegister() && it.registersUsed.firstOrNull() in listOf(requestRegister, processorRegister)
+        }
+    ) throw PatchException("Unexpected home request registers")
+
+    val method = response.method
+    val code = method.instructions.toList()
+    val copyIndex = code.withIndex().filter { (_, instruction) ->
+        instruction.getReference<MethodReference>()?.toString() ==
+            "Ljava/util/ArrayList;->addAll(Ljava/util/Collection;)Z"
+    }.singleOrNull()?.index ?: throw PatchException("Could not uniquely resolve the mutable instruction list")
+    val copyRegisters = code[copyIndex].registersUsed
+    if (copyRegisters.size != 2 || code.getOrNull(copyIndex + 1)?.opcode == Opcode.MOVE_RESULT) {
+        throw PatchException("Unexpected instruction-list copy")
+    }
+    val listRegister = copyRegisters[0]
+    // Use only registers overwritten before their first read, on the straight-line
+    // path after the copy. Existing loop targets retain their original instructions.
+    val straightLine = code.drop(copyIndex + 1).takeWhile {
+        it !is OffsetInstruction && it.opcode.canContinue()
+    }
+    val scratch = (0..15).filter { register ->
+        register != listRegister && straightLine.firstOrNull { register in it.registersUsed }?.let {
+            it.opcode.setsRegister() && it.opcode != Opcode.CHECK_CAST &&
+                it.registersUsed.first() == register && register !in it.registersUsed.drop(1)
+        } == true
+    }.take(2)
+    if (scratch.size != 2 || listRegister !in 0..15) {
+        throw PatchException("No safe registers for preserving the timeline cache")
+    }
+
+    response.classDef.fields.add(
+        ImmutableField(response.classDef.type, fieldName, "I", AccessFlags.PUBLIC.value, null, emptySet(), emptySet()).toMutable(),
+    )
+    factory.addInstructionsWithLabels(
+        fetchIndex + 1,
+        """
+        iget-object v$temporary, v$configRegister, $identifier
+        iget-object v$temporary, v$temporary, $requestScope
+        iget v$temporary, v$temporary, $requestType
+        add-int/lit8 v$temporary, v$temporary, -$forYouType
+        if-nez v$temporary, :native
+        iput v$fetchRegister, v$processorRegister, $field
+        """.trimIndent(),
+        ExternalLabel("native", factoryCode[fetchIndex + 1]),
+    )
+    method.addInstructions(
+        copyIndex + 1,
+        """
+        move-object/from16 v${scratch[0]}, p0
+        iget v${scratch[0]}, v${scratch[0]}, $field
+        const-class v${scratch[1]}, $cacheClass
+        invoke-static {v$listRegister, v${scratch[1]}, v${scratch[0]}}, $PATCHES_DESCRIPTOR/TimelinePosition;->preserveCache(Ljava/util/List;Ljava/lang/Class;I)V
+        """.trimIndent(),
+    )
+}
+
+private object InitialTimelineLoadFingerprint : Fingerprint(
+    returnType = "I",
+    parameters = emptyList(),
+    strings = listOf("android_initial_timeline_load_count", "android_home_timeline_mark_as_unlimited_timeline"),
+)
+
+context(context: BytecodePatchContext)
+internal fun preserveInitialTimelineLoad(forYouType: Int) {
+    val method = InitialTimelineLoadFingerprint.matchAll(1..1).single().method
+    val code = method.instructions.toList()
+    val type = code.filter { it.opcode == Opcode.IGET }.mapNotNull { it.getReference<FieldReference>() }
+        .singleOrNull { it.definingClass == method.definingClass && it.type == "I" }
+        ?: throw PatchException("Could not resolve initial-load timeline type")
+    val keyIndex = code.indexOfFirst {
+        it.getReference<StringReference>()?.string == "android_initial_timeline_load_count"
+    }
+    val call = code.getOrNull(keyIndex + 2)
+    val reference = call?.getReference<MethodReference>()
+    val registers = call?.registersUsed.orEmpty()
+    val fallback = code.getOrNull(keyIndex + 1)
+    val result = code.getOrNull(keyIndex + 3)
+    val exit = code.getOrNull(keyIndex + 4)
+    val receiver = method.implementation!!.registerCount - 1
+    if (call?.opcode != Opcode.INVOKE_VIRTUAL || reference?.parameterTypes != listOf("Ljava/lang/String;", "I") ||
+        reference.returnType != "I" || registers.size != 3 || registers.distinct().size != 3 ||
+        code[keyIndex].registersUsed.singleOrNull() != registers[1] ||
+        fallback?.opcode !in listOf(Opcode.CONST_16, Opcode.CONST) ||
+        fallback?.registersUsed?.singleOrNull() != registers[2] ||
+        (fallback as? NarrowLiteralInstruction)?.narrowLiteral?.let { it > 0 } != true ||
+        result?.opcode != Opcode.MOVE_RESULT || exit?.opcode != Opcode.RETURN ||
+        result.registersUsed != exit.registersUsed
+    ) throw PatchException("Unexpected initial-load configuration read")
+    val resultRegister = result.registersUsed.single()
+    val typeRegister = registers[1]
+    val defaultRegister = registers[2]
+    val forYouRegister = (0 until receiver).firstOrNull { it !in listOf(resultRegister, typeRegister, defaultRegister) }
+        ?: throw PatchException("No initial-load scope register available")
+    if (listOf(resultRegister, typeRegister, defaultRegister).distinct().size != 3 ||
+        listOf(resultRegister, typeRegister, defaultRegister, forYouRegister, receiver).any { it !in 0..15 } ||
+        receiver in listOf(resultRegister, typeRegister, defaultRegister)
+    ) throw PatchException("Unexpected initial-load registers")
+
+    // Only the first-load return is changed; later loads retain Twitter's existing limits.
+    method.addInstructions(keyIndex + 4, """
+        iget v$typeRegister, p0, $type
+        const/16 v$forYouRegister, $forYouType
+        invoke-static {v$resultRegister, v$defaultRegister, v$typeRegister, v$forYouRegister}, $PATCHES_DESCRIPTOR/TimelinePosition;->initialLoadCount(IIII)I
+        move-result v$resultRegister
+    """.trimIndent())
+}

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/RestoreTimelinePosition.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/timeline/disableAutoScroll/RestoreTimelinePosition.kt
@@ -1,0 +1,410 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.crimera.patches.twitter.timeline.disableAutoScroll
+
+import app.crimera.patches.twitter.utils.Constants.PATCHES_DESCRIPTOR
+import app.crimera.patches.twitter.utils.Constants.PREF_DESCRIPTOR
+import app.crimera.utils.changeString
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
+import app.morphe.patcher.extensions.InstructionExtensions.getInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.instructions
+import app.morphe.patcher.extensions.InstructionExtensions.replaceInstruction
+import app.morphe.patcher.Fingerprint
+import app.morphe.patcher.patch.BytecodePatchContext
+import app.morphe.patcher.patch.PatchException
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.getReference
+import app.morphe.util.registersUsed
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.iface.instruction.NarrowLiteralInstruction
+import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
+import com.android.tools.smali.dexlib2.Opcode
+
+private object HomeTimelineSaveFingerprint : Fingerprint(
+    classFingerprint = HomeTimelineRestoreFingerprint,
+    returnType = "V",
+    parameters = emptyList(),
+    strings = listOf("android_htl_position_metadata_capture_enabled"),
+)
+
+private data class TimelineFields(
+    val type: FieldReference,
+    val view: FieldReference,
+    val list: FieldReference,
+    val recycler: FieldReference,
+    val provider: FieldReference,
+    val rowId: FieldReference,
+    val offset: FieldReference,
+)
+
+context(context: BytecodePatchContext)
+internal fun preserveTimelinePosition(): Pair<String, Int> {
+    val restore = HomeTimelineRestoreFingerprint.matchAll(1..1).single()
+    val home = restore.classDef
+    val restoreCode = restore.method.instructions.toList()
+    val timelineType = restoreCode[0].getReference<FieldReference>()
+    val forYouType = (restoreCode.getOrNull(1) as? NarrowLiteralInstruction)?.narrowLiteral
+    if (restoreCode[0].opcode != Opcode.IGET || timelineType?.type != "I" ||
+        forYouType == null || forYouType !in 1..127 || restoreCode.getOrNull(2)?.opcode != Opcode.IF_NE ||
+        restoreCode[2].registersUsed != listOf(restoreCode[0].registersUsed[0], restoreCode[1].registersUsed.single())
+    ) throw PatchException("Unexpected For You restoration scope")
+
+    val scopeName = "pikoDisableAutoTimelineScroll"
+    val scope = "${home.type}->$scopeName()Z"
+    val captureName = "pikoCaptureVisibleTimeline"
+    if (home.methods.any { it.name == scopeName || it.name == captureName }) {
+        throw PatchException("Timeline position helpers already exist")
+    }
+
+    val save = HomeTimelineSaveFingerprint.matchAll(1..1).single().method
+    val captureReference = save.instructions.mapNotNull { it.getReference<MethodReference>() }
+        .singleOrNull { it.parameterTypes.isEmpty() && it.returnType == "Ljava/util/List;" }
+        ?: throw PatchException("Could not uniquely resolve native position capture")
+    val capture = context.mutableClassDefBy(captureReference.definingClass).methods.single {
+        it.toString() == captureReference.toString()
+    }
+    val captureCode = capture.instructions.toList()
+    val viewFields = captureCode.filter { it.opcode == Opcode.IGET_OBJECT }
+        .map { it.getReference<FieldReference>()!! }
+    if (viewFields.size != 3 || viewFields[1].definingClass != viewFields[0].type ||
+        viewFields[2].definingClass != viewFields[1].type || (capture.implementation?.registerCount ?: 0) < 2
+    ) throw PatchException("Unexpected timeline view chain")
+    val (view, list, recycler) = viewFields
+    val firstPosition = captureCode.firstOrNull { it.opcode == Opcode.INVOKE_VIRTUAL }
+        ?.getReference<MethodReference>() ?: throw PatchException("Missing native position model")
+    val positionConstructor = context.classDefBy(firstPosition.returnType).methods.singleOrNull {
+        it.name == "<init>" && it.parameterTypes == listOf("I", "I", "J") && AccessFlags.PUBLIC.isSet(it.accessFlags)
+    } ?: throw PatchException("Unexpected native position constructor")
+    val currentPosition = captureCode.mapNotNull { it.getReference<MethodReference>() }
+        .singleOrNull { it.definingClass == list.type && it.parameterTypes.isEmpty() }
+        ?: throw PatchException("Could not resolve pending timeline position")
+    val positionReader = context.classDefBy(list.type).methods.single { it.toString() == currentPosition.toString() }
+    val pending = positionReader.getInstruction(0).getReference<FieldReference>()
+    if (positionReader.getInstruction(0).opcode != Opcode.IGET_OBJECT || pending?.type != currentPosition.returnType) {
+        throw PatchException("Unexpected pending timeline position")
+    }
+
+    val recyclerClass = context.classDefBy(recycler.type)
+    val holderReader = recyclerClass.methods.singleOrNull {
+        AccessFlags.STATIC.isSet(it.accessFlags) && AccessFlags.PUBLIC.isSet(it.accessFlags) &&
+            it.parameterTypes == listOf("Landroid/view/View;") && it.returnType.startsWith(recycler.type.dropLast(1) + "$")
+    } ?: throw PatchException("Could not uniquely resolve the visible ViewHolder")
+    val holderClass = context.classDefBy(holderReader.returnType)
+    val itemId = holderClass.methods.singleOrNull {
+        it.name == "getItemId" && it.parameterTypes.isEmpty() && it.returnType == "J" && AccessFlags.PUBLIC.isSet(it.accessFlags)
+    } ?: throw PatchException("Missing visible item ID accessor")
+    val adapterPosition = holderClass.methods.singleOrNull {
+        it.name == "getAbsoluteAdapterPosition" && it.parameterTypes.isEmpty() && it.returnType == "I" &&
+            AccessFlags.PUBLIC.isSet(it.accessFlags)
+    } ?: throw PatchException("Missing visible adapter position accessor")
+    val bounds = recyclerClass.methods.singleOrNull {
+        AccessFlags.STATIC.isSet(it.accessFlags) && AccessFlags.PUBLIC.isSet(it.accessFlags) &&
+            it.parameterTypes == listOf("Landroid/graphics/Rect;", "Landroid/view/View;") && it.returnType == "V"
+    } ?: throw PatchException("Could not uniquely resolve decorated item bounds")
+
+    home.methods.add(
+        ImmutableMethod(home.type, scopeName, emptyList(), "Z", AccessFlags.PUBLIC.value or AccessFlags.FINAL.value,
+            null, null, MutableMethodImplementation(3)).toMutable().apply {
+            addInstructions("""
+                iget v0, p0, $timelineType
+                const/16 v1, $forYouType
+                if-ne v0, v1, :disabled
+                invoke-static {}, $PREF_DESCRIPTOR;->disableAutoTimelineScroll()Z
+                move-result v0
+                return v0
+                :disabled
+                const/4 v0, 0x0
+                return v0
+            """.trimIndent())
+        },
+    )
+
+    val snapshot = "${home.type}->$captureName(${capture.definingClass})Ljava/util/List;"
+    home.methods.add(
+        ImmutableMethod(home.type, captureName, listOf(ImmutableMethodParameter(capture.definingClass, null, null)),
+            "Ljava/util/List;", AccessFlags.PUBLIC.value or AccessFlags.STATIC.value,
+            null, null, MutableMethodImplementation(13)).toMutable().apply {
+            // Adapter positions can be NO_POSITION while an update awaits layout. The
+            // native capture adds child indices to that value and saves unrelated rows.
+            // Bound IDs and decorated offsets describe the items actually on screen.
+            addInstructions("""
+                instance-of v0, p0, ${home.type}
+                if-eqz v0, :native
+                check-cast p0, ${home.type}
+                invoke-virtual {p0}, $scope
+                move-result v0
+                if-eqz v0, :native
+                iget-object v0, p0, $view
+                iget-object v0, v0, $list
+                iget-object v1, v0, $pending
+                if-nez v1, :native
+                iget-object v0, v0, $recycler
+                new-instance v1, Ljava/util/ArrayList;
+                invoke-direct {v1}, Ljava/util/ArrayList;-><init>()V
+                new-instance v2, Landroid/graphics/Rect;
+                invoke-direct {v2}, Landroid/graphics/Rect;-><init>()V
+                const/4 v3, 0x0
+                :next_child
+                invoke-virtual {v0}, Landroid/view/ViewGroup;->getChildCount()I
+                move-result v4
+                if-ge v3, v4, :done
+                invoke-virtual {v0, v3}, Landroid/view/ViewGroup;->getChildAt(I)Landroid/view/View;
+                move-result-object v4
+                invoke-static {v4}, $holderReader
+                move-result-object v5
+                if-eqz v5, :next
+                invoke-virtual {v5}, $itemId
+                move-result-wide v6
+                const-wide/16 v8, 0x0
+                cmp-long v10, v6, v8
+                if-lez v10, :next
+                invoke-virtual {v5}, $adapterPosition
+                move-result v5
+                invoke-static {v2, v4}, $bounds
+                iget v8, v2, Landroid/graphics/Rect;->top:I
+                new-instance v4, ${firstPosition.returnType}
+                invoke-direct {v4, v8, v5, v6, v7}, $positionConstructor
+                invoke-virtual {v1, v4}, Ljava/util/ArrayList;->add(Ljava/lang/Object;)Z
+                :next
+                add-int/lit8 v3, v3, 0x1
+                goto :next_child
+                :done
+                invoke-virtual {v1}, Ljava/util/ArrayList;->isEmpty()Z
+                move-result v3
+                if-nez v3, :native
+                return-object v1
+                :native
+                const/4 v0, 0x0
+                return-object v0
+            """.trimIndent())
+        },
+    )
+    capture.addInstructionsWithLabels(0, """
+        invoke-static/range {p0 .. p0}, $snapshot
+        move-result-object v0
+        if-eqz v0, :native
+        return-object v0
+    """.trimIndent(), ExternalLabel("native", capture.getInstruction(0)))
+
+    val savedPositions = restoreCode.mapNotNull { it.getReference<FieldReference>() }
+        .singleOrNull { it.type == "Ljava/util/List;" } ?: throw PatchException("Missing saved position list")
+    val restoreStart = restoreCode.singleOrNull {
+        it.opcode == Opcode.IGET_OBJECT && it.getReference<FieldReference>()?.let { field ->
+            field.definingClass == home.type && field.type == savedPositions.definingClass
+        } == true
+    } ?: throw PatchException("Could not uniquely resolve saved position restoration")
+    val constructorCode = positionConstructor.implementation!!.instructions.toList()
+    val constructorReceiver = positionConstructor.implementation!!.registerCount - 5
+    fun positionField(parameter: Int, opcode: Opcode) = constructorCode.singleOrNull {
+        it.opcode == opcode && it.registersUsed == listOf(constructorReceiver + parameter, constructorReceiver)
+    }?.getReference<FieldReference>() ?: throw PatchException("Could not resolve saved position field")
+    preserveTimelineIdentity(home.type, forYouType, scope, save, restore.method,
+        TimelineFields(
+            type = timelineType,
+            view = view,
+            list = list,
+            recycler = recycler,
+            provider = restoreStart.getReference<FieldReference>()!!,
+            rowId = positionField(3, Opcode.IPUT_WIDE),
+            offset = positionField(1, Opcode.IPUT),
+        ))
+    return scope to forYouType
+}
+
+context(context: BytecodePatchContext)
+private fun preserveTimelineIdentity(
+    homeType: String, forYouType: Int, scope: String, save: MutableMethod, restore: MutableMethod,
+    fields: TimelineFields,
+) {
+    val code = save.instructions.toList()
+    val references = code.mapNotNull { it.getReference<MethodReference>() }
+    val constructor = references.singleOrNull {
+        it.name == "<init>" && it.parameterTypes == listOf("Ljava/lang/String;", "Ljava/lang/String;", "J", "J", "I")
+    } ?: throw PatchException("Could not resolve native timeline metadata")
+    val constructorMethod = context.classDefBy(constructor.definingClass).methods.single { it.toString() == constructor.toString() }
+    val receiver = constructorMethod.implementation!!.registerCount - 8
+    fun metadataField(parameter: Int, opcode: Opcode): FieldReference = constructorMethod.instructions.singleOrNull {
+        it.opcode == opcode && it.registersUsed == listOf(receiver + parameter, receiver)
+    }?.getReference<FieldReference>() ?: throw PatchException("Unexpected timeline metadata constructor")
+    val metadata = code.filter { it.opcode == Opcode.IPUT_OBJECT }.mapNotNull { it.getReference<FieldReference>() }
+        .singleOrNull { it.type == constructor.definingClass }
+        ?: throw PatchException("Could not resolve serialized timeline metadata field")
+    val modelMethods = references.filter { it.parameterTypes.isEmpty() && it.returnType == "Ljava/lang/String;" }
+        .filter { it.definingClass != homeType && it.definingClass != fields.type.definingClass }
+    if (modelMethods.size != 2 || modelMethods[0].definingClass != modelMethods[1].definingClass) {
+        throw PatchException("Could not resolve entry and group identity accessors")
+    }
+    val itemType = modelMethods.first().definingClass
+    val itemRow = code.filter { it.opcode == Opcode.IGET_WIDE }.mapNotNull { it.getReference<FieldReference>() }
+        .singleOrNull { it.definingClass == itemType } ?: throw PatchException("Could not resolve timeline item row ID")
+    val itemInfo = references.singleOrNull {
+        it.definingClass == itemType && it.parameterTypes.isEmpty() && it.returnType != "Ljava/lang/String;"
+    } ?: throw PatchException("Could not resolve timeline item metadata accessor")
+    val sort = code.filter { it.opcode == Opcode.IGET_WIDE }.mapNotNull { it.getReference<FieldReference>() }
+        .singleOrNull { it.definingClass == itemInfo.returnType } ?: throw PatchException("Could not resolve timeline sort metadata")
+    val adapter = references.singleOrNull { it.definingClass == fields.view.type && it.parameterTypes.isEmpty() }
+        ?: throw PatchException("Could not resolve timeline adapter accessor")
+    val count = references.filter { it.parameterTypes.isEmpty() && it.returnType == "I" }.distinctBy { it.toString() }.singleOrNull()
+        ?: throw PatchException("Could not resolve timeline item count")
+    val item = references.singleOrNull { it.parameterTypes == listOf("I") && it.returnType == "Ljava/lang/Object;" }
+        ?: throw PatchException("Could not resolve timeline item accessor")
+    val restoreCallIndex = restore.instructions.withIndex().singleOrNull { (_, instruction) ->
+        instruction.opcode == Opcode.INVOKE_VIRTUAL && instruction.getReference<MethodReference>()?.let {
+            it.parameterTypes == listOf("Ljava/util/List;") && it.returnType == "Z"
+        } == true
+    }?.index ?: throw PatchException("Could not uniquely resolve native position restoration")
+    val nativeRestore = restore.instructions[restoreCallIndex].getReference<MethodReference>()!!
+    val nativeCode = context.classDefBy(nativeRestore.definingClass).methods.single { it.toString() == nativeRestore.toString() }.instructions
+    val nativeMethods = nativeCode.mapNotNull { it.getReference<MethodReference>() }
+    val lookup = nativeMethods.singleOrNull { it.parameterTypes == listOf("J") && it.returnType == "I" }
+        ?: throw PatchException("Could not resolve row position lookup")
+    val scroll = nativeMethods.singleOrNull { it.parameterTypes == listOf("I", "I", "Z") && it.returnType == "V" }
+        ?: throw PatchException("Could not resolve native position application")
+    val bindingFields = mapOf(
+        "type" to fields.type,
+        "view" to fields.view,
+        "list" to fields.list,
+        "recycler" to fields.recycler,
+        "provider" to fields.provider,
+        "id" to fields.rowId,
+        "offset" to fields.offset,
+        "metadata" to metadata,
+        "entry" to metadataField(1, Opcode.IPUT_OBJECT),
+        "group" to metadataField(2, Opcode.IPUT_OBJECT),
+        "metadataRow" to metadataField(5, Opcode.IPUT_WIDE),
+        "metadataType" to metadataField(7, Opcode.IPUT),
+        "itemRow" to itemRow,
+        "sort" to sort,
+    )
+    val bindingMethods = mapOf(
+        "adapter" to adapter, "count" to count, "item" to item,
+        "itemEntry" to modelMethods[0], "itemGroup" to modelMethods[1], "itemInfo" to itemInfo,
+        "lookup" to lookup, "scroll" to scroll,
+    )
+    bindingFields.values.forEach { ref ->
+        val definition = context.classDefBy(ref.definingClass).fields.single { it.toString() == ref.toString() }
+        if (!AccessFlags.PUBLIC.isSet(definition.accessFlags)) throw PatchException("Timeline identity field is not public: $ref")
+    }
+    bindingMethods.values.forEach { ref ->
+        val definition = context.classDefBy(ref.definingClass).methods.single { it.toString() == ref.toString() }
+        if (!AccessFlags.PUBLIC.isSet(definition.accessFlags)) throw PatchException("Timeline identity method is not public: $ref")
+    }
+    val bindings = mapOf("forYouType" to forYouType.toString()) +
+        bindingFields.mapValues { it.value.toString() } + bindingMethods.mapValues { it.value.toString() }
+    bindTimelineAccess(bindings)
+    val extension = "$PATCHES_DESCRIPTOR/TimelinePosition;"
+    val home = context.mutableClassDefBy(homeType)
+    fun helper(name: String, parameters: List<String>, result: String, registers: Int, body: String) {
+        if (home.methods.any { it.name == name }) throw PatchException("Timeline identity helper already exists")
+        home.methods.add(ImmutableMethod(homeType, name, parameters.map { ImmutableMethodParameter(it, null, null) }, result,
+            AccessFlags.PUBLIC.value or AccessFlags.FINAL.value, null, null, MutableMethodImplementation(registers)).toMutable().apply {
+            addInstructions(0, body.trimIndent())
+        })
+    }
+    helper("pikoRestorePositions", listOf("Ljava/util/List;"), "Z", 4, """
+        invoke-virtual {p0}, $scope
+        move-result v0
+        if-eqz v0, :native
+        invoke-static {p0, p1}, $extension->restore(Ljava/lang/Object;Ljava/util/List;)Z
+        move-result v0
+        return v0
+        :native
+        invoke-virtual {p0, p1}, $nativeRestore
+        move-result v0
+        return v0
+    """)
+    val restoreRegisters = restore.instructions[restoreCallIndex].registersUsed
+    if (restoreRegisters.size != 2 || restoreRegisters.any { it !in 0..15 }) throw PatchException("Unexpected restore registers")
+    restore.replaceInstruction(restoreCallIndex, "invoke-virtual {v${restoreRegisters[0]}, v${restoreRegisters[1]}}, $homeType->pikoRestorePositions(Ljava/util/List;)Z")
+    for ((name, extensionMethod) in listOf("pikoKeepPosition" to "keep", "pikoCanSavePosition" to "canSave")) {
+        helper(name, emptyList(), "Z", 2, """
+            invoke-static {p0}, $extension->$extensionMethod(Ljava/lang/Object;)Z
+            move-result v0
+            return v0
+        """)
+    }
+    helper("pikoPreparePositions", listOf("Ljava/util/List;"), "V", 3, """
+        invoke-static {p0, p1}, $extension->prepare(Ljava/lang/Object;Ljava/util/List;)V
+        return-void
+    """)
+    helper("pikoRetryTimelinePosition", emptyList(), "V", 2, """
+        invoke-static {p0}, $extension->afterRender(Ljava/lang/Object;)V
+        return-void
+    """)
+    val resetIndex = restore.instructions.indexOfFirst {
+        it.getReference<MethodReference>()?.let { ref -> ref.definingClass == fields.provider.type && ref.name == "reset" && ref.parameterTypes.isEmpty() } == true
+    }
+    if (resetIndex < 0) throw PatchException("Could not resolve saved position reset")
+    val resetResultRegister = restore.instructions.take(resetIndex).lastOrNull { it.opcode == Opcode.MOVE_RESULT }
+        ?.registersUsed?.singleOrNull() ?: throw PatchException("Could not resolve reset guard register")
+    val resetReceiver = restore.instructions[resetIndex].registersUsed.singleOrNull()
+    if (resetResultRegister !in 0..255 || resetResultRegister == resetReceiver ||
+        resetResultRegister >= restore.implementation!!.registerCount - 1
+    ) throw PatchException("Unexpected reset guard register")
+    val afterReset = restore.instructions[resetIndex + 1]
+    restore.addInstructionsWithLabels(resetIndex, """
+        invoke-virtual/range {p0 .. p0}, $homeType->pikoKeepPosition()Z
+        move-result v$resetResultRegister
+        if-nez v$resetResultRegister, :keep
+    """.trimIndent(), ExternalLabel("keep", afterReset))
+    val saveIndex = save.instructions.indexOfFirst {
+        it.getReference<MethodReference>()?.let { ref -> ref.definingClass == fields.provider.type && ref.parameterTypes == listOf("Ljava/util/List;") } == true
+    }
+    if (saveIndex < 0) throw PatchException("Could not resolve native position persistence")
+    val positionRegister = save.instructions[saveIndex].registersUsed.last()
+    val saveReceiver = save.implementation!!.registerCount - 1
+    if (positionRegister !in 0..15 || saveReceiver !in 0..15) throw PatchException("Unexpected position persistence registers")
+    save.addInstructions(saveIndex, "invoke-virtual {v$saveReceiver, v$positionRegister}, $homeType->pikoPreparePositions(Ljava/util/List;)V")
+    save.addInstructionsWithLabels(0, """
+        invoke-virtual/range {p0 .. p0}, $homeType->pikoCanSavePosition()Z
+        move-result v0
+        if-nez v0, :save
+        return-void
+    """.trimIndent(), ExternalLabel("save", save.instructions.first()))
+
+    val scrollListener = context.classDefBy(fields.list.type).fields.mapNotNull {
+        if (!it.type.startsWith(fields.list.type.dropLast(1) + "$")) null else context.classDefBy(it.type)
+    }.flatMap { it.methods }.singleOrNull {
+        it.name == "onScrollStateChanged" && it.parameterTypes == listOf(fields.recycler.type, "I") && it.returnType == "V"
+    } ?: throw PatchException("Could not resolve the timeline scroll-state listener")
+    context.mutableClassDefBy(scrollListener.definingClass).methods.single { it.toString() == scrollListener.toString() }
+        .addInstructions(0, "invoke-static/range {p1 .. p2}, $extension->onScrollStateChanged(Landroid/view/View;I)V")
+}
+
+context(context: BytecodePatchContext)
+private fun bindTimelineAccess(bindings: Map<String, String>) {
+    val bindingClass = "$PATCHES_DESCRIPTOR/TimelinePosition\$Binding;"
+    val prefix = "piko_timeline_"
+    val constructor = context.mutableClassDefBy(bindingClass).methods.singleOrNull { it.name == "<init>" }
+        ?: throw PatchException("Could not uniquely resolve timeline access initialization")
+    val placeholders = constructor.instructions.mapNotNull { it.getReference<StringReference>()?.string }
+        .filter { it.startsWith(prefix) }
+    if (placeholders.size != bindings.size || placeholders.toSet() != bindings.keys.map { prefix + it }.toSet()) {
+        throw PatchException("Timeline access placeholders do not match the resolved bindings")
+    }
+    bindings.forEach { (name, descriptor) ->
+        if (descriptor.any { it == '"' || it == '\\' || it == '\n' }) {
+            throw PatchException("Unsupported timeline identity descriptor: $name")
+        }
+        val placeholder = prefix + name
+        val fingerprint = object : Fingerprint(
+            definingClass = bindingClass,
+            name = "<init>",
+            strings = listOf(placeholder),
+        ) {}
+        fingerprint.matchAll(1..1)
+        fingerprint.changeString(placeholder, descriptor)
+    }
+}


### PR DESCRIPTION
Fix "Disable auto timeline scroll on launch" losing the reading position in the For You. capture the visible posts and their offsets, preserve the saved position during startup loading, and retry restoration when the matching post becomes available. also respect the setting when it is turned off. the previous implementation unconditionally overrode the home cold-start decision, so disabling the setting did not restore Twitter's original behavior

Closes #778, #1363, #1379