### PR TITLE
fix(Twitter - Show changelogs): Error message is shown with changelog dialog

### DIFF
--- a/extensions/shared/library/src/main/java/app/morphe/extension/shared/requests/Requester.java
+++ b/extensions/shared/library/src/main/java/app/morphe/extension/shared/requests/Requester.java
@@ -28,7 +28,7 @@ public class Requester {
         connection.setFixedLengthStreamingMode(0);
         connection.setRequestMethod(route.getMethod().name());
         String agentString = System.getProperty("http.agent")
-                + "; ReVanced/" + Utils.getAppVersionName()
+                + "; Morphe/" + Utils.getAppVersionName()
                 + " (" + Utils.getPatchesReleaseVersion() + ")";
         connection.setRequestProperty("User-Agent", agentString);
 

--- a/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/Changelogs.java
+++ b/extensions/twitter/src/main/java/app/morphe/extension/twitter/patches/Changelogs.java
@@ -7,9 +7,8 @@
 package app.morphe.extension.twitter.patches;
 
 import static android.text.Html.FROM_HTML_MODE_COMPACT;
-
-import static app.morphe.extension.shared.requests.Route.Method.GET;
 import static app.morphe.extension.shared.StringRef.str;
+import static app.morphe.extension.shared.requests.Route.Method.GET;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -18,24 +17,25 @@ import android.text.Html;
 import android.text.method.LinkMovementMethod;
 import android.widget.TextView;
 
-import org.json.JSONObject;
+import androidx.annotation.Nullable;
 
 import java.net.HttpURLConnection;
 
+import app.morphe.extension.crimera.PikoUtils;
+import app.morphe.extension.shared.Logger;
 import app.morphe.extension.shared.Utils;
 import app.morphe.extension.shared.requests.Requester;
 import app.morphe.extension.shared.requests.Route;
 import app.morphe.extension.twitter.Pref;
 
 public class Changelogs {
-    private static final String CHANGELOG_PROVIDER = "https://api.github.com/repos/crimera/piko/releases/tags";
-    private static String patchVersion, latestChangelogVersion;
-    static{
-        latestChangelogVersion = Pref.getLatestChangelogVersion();
-        patchVersion = Utils.getPatchesReleaseVersion();
-    }
+    private static final String CHANGELOG_URL = "https://raw.githubusercontent.com";
+    private static final String CHANGELOG_ROUTE_MAIN = "/crimera/piko/refs/heads/main/CHANGELOG.md";
+    private static final String CHANGELOG_ROUTE_DEV = "/crimera/piko/refs/heads/dev/CHANGELOG.md";
+    private static final String patchVersion = Utils.getPatchesReleaseVersion();
+    private static String latestChangelogVersion = Pref.getLatestChangelogVersion();
 
-    private static String convertMarkdownToHtml(String markdown) {
+    private static String convertMarkdownToHtml(@Nullable String markdown) {
         // Basic manual Markdown to HTML conversion
         if(markdown!=null) {
             return markdown
@@ -50,54 +50,79 @@ public class Changelogs {
         return null;
     }
 
-    private static String getUpdateMessage() throws Exception{
-        if(!Utils.isNetworkConnected()) return null;
+    @Nullable
+    private static String getUpdateMessage() throws Exception {
+        try {
+            String route = patchVersion.contains("dev")
+                    ? CHANGELOG_ROUTE_DEV
+                    : CHANGELOG_ROUTE_MAIN;
 
-        Route route = new Route(GET, "/v"+patchVersion);
-        HttpURLConnection connection = Requester.getConnectionFromRoute(CHANGELOG_PROVIDER, route);
+            HttpURLConnection connection = Requester.getConnectionFromRoute(
+                    CHANGELOG_URL, new Route(GET, route));
+            connection.setConnectTimeout(10_000);
+            connection.setReadTimeout(10_000);
 
-        JSONObject responseJson = Requester.parseJSONObject(connection);
-        String updateMessage = responseJson.getString("body");
-        return convertMarkdownToHtml(updateMessage);
+            String updateMessage = Requester.parseStringAndDisconnect(connection);
+            return convertMarkdownToHtml(updateMessage);
+        } catch (Exception ex) {
+            Logger.printInfo(() -> "Could not fetch changelog", ex);
+            return null;
+        }
     }
 
     public static void showChangelogDialog(Context context){
         String htmlString = Pref.getChangelog();
-        final var finalMessage = Html.fromHtml(htmlString, FROM_HTML_MODE_COMPACT);
-        Utils.runOnMainThread(() -> {
-            TextView textView = new TextView(context);
-            textView.setText(finalMessage);
-            textView.setMovementMethod(LinkMovementMethod.getInstance());
-            textView.setPadding(40, 40, 40, 40);
+        var message = Html.fromHtml(htmlString, FROM_HTML_MODE_COMPACT);
+        TextView textView = new TextView(context);
+        textView.setText(message);
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
+        textView.setPadding(40, 40, 40, 40);
 
-            AlertDialog dialog = new AlertDialog.Builder(context)
-                    .setTitle(str("piko_changelogs_title"))
-                    .setView(textView)
-                    .setPositiveButton(str("ok"), (dialogInterface, i) -> dialogInterface.dismiss())
-                    .create();
+        AlertDialog dialog = new AlertDialog.Builder(context)
+                .setTitle(str("piko_changelogs_title"))
+                .setView(textView)
+                .setPositiveButton(str("ok"), (dialogInterface, i) -> dialogInterface.dismiss())
+                .create();
 
-            dialog.show();
-        });
+        dialog.show();
     }
 
     public static void showChangelog(Activity context) {
-        if (latestChangelogVersion.equals(patchVersion)) return;
+        if (latestChangelogVersion.equals(patchVersion)) {
+            Logger.printInfo(() -> "Changelog check is up to date");
+            return;
+        }
+        if (!Utils.isNetworkConnected()) {
+            Logger.printInfo(() -> "Skipping changelog check, network is not connected");
+            return;
+        }
+        if (context.isDestroyed()) {
+            Logger.printInfo(() -> "Cannot check changelog, activity is destroyed: " + context);
+            return;
+        }
+
         Utils.runOnBackgroundThread(() -> {
-            String htmlString = null;
             try {
-                htmlString = getUpdateMessage();
+                String htmlString = getUpdateMessage();
+                if (htmlString == null) {
+                    return;
+                }
+
+                Utils.runOnMainThread(()-> {
+                    if (context.isDestroyed()) {
+                        Logger.printInfo(() -> "Cannot show changelog, activity is destroyed: " + context);
+                        return;
+                    }
+
+                    latestChangelogVersion = patchVersion;
+                    Pref.setLatestChangelogVersion(patchVersion);
+                    Pref.setChangelog(htmlString);
+                    showChangelogDialog(context);
+                });
             } catch (Exception ex) {
-                app.morphe.extension.crimera.PikoUtils.logger(ex);
-                htmlString = null;
+                PikoUtils.logger(ex);
             }
-            if (htmlString == null) return;
-
-            Pref.setLatestChangelogVersion(patchVersion);
-            Pref.setChangelog(htmlString);
-            latestChangelogVersion = patchVersion;
-            showChangelogDialog(context);
         });
-
-
     }
+
 }

--- a/patches/src/main/kotlin/app/crimera/patches/twitter/misc/showchangelogs/ShowChangelogsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/twitter/misc/showchangelogs/ShowChangelogsPatch.kt
@@ -11,8 +11,13 @@ import app.crimera.patches.twitter.utils.Constants
 import app.crimera.patches.twitter.utils.Constants.COMPATIBILITY_X
 import app.crimera.patches.twitter.utils.enableSettings
 import app.morphe.patcher.Fingerprint
-import app.morphe.patcher.extensions.InstructionExtensions.addInstruction
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
 import app.morphe.patcher.patch.bytecodePatch
+import app.morphe.patcher.util.proxy.mutableTypes.MutableMethod.Companion.toMutable
+import com.android.tools.smali.dexlib2.AccessFlags
+import com.android.tools.smali.dexlib2.builder.MutableMethodImplementation
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethod
+import com.android.tools.smali.dexlib2.immutable.ImmutableMethodParameter
 
 private object MainActivityFingerprint : Fingerprint(
     definingClass = "Lcom/twitter/app/main/MainActivity;",
@@ -28,18 +33,34 @@ val changelogsPatch =
         dependsOn(settingsPatch)
 
         execute {
+            MainActivityFingerprint.classDef.apply {
+                require(methods.none { it.name == "onCreate" }) {
+                    "Main activity already has an onCreate method"
+                }
 
-            val superClassName = MainActivityFingerprint.classDef.superclass!!
+                // Add missing method. Could override superclass onCreate but
+                // then extension hook is called multiple times by unrealted activities.
+                methods += ImmutableMethod(
+                    type,
+                    "onCreate",
+                    listOf(ImmutableMethodParameter("Landroid/os/Bundle;", null, null)),
+                    "V",
+                    AccessFlags.PUBLIC.value,
+                    null,
+                    null,
+                    MutableMethodImplementation(3)
+                ).toMutable().apply {
+                    addInstructions(
+                        0,
+                        """
+                            invoke-super {p0, p1}, ${superclass}->onCreate(Landroid/os/Bundle;)V
+                            invoke-static {p0}, ${Constants.PATCHES_DESCRIPTOR}/Changelogs;->showChangelog(Landroid/app/Activity;)V
+                            return-void
+                        """
+                    )
+                }
+            }
 
-            val superclassOnCreateMethod =
-                mutableClassDefBy(superClassName)
-                    .methods
-                    .first { it.name == "onCreate" }
-
-            superclassOnCreateMethod.addInstruction(
-                0,
-                "invoke-static {p0}, ${Constants.PATCHES_DESCRIPTOR}/Changelogs;->showChangelog(Landroid/app/Activity;)V",
-            )
             enableSettings("showChangelogsPatchEnabled")
         }
     }


### PR DESCRIPTION
Fixes error toast when changelog dialog is presented.

Was caused by the changelog hook being called for multiple activities, some of which were already destroyed.

Also changes from GitHub API to raw urls, to avoid github api not available or user ip address is rate limited.