### PR TITLE
feat(Instagram): Strip stkn tracking parameter from share links

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -48,7 +48,7 @@ public class Links {
     private static final ShareLinkSanitizer SHARE_LINK_SANITIZER = new ShareLinkSanitizer(
             "instagram.com",
             Arrays.asList("comment_id", "img_index", "open_comments", "story_media_id"),
-            Arrays.asList("igsh", "igsi", "utm_source", "utm_medium", "utm_content", "fbclid", "si")
+            Arrays.asList("igsh", "igsi", "utm_source", "utm_medium", "utm_content", "fbclid", "si", "stkn")
     );
 
     static {


### PR DESCRIPTION
saw this new parameter in my links today so adding this here so it can get removed.