### PR TITLE
feat(Instagram): Reorder Navigation Tabs

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/constants/UI.java
@@ -11,6 +11,7 @@ import static app.morphe.extension.instagram.utils.IgStr.str;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.content.res.Resources;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
@@ -66,7 +67,30 @@ public class UI {
         TypedValue typedValue = new TypedValue();
         int attrId = ResourceUtils.getAttrIdentifier(attrName);
         boolean resolved = context.getTheme().resolveAttribute(attrId, typedValue, true);
-        return context.getColor(typedValue.resourceId);
+        if (!resolved) {
+            // Seen on cold start when SettingsActivity is the first activity in the
+            // process (task-restore relaunch): Utils.getContext() doesn't carry IG's
+            // real theme yet, so IGDS design-system attrs aren't defined on it. Can't
+            // fix that at the source (Utils.getContext() is in the closed-source
+            // morphe.extensions.library dependency) — fall back instead of crashing.
+            Logger.printException(() -> "Theme attribute not resolved, using fallback: " + attrName,
+                    new Resources.NotFoundException(attrName));
+            return fallbackColour(context);
+        }
+        // resolveAttribute can yield either a resource reference (resourceId != 0,
+        // needs getColor(resourceId)) or a raw packed color already in typedValue.data
+        // (resourceId == 0 legitimately, not a failure).
+        return typedValue.resourceId != 0
+                ? context.getColor(typedValue.resourceId)
+                : typedValue.data;
+    }
+
+    private static int fallbackColour(Context context) {
+        int nightMask = context.getResources().getConfiguration().uiMode
+                & android.content.res.Configuration.UI_MODE_NIGHT_MASK;
+        return nightMask == android.content.res.Configuration.UI_MODE_NIGHT_YES
+                ? 0xFF000000
+                : 0xFFFFFFFF;
     }
 
     public static boolean isDarkMode() {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/HideNavigationButtonsPatch.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/HideNavigationButtonsPatch.java
@@ -17,21 +17,31 @@ import app.morphe.extension.instagram.utils.Pref;
 @SuppressWarnings("unused")
 public class HideNavigationButtonsPatch {
 
+    // A03="fragment_share" is shared by two enum constants (SHARE and CREATION,
+    // the real camera/create button). Disambiguate via Enum.name() for this key only.
+    private static final String AMBIGUOUS_SHARE_KEY = "fragment_share";
+    private static final String CREATION_ENUM_NAME = "CREATION";
+    private static final String NEWS_ENUM_NAME = "NEWS";
+
     private static final boolean HIDE_FEED;
     private static final boolean HIDE_REELS;
     private static final boolean HIDE_DIRECT;
     private static final boolean HIDE_SEARCH;
+    private static final boolean HIDE_PROFILE;
     private static final boolean HIDE_CREATE;
+    private static final boolean HIDE_NEWS;
 
     static {
         HIDE_FEED = Pref.hideNavigationFeed() && SettingsStatus.hideNavigationButtons;
         HIDE_REELS = Pref.hideNavigationReels() && SettingsStatus.hideNavigationButtons;
         HIDE_DIRECT = Pref.hideNavigationDirect() && SettingsStatus.hideNavigationButtons;
         HIDE_SEARCH = Pref.hideNavigationSearch() && SettingsStatus.hideNavigationButtons;
+        HIDE_PROFILE = Pref.hideNavigationProfile() && SettingsStatus.hideNavigationButtons;
         HIDE_CREATE = Pref.hideNavigationCreate() && SettingsStatus.hideNavigationButtons;
+        HIDE_NEWS = Pref.hideNavigationNews() && SettingsStatus.hideNavigationButtons;
     }
 
-    // Credits to brosssh.
+     // Credits to brosssh.
     // https://github.com/brosssh/morphe-patches/blob/27cc95b04b162d0df3b5722542f9fd095f42fd9d/extensions/instagram/src/main/java/app/morphe/extension/instagram/hide/navigation/HideNavigationButtonsPatch.java
     /**
      * Injection point.
@@ -45,7 +55,6 @@ public class HideNavigationButtonsPatch {
             String enumNameField
     ) throws IllegalAccessException, NoSuchFieldException {
         List<Object> mutableList = new ArrayList<>(navigationButtonsList);
-
         Iterator<Object> iterator = mutableList.iterator();
 
         while (iterator.hasNext()) {
@@ -55,15 +64,76 @@ public class HideNavigationButtonsPatch {
             String name = (String) f.get(button);
             if (name == null) continue;
 
+            boolean matchesCreate = name.equals(AMBIGUOUS_SHARE_KEY)
+                    && HIDE_CREATE
+                    && isCreationEnum(button);
+            boolean matchesNews = (name.equals("fragment_news") || isNewsEnum(button)) && HIDE_NEWS;
+
             if (name.equals("fragment_feed") && HIDE_FEED ||
                     name.equals("fragment_clips") && HIDE_REELS ||
                     name.equals("fragment_direct_tab") && HIDE_DIRECT ||
                     name.equals("fragment_search") && HIDE_SEARCH ||
-                    name.equals("fragment_share") && HIDE_CREATE
+                    matchesCreate ||
+                    name.equals("fragment_profile") && HIDE_PROFILE ||
+                    matchesNews
             ) {
                 iterator.remove();
             }
         }
-        return mutableList;
+
+        return reorderNavigationButtons(mutableList, enumNameField);
+    }
+
+    /** Reorders the filtered list per the saved order; unknown buttons append at the end. */
+    private static List<Object> reorderNavigationButtons(
+            List<Object> buttons,
+            String enumNameField
+    ) throws NoSuchFieldException, IllegalAccessException {
+        String savedOrder = Pref.navigationButtonsOrder();
+        if (savedOrder == null || savedOrder.isEmpty()) return buttons;
+
+        List<Object> remaining = new ArrayList<>(buttons);
+        List<Object> sorted = new ArrayList<>(buttons.size());
+
+        for (String key : savedOrder.split(",")) {
+            Iterator<Object> it = remaining.iterator();
+            while (it.hasNext()) {
+                Object button = it.next();
+                Field f = button.getClass().getDeclaredField(enumNameField);
+                f.setAccessible(true);
+                Object fieldValue = f.get(button);
+
+                if (keyMatchesField(key, fieldValue, button)) {
+                    sorted.add(button);
+                    it.remove();
+                    break;
+                }
+            }
+        }
+        sorted.addAll(remaining);
+        return sorted;
+    }
+
+    private static boolean keyMatchesField(String savedKey, Object fieldValue, Object button) {
+        if (AMBIGUOUS_SHARE_KEY.equals(savedKey)) {
+            return AMBIGUOUS_SHARE_KEY.equals(fieldValue) && isCreationEnum(button);
+        }
+        if ("fragment_news".equals(savedKey)) {
+            return "fragment_news".equals(fieldValue) || isNewsEnum(button);
+        }
+        return savedKey.equals(fieldValue);
+    }
+
+    private static boolean isCreationEnum(Object button) {
+        return button instanceof Enum && CREATION_ENUM_NAME.equals(((Enum<?>) button).name());
+    }
+
+    private static boolean isNewsEnum(Object button) {
+        return button instanceof Enum && NEWS_ENUM_NAME.equals(((Enum<?>) button).name());
+    }
+
+    /** News moved to the top action bar bypasses the IgTab list above entirely. */
+    public static String filterNewsTopBarEntry(String original) {
+        return "news".equals(original) && HIDE_NEWS ? null : original;
     }
 }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/NavigationButtonsOrderDialog.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/hide/navigation/NavigationButtonsOrderDialog.java
@@ -1,0 +1,467 @@
+/*
+ * Copyright (C) 2026 piko <https://github.com/crimera/piko>
+ *
+ * See the included NOTICE file for GPLv3 §7(b) terms that apply to this code.
+ */
+
+package app.morphe.extension.instagram.patches.hide.navigation;
+
+import static app.morphe.extension.instagram.utils.IgStr.str;
+
+import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.Application;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.graphics.Color;
+import android.graphics.Typeface;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.GradientDrawable;
+import android.preference.Preference;
+import android.util.TypedValue;
+import android.view.Gravity;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewConfiguration;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.view.WindowManager;
+import android.widget.CompoundButton;
+import android.widget.LinearLayout;
+import android.widget.ScrollView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import app.morphe.extension.crimera.sharedPreference.SharedPref;
+import app.morphe.extension.crimera.settings.BooleanSetting;
+import app.morphe.extension.instagram.settings.Settings;
+import app.morphe.extension.instagram.settings.SettingsRestart;
+import app.morphe.extension.instagram.settings.preference.widgets.InstagramPreferenceStyle;
+import app.morphe.extension.instagram.utils.Pref;
+import app.morphe.extension.shared.Utils;
+
+/**
+ * Drag-to-reorder dialog for the navigation tabs. Not a ListView/BaseAdapter:
+ * view recycling during an active drag detaches the View receiving the touch
+ * stream mid-gesture. Rows are plain LinearLayout children, rebuilt once per
+ * drop.
+ */
+public final class NavigationButtonsOrderDialog {
+
+    private static final Tab[] TABS = {
+            new Tab("fragment_feed", "piko_nav_tab_feed", "tab_home_drawable", Settings.HIDE_NAVIGATION_FEED),
+            new Tab("fragment_clips", "piko_nav_tab_reels", "tab_clips_drawable", Settings.HIDE_NAVIGATION_REELS),
+            new Tab("fragment_direct_tab", "piko_nav_tab_direct", "tab_prism_direct_drawable", Settings.HIDE_NAVIGATION_DIRECT),
+            new Tab("fragment_search", "piko_nav_tab_search", "tab_search_drawable", Settings.HIDE_NAVIGATION_SEARCH),
+            new Tab("fragment_profile", "piko_nav_tab_profile", "tab_profile_drawable", Settings.HIDE_NAVIGATION_PROFILE),
+            new Tab("fragment_share", "piko_nav_tab_create", "tab_camera_drawable", Settings.HIDE_NAVIGATION_CREATE),
+            new Tab("fragment_news", "piko_nav_tab_news", "tab_activity_heart_drawable", Settings.HIDE_NAVIGATION_NEWS),
+    };
+
+    private NavigationButtonsOrderDialog() {
+    }
+
+    public static void show(Context context) {
+        Context themed = InstagramPreferenceStyle.dialogContext(context);
+        List<Tab> items = currentState();
+
+        LinearLayout root = new LinearLayout(themed);
+        root.setOrientation(LinearLayout.VERTICAL);
+        GradientDrawable cardBackground = new GradientDrawable();
+        cardBackground.setColor(InstagramPreferenceStyle.backgroundColor());
+        cardBackground.setCornerRadius(dp(themed, 20));
+        root.setBackground(cardBackground);
+
+        int pad = dp(themed, 20);
+        TextView title = new TextView(themed);
+        title.setText(str("piko_reorder_navigation_buttons_title"));
+        title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 20);
+        title.setTypeface(null, Typeface.BOLD);
+        title.setTextColor(InstagramPreferenceStyle.primaryTextColor());
+        title.setPadding(pad, pad, pad, dp(themed, 12));
+        root.addView(title);
+
+        ScrollView scrollView = new ScrollView(themed) {
+            @Override
+            protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
+                int maxHeightPx = (int) (getResources().getDisplayMetrics().heightPixels * 0.62f);
+                int cappedHeightSpec = View.MeasureSpec.makeMeasureSpec(maxHeightPx, View.MeasureSpec.AT_MOST);
+                super.onMeasure(widthMeasureSpec, cappedHeightSpec);
+            }
+        };
+        LinearLayout rowsContainer = new LinearLayout(themed);
+        rowsContainer.setOrientation(LinearLayout.VERTICAL);
+        scrollView.addView(rowsContainer, new ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        root.addView(scrollView, new LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+
+        Dialog dialog = new Dialog(themed, android.R.style.Theme_DeviceDefault_Dialog_NoActionBar_MinWidth);
+        dialog.setContentView(root);
+
+        DragController controller = new DragController(themed, scrollView, rowsContainer, items);
+        controller.rebuildRows();
+
+        LinearLayout buttonRow = new LinearLayout(themed);
+        buttonRow.setOrientation(LinearLayout.HORIZONTAL);
+        buttonRow.setPadding(pad, dp(themed, 12), pad, dp(themed, 16));
+
+        TextView reset = actionText(themed, str("piko_reorder_navigation_buttons_reset"));
+        TextView cancel = actionText(themed, str("piko_cancel"));
+        TextView set = actionText(themed, str("piko_ok"));
+
+        reset.setOnClickListener(v -> controller.resetToDefault());
+        cancel.setOnClickListener(v -> dialog.dismiss());
+        set.setOnClickListener(v -> {
+            String prevOrder = Pref.navigationButtonsOrder();
+            String nextOrder = String.join(",", controller.currentKeyOrder());
+            boolean changed = !nextOrder.equals(prevOrder);
+
+            dialog.dismiss();
+            if (changed) {
+                new AlertDialog.Builder(InstagramPreferenceStyle.dialogContext(context))
+                        .setTitle(str("piko_restart_app"))
+                        .setCancelable(false)
+                        .setPositiveButton(str("piko_ok"), (d, w) -> {
+                            SharedPref.setStringPref(Settings.NAVIGATION_BUTTONS_ORDER.key, nextOrder);
+                            SettingsRestart.markChanged(prevOrder, nextOrder);
+                            Utils.restartApp(Utils.getContext());
+                        })
+                        .setNegativeButton(str("piko_cancel"), null)
+                        .show();
+            }
+        });
+
+        LinearLayout.LayoutParams flexParams = new LinearLayout.LayoutParams(
+                0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f);
+        buttonRow.addView(reset, flexParams);
+        buttonRow.addView(cancel, flexParams);
+        buttonRow.addView(set, flexParams);
+        root.addView(buttonRow);
+
+        Window window = dialog.getWindow();
+        if (window != null) {
+            window.setBackgroundDrawable(new ColorDrawable(Color.TRANSPARENT));
+            WindowManager.LayoutParams params = window.getAttributes();
+            params.width = (int) (themed.getResources().getDisplayMetrics().widthPixels * 0.88f);
+            params.height = ViewGroup.LayoutParams.WRAP_CONTENT;
+            params.gravity = Gravity.CENTER;
+            window.setAttributes(params);
+        }
+
+        // Dialog isn't Activity-managed, so it survives a MaterialYouTheme-triggered
+        // activity.recreate() and crashes on the torn-down window. Auto-dismiss on destroy.
+        Activity hostActivity = unwrapActivity(context);
+        if (hostActivity != null) {
+            Application app = hostActivity.getApplication();
+            Application.ActivityLifecycleCallbacks lifecycleGuard =
+                    new Application.ActivityLifecycleCallbacks() {
+                        @Override
+                        public void onActivityDestroyed(Activity activity) {
+                            if (activity == hostActivity && dialog.isShowing()) {
+                                dialog.dismiss();
+                            }
+                        }
+
+                        @Override public void onActivityCreated(Activity a, android.os.Bundle b) {}
+                        @Override public void onActivityStarted(Activity a) {}
+                        @Override public void onActivityResumed(Activity a) {}
+                        @Override public void onActivityPaused(Activity a) {}
+                        @Override public void onActivityStopped(Activity a) {}
+                        @Override public void onActivitySaveInstanceState(Activity a, android.os.Bundle b) {}
+                    };
+            app.registerActivityLifecycleCallbacks(lifecycleGuard);
+            dialog.setOnDismissListener(d -> app.unregisterActivityLifecycleCallbacks(lifecycleGuard));
+        }
+
+        dialog.show();
+    }
+
+    private static Activity unwrapActivity(Context context) {
+        while (context instanceof ContextWrapper) {
+            if (context instanceof Activity) return (Activity) context;
+            context = ((ContextWrapper) context).getBaseContext();
+        }
+        return context instanceof Activity ? (Activity) context : null;
+    }
+
+    private static TextView actionText(Context context, String text) {
+        TextView tv = new TextView(context);
+        tv.setText(text);
+        tv.setGravity(Gravity.CENTER);
+        tv.setTypeface(null, Typeface.BOLD);
+        tv.setTextColor(InstagramPreferenceStyle.primaryTextColor());
+        tv.setPadding(0, dp(context, 8), 0, dp(context, 8));
+        return tv;
+    }
+
+    private static List<Tab> currentState() {
+        List<String> allKeys = new ArrayList<>();
+        for (Tab t : TABS) allKeys.add(t.key);
+
+        List<String> ordered = new ArrayList<>();
+        String saved = Pref.navigationButtonsOrder();
+        if (saved != null && !saved.isEmpty()) {
+            for (String key : saved.split(",")) {
+                if (allKeys.remove(key)) ordered.add(key);
+            }
+        }
+        ordered.addAll(allKeys);
+
+        List<Tab> result = new ArrayList<>(ordered.size());
+        for (String key : ordered) {
+            result.add(tabByKey(key));
+        }
+        return result;
+    }
+
+    private static Tab tabByKey(String key) {
+        for (Tab t : TABS) if (t.key.equals(key)) return t;
+        throw new IllegalStateException("Unknown tab key: " + key);
+    }
+
+    private static int dp(Context context, int value) {
+        return (int) TypedValue.applyDimension(
+                TypedValue.COMPLEX_UNIT_DIP, value, context.getResources().getDisplayMetrics());
+    }
+
+    private static final class Tab {
+        final String key;
+        final String labelResKey;
+        final String iconResName;
+        final BooleanSetting hideSetting;
+
+        Tab(String key, String labelResKey, String iconResName, BooleanSetting hideSetting) {
+            this.key = key;
+            this.labelResKey = labelResKey;
+            this.iconResName = iconResName;
+            this.hideSetting = hideSetting;
+        }
+    }
+
+    /** Owns the row Views + drag gesture. Rows rebuild from `items` once per drop. */
+    private static final class DragController {
+        private final Context context;
+        private final ScrollView scrollView;
+        private final LinearLayout container;
+        private final List<Tab> items;
+        private final int touchSlop;
+
+        DragController(Context context, ScrollView scrollView, LinearLayout container, List<Tab> items) {
+            this.context = context;
+            this.scrollView = scrollView;
+            this.container = container;
+            this.items = items;
+            this.touchSlop = ViewConfiguration.get(context).getScaledTouchSlop();
+        }
+
+        List<String> currentKeyOrder() {
+            List<String> keys = new ArrayList<>(items.size());
+            for (Tab t : items) keys.add(t.key);
+            return keys;
+        }
+
+        void resetToDefault() {
+            items.clear();
+            for (Tab t : TABS) items.add(t);
+            rebuildRows();
+        }
+
+        void rebuildRows() {
+            container.removeAllViews();
+            for (int i = 0; i < items.size(); i++) {
+                container.addView(buildRow(i), new LinearLayout.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+            }
+        }
+
+        // News/Create hide toggles aren't confirmed working yet — block reordering
+        // them until that's sorted, so a drag can't be blamed on the wrong bug.
+        private static final Set<String> LOCKED_KEYS =
+                new HashSet<>(Arrays.asList("fragment_news", "fragment_share"));
+
+        private View buildRow(int index) {
+            Tab tab = items.get(index);
+            boolean locked = LOCKED_KEYS.contains(tab.key);
+
+            View row = InstagramPreferenceStyle.createPreferenceView(
+                    context, InstagramPreferenceStyle.TRAILING_SWITCH, tab.iconResName);
+
+            Preference dummy = new Preference(context);
+            dummy.setTitle(str(tab.labelResKey));
+            dummy.setEnabled(true);
+            InstagramPreferenceStyle.bindText(dummy, row);
+
+            View handle = replaceSwitchWithDragHandle(row);
+            if (locked) {
+                if (handle != null) handle.setAlpha(0.35f);
+            } else {
+                row.setOnTouchListener(new DragTouchListener(index));
+            }
+            return row;
+        }
+
+        private View replaceSwitchWithDragHandle(View row) {
+            CompoundButton switchView = InstagramPreferenceStyle.findSwitch(row);
+            if (switchView == null) return null;
+            Object parentObj = switchView.getParent();
+            if (!(parentObj instanceof ViewGroup)) return null;
+            ViewGroup switchParent = (ViewGroup) parentObj;
+            int slot = switchParent.indexOfChild(switchView);
+            switchParent.removeView(switchView);
+
+            int handleSize = dp(context, 36);
+            View handle = buildDragHandle(context);
+            switchParent.addView(handle, slot, new LinearLayout.LayoutParams(handleSize, handleSize));
+            return handle;
+        }
+
+        private static View buildDragHandle(Context context) {
+            LinearLayout handle = new LinearLayout(context);
+            handle.setOrientation(LinearLayout.VERTICAL);
+            handle.setGravity(Gravity.CENTER);
+
+            GradientDrawable buttonBackground = new GradientDrawable();
+            buttonBackground.setColor(withAlpha(InstagramPreferenceStyle.secondaryTextColor(), 40));
+            buttonBackground.setCornerRadius(dp(context, 10));
+            handle.setBackground(buttonBackground);
+
+            int barWidth = dp(context, 16);
+            int barHeight = dp(context, 2);
+            int barGap = dp(context, 3);
+            int barColor = InstagramPreferenceStyle.primaryTextColor();
+
+            for (int i = 0; i < 3; i++) {
+                View bar = new View(context);
+                GradientDrawable barBackground = new GradientDrawable();
+                barBackground.setColor(barColor);
+                barBackground.setCornerRadius(barHeight / 2f);
+                bar.setBackground(barBackground);
+
+                LinearLayout.LayoutParams barParams =
+                        new LinearLayout.LayoutParams(barWidth, barHeight);
+                if (i > 0) barParams.topMargin = barGap;
+                handle.addView(bar, barParams);
+            }
+            return handle;
+        }
+
+        private static int withAlpha(int color, int alpha) {
+            return (color & 0x00FFFFFF) | (alpha << 24);
+        }
+
+        private final class DragTouchListener implements View.OnTouchListener {
+            private final int originalIndex;
+            private float startRawY;
+            private boolean armed;
+            private boolean dragging;
+            private Runnable armRunnable;
+            private List<Integer> virtualOrder;
+            private int rowHeightPx;
+
+            DragTouchListener(int originalIndex) {
+                this.originalIndex = originalIndex;
+            }
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        startRawY = event.getRawY();
+                        armed = false;
+                        dragging = false;
+                        armRunnable = () -> startDrag(v);
+                        v.postDelayed(armRunnable, ViewConfiguration.getLongPressTimeout());
+                        return true; // row isn't clickable anymore, must consume to keep the gesture
+
+                    case MotionEvent.ACTION_MOVE:
+                        if (!armed) {
+                            if (Math.abs(event.getRawY() - startRawY) > touchSlop) {
+                                v.removeCallbacks(armRunnable);
+                            }
+                            return false;
+                        }
+                        dragging = true;
+                        float dy = event.getRawY() - startRawY;
+                        v.setTranslationY(dy);
+                        updateHoverSlot(dy);
+                        return true;
+
+                    case MotionEvent.ACTION_UP:
+                    case MotionEvent.ACTION_CANCEL:
+                        v.removeCallbacks(armRunnable);
+                        if (!armed) return false;
+                        finishDrag(v);
+                        return dragging;
+                }
+                return false;
+            }
+
+            private static final float DRAG_ELEVATION_DP = 8f;
+
+            private void startDrag(View v) {
+                armed = true;
+                rowHeightPx = v.getHeight();
+                virtualOrder = new ArrayList<>();
+                for (int i = 0; i < items.size(); i++) virtualOrder.add(i);
+                v.setBackgroundColor(InstagramPreferenceStyle.pressedBackgroundColor());
+                // elevation only, not bringToFront(): LinearLayout lays out by array
+                // order, not Z, so reordering the child array would relocate it mid-drag.
+                v.setElevation(dp(v.getContext(), (int) DRAG_ELEVATION_DP));
+                scrollView.requestDisallowInterceptTouchEvent(true);
+            }
+
+            private void updateHoverSlot(float dy) {
+                if (rowHeightPx <= 0) return;
+                int currentSlot = virtualOrder.indexOf(originalIndex);
+                int targetSlot = clamp(
+                        originalIndex + Math.round(dy / rowHeightPx), 0, items.size() - 1);
+                if (targetSlot == currentSlot) return;
+
+                virtualOrder.remove(Integer.valueOf(originalIndex));
+                virtualOrder.add(targetSlot, originalIndex);
+
+                for (int i = 0; i < container.getChildCount(); i++) {
+                    if (i == originalIndex) continue;
+                    View sibling = container.getChildAt(i);
+                    int newSlot = virtualOrder.indexOf(i);
+                    sibling.animate().translationY((newSlot - i) * rowHeightPx).setDuration(120).start();
+                }
+            }
+
+            private void finishDrag(View v) {
+                scrollView.requestDisallowInterceptTouchEvent(false);
+                v.setBackgroundColor(Color.TRANSPARENT);
+                v.setElevation(0f);
+
+                if (dragging && virtualOrder != null) {
+                    List<Tab> reordered = new ArrayList<>(items.size());
+                    for (int originalIdx : virtualOrder) reordered.add(items.get(originalIdx));
+                    items.clear();
+                    items.addAll(reordered);
+                }
+                for (int i = 0; i < container.getChildCount(); i++) {
+                    container.getChildAt(i).animate().cancel();
+                }
+                // Deferred: mutating `container` mid-dispatchTouchEvent corrupts the
+                // ScrollView's children array.
+                v.post(this::rebuildRowsSafe);
+            }
+
+            private void rebuildRowsSafe() {
+                if (!container.isAttachedToWindow()) return;
+                rebuildRows();
+            }
+        }
+
+        private static int clamp(int value, int min, int max) {
+            return Math.max(min, Math.min(max, value));
+        }
+    }
+}

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/Settings.java
@@ -85,6 +85,9 @@ public class Settings {
     public static final BooleanSetting HIDE_NAVIGATION_DIRECT = new BooleanSetting("hide_navigation_direct", false);
     public static final BooleanSetting HIDE_NAVIGATION_SEARCH = new BooleanSetting("hide_navigation_search", false);
     public static final BooleanSetting HIDE_NAVIGATION_CREATE = new BooleanSetting("hide_navigation_create", false);
+    public static final BooleanSetting HIDE_NAVIGATION_PROFILE = new BooleanSetting("hide_navigation_profile", false);
+    public static final BooleanSetting HIDE_NAVIGATION_NEWS = new BooleanSetting("hide_navigation_news", false);
+    public static final StringSetting NAVIGATION_BUTTONS_ORDER = new StringSetting("navigation_buttons_order", "");
 
     public static final StringSetting ACTION_BAR_MAIN_FEED = new StringSetting("action_bar_main_feed", "");
     public static final StringSetting ACTION_BAR_USER_PROFILE = new StringSetting("action_bar_user_profile", "");

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/ScreenBuilder.java
@@ -838,9 +838,33 @@ public class ScreenBuilder {
 
         addPreference(
                 helper.switchPreference(
+                        str("piko_hide_navigation_profile"),
+                        "",
+                        Settings.HIDE_NAVIGATION_PROFILE
+                )
+        );
+
+        addPreference(
+                helper.switchPreference(
                         str("piko_hide_navigation_create"),
                         "",
                         Settings.HIDE_NAVIGATION_CREATE
+                )
+        );
+        
+        addPreference(
+                helper.switchPreference(
+                        str("piko_hide_navigation_news"),
+                        "",
+                        Settings.HIDE_NAVIGATION_NEWS
+                )
+        );
+
+        addPreference(
+                helper.buttonPreference(
+                        str("piko_reorder_navigation_buttons_title"),
+                        str("piko_reorder_navigation_buttons_desc"),
+                        "piko_reorder_navigation_buttons"
                 )
         );
     }

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/ButtonPref.java
@@ -27,6 +27,7 @@ import app.morphe.extension.instagram.constants.UI;
 import app.morphe.extension.instagram.constants.Constants;
 import app.morphe.extension.instagram.utils.InstaUtils;
 import app.morphe.extension.instagram.patches.dm.SavedMessagesHook;
+import app.morphe.extension.instagram.patches.hide.navigation.NavigationButtonsOrderDialog;
 
 public class ButtonPref extends Preference {
     private final Context context;
@@ -92,6 +93,9 @@ public class ButtonPref extends Preference {
                         RecommendedFlags.downloadRecommendedFlagsFile(
                                 recreateActivityOnComplete(context)
                         );
+
+                    } else if (key.equals("piko_reorder_navigation_buttons")) {
+                        NavigationButtonsOrderDialog.show(context);
                     }
                 } catch (Exception e) {
                     Utils.showToastShort(e.getMessage());
@@ -151,7 +155,8 @@ public class ButtonPref extends Preference {
                 || key.equals("piko_export_experiment_mappings")
                 || key.equals("piko_download_id_mapping")
                 || key.equals("piko_rec_flags_refresh_file")
-                || key.equals("view_deleted_messages")));
+                || key.equals("view_deleted_messages")
+                || key.equals("piko_reorder_navigation_buttons")));
     }
 
     private static boolean hasPressedHighlight(String key) {
@@ -203,5 +208,3 @@ public class ButtonPref extends Preference {
     }
 
 }
