### PR TITLE
fix(Instagram): Skip event dispatch when analytics are disabled

### DIFF
--- a/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
+++ b/extensions/instagram/src/main/java/app/morphe/extension/instagram/patches/Links.java
@@ -113,12 +113,11 @@ public class Links {
        boolean shouldBlockUri = false;
         try {
             if (uri != null && uri.getPath() != null) {
-                String host = uri.getHost();
+                String host = uri.getHost() != null ? uri.getHost() : "";
                 String path = uri.getPath();
 
                 if (host.contains("graph.instagram.com")
-                        || host.contains("graph.facebook.com")
-                        || path.contains("/logging_client_events")) {
+                        || host.contains("graph.facebook.com")) {
                     shouldBlockUri = DISABLE_ANALYTICS;
                 } else if (path.contains("/api/v2/media/seen/")) {
                     shouldBlockUri = Pref.viewStoriesAnonymously();

--- a/patches/src/main/kotlin/app/crimera/patches/instagram/links/misc/DisableAnalyticsPatch.kt
+++ b/patches/src/main/kotlin/app/crimera/patches/instagram/links/misc/DisableAnalyticsPatch.kt
@@ -10,6 +10,7 @@ import app.crimera.patches.instagram.links.interceptUriPatch
 import app.crimera.patches.instagram.misc.settings.settingsPatch
 import app.crimera.patches.instagram.utils.Constants.COMPATIBILITY_INSTAGRAM
 import app.crimera.patches.instagram.utils.Constants.LINKS_DESCRIPTOR
+import app.crimera.patches.instagram.utils.Constants.PREF_CALL_DESCRIPTOR
 import app.crimera.patches.instagram.utils.enableSettings
 import app.morphe.patcher.Fingerprint
 import app.morphe.patcher.extensions.InstructionExtensions.addInstructionsWithLabels
@@ -18,10 +19,14 @@ import app.morphe.patcher.extensions.InstructionExtensions.instructions
 import app.morphe.patcher.patch.PatchException
 import app.morphe.patcher.patch.bytecodePatch
 import app.morphe.patcher.util.smali.ExternalLabel
+import app.morphe.util.findFreeRegister
+import app.morphe.util.registersUsed
 import com.android.tools.smali.dexlib2.AccessFlags
 import com.android.tools.smali.dexlib2.Opcode
 import com.android.tools.smali.dexlib2.iface.instruction.ReferenceInstruction
 import com.android.tools.smali.dexlib2.iface.reference.FieldReference
+import com.android.tools.smali.dexlib2.iface.reference.MethodReference
+import com.android.tools.smali.dexlib2.iface.reference.StringReference
 
 private object IgBloksFullScreenOpenFingerprint : Fingerprint(
     returnType = "V",
@@ -31,6 +36,18 @@ private object IgBloksFullScreenOpenFingerprint : Fingerprint(
             "Lcom/instagram/bloks/hosting/IgBloksScreenConfig;",
         ),
     strings = listOf("BKDataFetcher.fetch"),
+    custom = { method, _ ->
+        !AccessFlags.STATIC.isSet(method.accessFlags)
+    }
+)
+
+private object EventBuilderCommitFingerprint : Fingerprint(
+    returnType = "V",
+    parameters = emptyList(),
+    strings = listOf(
+        "EventBuilder was not acquired: BaseParameters null.",
+        "Must call ejectBaseParameters and ejectExtraParameters before release",
+    ),
     custom = { method, _ ->
         !AccessFlags.STATIC.isSet(method.accessFlags)
     }
@@ -83,5 +100,45 @@ val disableAnalyticsPatch =
                     )
                 }
             }
+
+            // Skip event dispatch when analytics are disabled.
+            // This prevents event delivery to the native logger queue.
+            EventBuilderCommitFingerprint.method.apply {
+                val serializerStringIndex = instructions.indexOfFirst {
+                    ((it as? ReferenceInstruction)?.reference as? StringReference)?.string == "Failed to serialize params"
+                }
+
+                if (serializerStringIndex == -1) {
+                    throw PatchException("EventBuilder serialization failure string not found")
+                }
+
+                val dispatchInstructionIndex = instructions.indices
+                    .filter { it > serializerStringIndex }
+                    .firstOrNull { idx ->
+                        val instruction = instructions[idx]
+                        if (instruction.opcode != Opcode.INVOKE_VIRTUAL && instruction.opcode != Opcode.INVOKE_INTERFACE) {
+                            return@firstOrNull false
+                        }
+                        val ref = (instruction as? ReferenceInstruction)?.reference as? MethodReference ?: return@firstOrNull false
+                        ref.returnType == "V" && ref.parameterTypes.size == 1 &&
+                            ref.parameterTypes.single() != "Ljava/lang/String;" &&
+                            ref.parameterTypes.single() != "Ljava/lang/Throwable;"
+                    } ?: throw PatchException("EventBuilder commit dispatch instruction not found")
+
+                val dispatchInstruction = getInstruction(dispatchInstructionIndex)
+                val freeRegister = findFreeRegister(dispatchInstructionIndex, dispatchInstruction.registersUsed)
+                val nextInstruction = getInstruction(dispatchInstructionIndex + 1)
+
+                addInstructionsWithLabels(
+                    dispatchInstructionIndex,
+                    """
+                    $PREF_CALL_DESCRIPTOR->disableAnalytics()Z
+                    move-result v$freeRegister
+                    if-nez v$freeRegister, :piko_skip_dispatch
+                    """.trimIndent(),
+                    ExternalLabel("piko_skip_dispatch", nextInstruction),
+                )
+            }
         }
     }
+


### PR DESCRIPTION
Throwing an `IOException` for `/logging_client_events` in `Links.interceptUri()` caused Meta's native `fflogger_worker` thread to treat blocked requests as transient connection failures, triggering an
unthrottled background retry storm that consumed excessive CPU.

This bypasses event dispatch directly inside `EventBuilder.commit()` when `disableAnalytics` is enabled so events never enter the native logger queue. Also removes `/logging_client_events` from `Links.
interceptUri()` while keeping Graph API endpoints blocked.

## Testing
- `.\gradlew.bat clean :patches:buildAndroid --no-daemon --console=plain`
- `.\gradlew.bat :patches:checkStringResources --no-daemon --console=plain`
- Tested on Instagram v435.0.0.37.76 with Piko v3.10.0-dev.6
- Tested on Infinix X6838 (Android 14)