-
-

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/settings/preference/widgets/InstagramPreferenceStyle.java
@@ -163,7 +163,9 @@ public final class InstagramPreferenceStyle {
 
     public static View createPreferenceView(Context context, int trailingType, String iconResName) {
         PreferenceRow row = new PreferenceRow(context, trailingType);
-        row.setOrientation(trailingType == TRAILING_SWITCH ? LinearLayout.VERTICAL : LinearLayout.HORIZONTAL);
+        // row stays HORIZONTAL so the icon sits left of the text (was VERTICAL,
+        // which stacked the icon above the title instead).
+        row.setOrientation(LinearLayout.HORIZONTAL);
         row.setGravity(Gravity.CENTER_VERTICAL);
         row.setMinimumHeight(dp(context, 78));
         row.setPadding(dp(context, 17), dp(context, 10), dp(context, 17), dp(context, 10));
@@ -177,11 +179,28 @@ public final class InstagramPreferenceStyle {
             row.setIcon(iconResName);
         }
 
+        // title/switch/summary now nest in this vertical column instead of
+        // going directly into `row`, which is horizontal (icon | column).
+        LinearLayout contentColumn = new LinearLayout(context);
+        contentColumn.setOrientation(LinearLayout.VERTICAL);
+        contentColumn.setGravity(Gravity.CENTER_VERTICAL);
+        LinearLayout.LayoutParams contentParams = new LinearLayout.LayoutParams(
+                0,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                1f
+        );
+        if (trailingType != TRAILING_SWITCH) {
+            // TRAILING_CHEVRON has a sibling trailing icon after contentColumn;
+            // TRAILING_SWITCH's switch lives inside titleRow, no sibling needed.
+            contentParams.rightMargin = dp(context, 14);
+        }
+        row.addView(contentColumn, contentParams);
+
         if (trailingType == TRAILING_SWITCH) {
             LinearLayout titleRow = new LinearLayout(context);
             titleRow.setOrientation(LinearLayout.HORIZONTAL);
             titleRow.setGravity(Gravity.CENTER_VERTICAL);
-            row.addView(titleRow, new LinearLayout.LayoutParams(
+            contentColumn.addView(titleRow, new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT
             ));
@@ -214,7 +233,7 @@ public final class InstagramPreferenceStyle {
             summary.setTextColor(secondaryTextColor());
             summary.setLineSpacing(dp(context, 1), 1.0f);
             summary.setPadding(0, dp(context, 10), 0, 0);
-            row.addView(summary, new LinearLayout.LayoutParams(
+            contentColumn.addView(summary, new LinearLayout.LayoutParams(
                     LinearLayout.LayoutParams.MATCH_PARENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT
             ));
@@ -222,25 +241,13 @@ public final class InstagramPreferenceStyle {
             return row;
         }
 
-        LinearLayout textColumn = new LinearLayout(context);
-        textColumn.setOrientation(LinearLayout.VERTICAL);
-        textColumn.setGravity(Gravity.CENTER_VERTICAL);
-
-        LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(
-                0,
-                LinearLayout.LayoutParams.WRAP_CONTENT,
-                1f
-        );
-        textParams.rightMargin = dp(context, 14);
-        row.addView(textColumn, textParams);
-
         TextView title = new TextView(context);
         title.setTag(TAG_TITLE);
         title.setTextSize(TypedValue.COMPLEX_UNIT_SP, 18);
         title.setTextColor(primaryTextColor());
         title.setIncludeFontPadding(true);
         title.setSingleLine(false);
-        textColumn.addView(title, new LinearLayout.LayoutParams(
+        contentColumn.addView(title, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT
         ));
@@ -251,7 +258,7 @@ public final class InstagramPreferenceStyle {
         summary.setTextColor(secondaryTextColor());
         summary.setLineSpacing(dp(context, 1), 1.0f);
         summary.setPadding(0, dp(context, 10), 0, 0);
-        textColumn.addView(summary, new LinearLayout.LayoutParams(
+        contentColumn.addView(summary, new LinearLayout.LayoutParams(
                 LinearLayout.LayoutParams.MATCH_PARENT,
                 LinearLayout.LayoutParams.WRAP_CONTENT
         ));
@@ -565,18 +572,26 @@ public final class InstagramPreferenceStyle {
             return allowed;
         }
 
+        // titleRow nests inside contentColumn now, not a direct child of `row` —
+        // getTop()/getBottom() alone would be wrong; walk the tree instead.
+        private final Rect highlightRect = new Rect();
+
         private int highlightTop() {
             if (highlightView == null) {
                 return 0;
             }
-            return Math.max(0, highlightView.getTop() - dp(getContext(), 10));
+            highlightRect.set(0, 0, highlightView.getWidth(), highlightView.getHeight());
+            offsetDescendantRectToMyCoords(highlightView, highlightRect);
+            return Math.max(0, highlightRect.top - dp(getContext(), 10));
         }
 
         private int highlightBottom() {
             if (highlightView == null) {
                 return getHeight();
             }
-            return Math.min(getHeight(), highlightView.getBottom() + dp(getContext(), 10));
+            highlightRect.set(0, 0, highlightView.getWidth(), highlightView.getHeight());
+            offsetDescendantRectToMyCoords(highlightView, highlightRect);
+            return Math.min(getHeight(), highlightRect.bottom + dp(getContext(), 10));
         }
 
         private void setDrawPressedHighlight(boolean drawPressedHighlight) {

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/theme/MaterialYouState.java
@@ -116,9 +116,12 @@ final class MaterialYouState {
             boolean pikoSettingsActivity,
             boolean activityDark
     ) {
-        return pikoSettingsActivity
-                ? observedInstagramDark
-                : activityDark;
+        // Was `cond ? Boolean : boolean` — mixed ternary unboxes the Boolean branch
+        // even when it's null, causing an NPE on cold start.
+        if (pikoSettingsActivity) {
+            return observedInstagramDark;
+        }
+        return activityDark;
     }
 
     static Boolean updateObservedInstagramDarkForNativeMode(

--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/utils/Pref.java
@@ -265,6 +265,18 @@ public class Pref {
         return SharedPref.getBooleanPref(Settings.HIDE_NAVIGATION_CREATE);
     }
 
+    public static boolean hideNavigationProfile() {
+        return SharedPref.getBooleanPref(Settings.HIDE_NAVIGATION_PROFILE);
+    }
+
+    public static boolean hideNavigationNews() {
+        return SharedPref.getBooleanPref(Settings.HIDE_NAVIGATION_NEWS);
+    }
+
+    public static String navigationButtonsOrder() {
+        return SharedPref.getStringPref(Settings.NAVIGATION_BUTTONS_ORDER);
+    }
+
     public static boolean removeEmptyBottomSpace() {
         return SharedPref.getBooleanPref(Settings.REMOVE_EMPTY_BOTTOM_SPACE);
     }

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/HideNavigationButtons.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/misc/distractionFree/HideNavigationButtons.kt
@@ -53,8 +53,8 @@ private const val EXTENSION_CLASS_DESCRIPTOR =
 @Suppress("unused")
 val hideNavigationButtonsPatch =
     bytecodePatch(
-        name = "Hide navigation buttons",
-        description = "Hides navigation bar buttons, such as the Reels and Create button.",
+        name = "Hide and Reorder navigation buttons",
+        description = "Hides and Reorder navigation bar buttons, such as the Reels and Create button.",
     ) {
         compatibleWith(COMPATIBILITY_INSTAGRAM)
 

--- a/patches/src/main/resources/addresources/values/instagram/strings.xml
+++ b/patches/src/main/resources/addresources/values/instagram/strings.xml
@@ -176,17 +176,29 @@
     <string name="piko_more_options">More options</string>
 
     <!-- Navigation Section -->
-    <string name="piko_category_hide_navigation_buttons">Hide navigation buttons</string>
+    <string name="piko_category_hide_navigation_buttons">Reorder/Hide navigation buttons</string>
     <string name="piko_hide_navigation_feed">Hide Feed button</string>
     <string name="piko_hide_navigation_reels">Hide Reels button</string>
     <string name="piko_hide_navigation_direct">Hide Direct button</string>
     <string name="piko_hide_navigation_search">Hide Search button</string>
+    <string name="piko_hide_navigation_profile">Hide Profile button</string>
     <string name="piko_hide_navigation_create">Hide Create button</string>
+    <string name="piko_hide_navigation_news">Hide Notification button</string>
+    <string name="piko_reorder_navigation_buttons_title">Reorder Navigation Buttons</string>
+    <string name="piko_reorder_navigation_buttons_desc">You can customize navigation tabs according to your needs. (You can only place a maximum of 5 buttons.)</string>
+    <string name="piko_nav_tab_feed">Home</string>
+    <string name="piko_nav_tab_search">Search</string>
+    <string name="piko_nav_tab_reels">Reels</string>
+    <string name="piko_nav_tab_direct">Direct</string>
+    <string name="piko_nav_tab_create">Create</string>
+    <string name="piko_nav_tab_profile">Profile</string>
+    <string name="piko_nav_tab_news">Notification</string>
+    <string name="piko_reorder_navigation_buttons_reset">Reset</string>
 
     <!-- Information Section -->
     <string name="piko_category_about">About</string>
-    <string name="piko_export_pref">Export Piko settings</string>
-    <string name="piko_import_pref">Import Piko settings</string>
+    <string name="piko_export_pref">Export Piko preferences</string>
+    <string name="piko_import_pref">Import Piko preferences</string>
     <string name="piko_reset_pref">Reset Piko settings</string>
     <string name="piko_reset_pref_confirm">Reset Piko settings?</string>
     <string name="piko_reset_pref_success">Piko settings reset</string>


### PR DESCRIPTION

Added a feature to reorder Instagram tabs however the user likes. I renamed the patch and its description, and renamed the tab in the settings, as shown in the video. I also added two new hide buttons.

NOTE: I haven't yet found a way to reorder or hide the `news ` and `share `buttons, so I've disabled them in the reordering window.

https://github.com/user-attachments/assets/a7a74dfc-ece0-460a-be7f-4c0c12062764

